### PR TITLE
Clean up recovery notification policy

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -51,14 +51,22 @@ class _HorcruxAppState extends ConsumerState<HorcruxApp> with WidgetsBindingObse
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (state == AppLifecycleState.paused) {
-      unawaited(_mergeProcessedNostrEventStoreOnBackground());
+    // macOS/desktop often never reaches [paused]; persist cursors on inactive/hidden/detached too.
+    switch (state) {
+      case AppLifecycleState.resumed:
+        break;
+      case AppLifecycleState.inactive:
+      case AppLifecycleState.paused:
+      case AppLifecycleState.hidden:
+      case AppLifecycleState.detached:
+        unawaited(_flushStoresToDisk());
+        break;
     }
   }
 
-  Future<void> _mergeProcessedNostrEventStoreOnBackground() async {
+  Future<void> _flushStoresToDisk() async {
     try {
-      await ref.read(processedNostrEventStoreProvider).mergePersistedStateOnBackground();
+      await ref.read(processedNostrEventStoreProvider).writeStores();
     } catch (e, st) {
       Log.error('ProcessedNostrEventStore background merge failed', e, st);
     }

--- a/lib/providers/recovery_provider.dart
+++ b/lib/providers/recovery_provider.dart
@@ -10,25 +10,25 @@ import 'key_provider.dart';
 /// Pending steward recovery requests for banner / modal.
 ///
 /// [RecoveryService.notificationStream] is a **broadcast** stream: emissions that happen before
-/// any listener subscribes (e.g. during [RecoveryService.initialize]) are **dropped**. We therefore
-/// emit the current list once on subscribe via [RecoveryService.getPendingNotifications], then
-/// forward live updates from [RecoveryService.notificationStream].
+/// any listener subscribes (e.g. during [RecoveryService.initialize]) are **dropped**. We attach
+/// to [RecoveryService.notificationStream] **before** awaiting [RecoveryService.getPendingNotifications]
+/// so notifications are not missed while the initial snapshot loads, then emit that snapshot.
 final pendingRecoveryRequestsProvider = StreamProvider<List<RecoveryRequest>>((ref) {
   final service = ref.watch(recoveryServiceProvider);
   return Stream.multi((controller) async {
     StreamSubscription<List<RecoveryRequest>>? subscription;
-    try {
-      controller.add(await service.getPendingNotifications());
-    } catch (e, st) {
-      controller.addError(e, st);
-      return;
-    }
     subscription = service.notificationStream.listen(
       controller.add,
       onError: controller.addError,
       onDone: controller.close,
     );
     controller.onCancel = () => subscription?.cancel();
+    try {
+      controller.add(await service.getPendingNotifications());
+    } catch (e, st) {
+      controller.addError(e, st);
+      return;
+    }
   });
 });
 

--- a/lib/providers/recovery_provider.dart
+++ b/lib/providers/recovery_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/recovery_request.dart';
 import '../models/recovery_status.dart' as recovery_status;
@@ -5,12 +7,29 @@ import 'vault_provider.dart';
 import '../services/recovery_service.dart';
 import 'key_provider.dart';
 
-/// Provider for pending recovery request notifications
-/// Streams live updates of unresponded recovery requests (excluding user's own requests)
-/// Requests remain visible until the current user has responded (approved or denied)
+/// Pending steward recovery requests for banner / modal.
+///
+/// [RecoveryService.notificationStream] is a **broadcast** stream: emissions that happen before
+/// any listener subscribes (e.g. during [RecoveryService.initialize]) are **dropped**. We therefore
+/// emit the current list once on subscribe via [RecoveryService.getPendingNotifications], then
+/// forward live updates from [RecoveryService.notificationStream].
 final pendingRecoveryRequestsProvider = StreamProvider<List<RecoveryRequest>>((ref) {
   final service = ref.watch(recoveryServiceProvider);
-  return service.notificationStream;
+  return Stream.multi((controller) async {
+    StreamSubscription<List<RecoveryRequest>>? subscription;
+    try {
+      controller.add(await service.getPendingNotifications());
+    } catch (e, st) {
+      controller.addError(e, st);
+      return;
+    }
+    subscription = service.notificationStream.listen(
+      controller.add,
+      onError: controller.addError,
+      onDone: controller.close,
+    );
+    controller.onCancel = () => subscription?.cancel();
+  });
 });
 
 /// Provider for recovery status of a specific vault

--- a/lib/providers/recovery_provider.dart
+++ b/lib/providers/recovery_provider.dart
@@ -13,6 +13,9 @@ import 'key_provider.dart';
 /// any listener subscribes (e.g. during [RecoveryService.initialize]) are **dropped**. We attach
 /// to [RecoveryService.notificationStream] **before** awaiting [RecoveryService.getPendingNotifications]
 /// so notifications are not missed while the initial snapshot loads, then emit that snapshot.
+///
+/// Only the snapshot [Future] suspends; after it completes the [Stream.multi] sink may already be
+/// closed (e.g. listener disposed), so we skip [add]/[addError] when [controller.isClosed].
 final pendingRecoveryRequestsProvider = StreamProvider<List<RecoveryRequest>>((ref) {
   final service = ref.watch(recoveryServiceProvider);
   return Stream.multi((controller) async {
@@ -24,10 +27,11 @@ final pendingRecoveryRequestsProvider = StreamProvider<List<RecoveryRequest>>((r
     );
     controller.onCancel = () => subscription?.cancel();
     try {
-      controller.add(await service.getPendingNotifications());
+      final pending = await service.getPendingNotifications();
+      if (controller.isClosed) return;
+      controller.add(pending);
     } catch (e, st) {
-      controller.addError(e, st);
-      return;
+      if (!controller.isClosed) controller.addError(e, st);
     }
   });
 });

--- a/lib/services/ndk_service.dart
+++ b/lib/services/ndk_service.dart
@@ -277,9 +277,10 @@ class NdkService {
     Nip01Event event, {
     required String relayUrl,
   }) async {
-    unawaited(_processedEventStore.recordLastSeen(relayUrl, event.createdAt));
-
     if (!await _processedEventStore.claimEvent(event.id)) {
+      if (await _processedEventStore.contains(event.id)) {
+        await _processedEventStore.recordLastSeen(relayUrl, event.createdAt);
+      }
       return;
     }
 
@@ -315,6 +316,7 @@ class NdkService {
       }
 
       await _processedEventStore.recordProcessed(event.id);
+      await _processedEventStore.recordLastSeen(relayUrl, event.createdAt);
     } catch (e) {
       await _processedEventStore.releaseClaimedEvent(event.id);
       Log.error('Error handling gift wrap event ${event.id}', e);

--- a/lib/services/ndk_service.dart
+++ b/lib/services/ndk_service.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:math' as math;
+
 import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ndk/ndk.dart';
@@ -9,10 +11,34 @@ import 'vault_share_service.dart';
 import 'invitation_service.dart';
 import 'shard_distribution_service.dart';
 import 'logger.dart';
+import 'processed_nostr_event_store.dart';
 import 'publish_service.dart';
 import '../models/nostr_kinds.dart';
 import '../models/shard_data.dart';
 import '../models/recovery_request.dart';
+
+/// Nostr `since` for relay subscription filters ([NdkService] gift-wrap subscriptions).
+///
+/// When a cursor exists: [min] of (rolling window start, last seen `created_at`) — the
+/// **older** bound — so a stale cursor (e.g. weeks ago) requests from that cursor, not
+/// only the last [recentWindow]. When the cursor is inside the window, we still go back
+/// to the window start so we always overlap at least [recentWindow].
+///
+/// No cursor yet (never received an event for this relay): `0` so the REQ asks from
+/// the epoch (full history the relay will return, subject to relay `limit`).
+@visibleForTesting
+int computeSinceTime({
+  required DateTime nowUtc,
+  required int? lastSeenEventCreatedAtUnix,
+  Duration recentWindow = const Duration(days: 3),
+}) {
+  final windowStartSec = nowUtc.subtract(recentWindow).millisecondsSinceEpoch ~/ 1000;
+  final last = lastSeenEventCreatedAtUnix;
+  if (last == null || last <= 0) {
+    return 0;
+  }
+  return math.min(windowStartSec, last);
+}
 
 /// Event emitted when a recovery response is received
 class RecoveryResponseEvent {
@@ -38,9 +64,11 @@ class RecoveryResponseEvent {
 // Provider for NdkService
 final Provider<NdkService> ndkServiceProvider = Provider<NdkService>((ref) {
   final loginService = ref.read(loginServiceProvider);
+  final processedEventStore = ref.read(processedNostrEventStoreProvider);
   final service = NdkService(
     ref: ref,
     loginService: loginService,
+    processedEventStore: processedEventStore,
     getInvitationService: () => ref.read(invitationServiceProvider),
   );
 
@@ -57,13 +85,14 @@ final Provider<NdkService> ndkServiceProvider = Provider<NdkService>((ref) {
 class NdkService {
   final Ref _ref;
   final LoginService _loginService;
+  final ProcessedNostrEventStore _processedEventStore;
   final InvitationService Function() _getInvitationService;
 
   Ndk? _ndk;
   bool _isInitialized = false;
-  NdkResponse? _giftWrapSubscription;
+  final List<NdkResponse> _subscriptionResponses = [];
+  final List<StreamSubscription<Nip01Event>> _subscriptionStreamSubs = [];
   final List<String> _activeRelays = [];
-  StreamSubscription<Nip01Event>? _giftWrapStreamSub;
 
   late final PublishService _publishService;
 
@@ -82,9 +111,11 @@ class NdkService {
   NdkService({
     required Ref ref,
     required LoginService loginService,
+    required ProcessedNostrEventStore processedEventStore,
     required InvitationService Function() getInvitationService,
   })  : _ref = ref,
         _loginService = loginService,
+        _processedEventStore = processedEventStore,
         _getInvitationService = getInvitationService {
     _publishService = PublishService(
       getNdk: getNdk,
@@ -198,35 +229,62 @@ class NdkService {
 
     Log.info('Setting up NDK subscriptions on ${_activeRelays.length} relays');
 
-    // Subscribe to all gift wrap events (kind 1059)
-    // All Horcrux data (shards, recovery requests, recovery responses) are sent as gift wraps
-    _giftWrapSubscription = _ndk!.requests.subscription(
-      filters: [
-        Filter(
-          kinds: [NostrKind.giftWrap.value], // Gift wrap events
-          pTags: [myPubkey], // Events sent to us
-          limit: 100, // Get recent events
-        ),
-      ],
-      explicitRelays: _activeRelays,
-    );
+    await _processedEventStore.ensureLoaded();
 
-    // Listen to gift wrap stream - will route to appropriate handler based on inner kind
-    _giftWrapStreamSub = _giftWrapSubscription!.stream.listen(
-      (event) => _handleGiftWrap(event),
-      onError: (error) => Log.error('Error in gift wrap stream', error),
-    );
+    // One subscription per relay so we can persist a cursor per relay (merged NDK streams
+    // do not expose which relay delivered each event).
+    for (final relayUrl in _activeRelays) {
+      final lastSeen = await _processedEventStore.getLastSeen(relayUrl);
+      final sinceFilter = computeSinceTime(
+        nowUtc: DateTime.now().toUtc(),
+        lastSeenEventCreatedAtUnix: lastSeen,
+      );
+      Log.info(
+        'Nostr subscription for $relayUrl since=$sinceFilter '
+        '(last seen event created_at=${lastSeen ?? 'none'})',
+      );
+
+      // Subscribe to all gift wrap events (kind 1059)
+      // All Horcrux data (shards, recovery requests, recovery responses) are sent as gift wraps
+      final response = _ndk!.requests.subscription(
+        filters: [
+          Filter(
+            kinds: [NostrKind.giftWrap.value],
+            pTags: [myPubkey],
+            since: sinceFilter,
+          ),
+        ],
+        explicitRelays: [relayUrl],
+      );
+      _subscriptionResponses.add(response);
+
+      _subscriptionStreamSubs.add(
+        response.stream.listen(
+          (event) => _handleIncomingNostrEvent(event, relayUrl: relayUrl),
+          onError: (error) => Log.error('Error in Nostr subscription stream ($relayUrl)', error),
+        ),
+      );
+    }
 
     Log.info(
-      'NDK subscriptions active for gift wrapped events (kind ${NostrKind.giftWrap.value})',
+      'NDK subscriptions setup for ${_subscriptionResponses.length} relays',
     );
   }
 
-  /// Handle incoming gift wrap event (kind 1059)
-  /// Routes to appropriate handler based on the inner kind
-  Future<void> _handleGiftWrap(Nip01Event event) async {
+  /// Handle incoming Nostr events
+  /// Routes to appropriate handler based on the inner kind.
+  Future<void> _handleIncomingNostrEvent(
+    Nip01Event event, {
+    required String relayUrl,
+  }) async {
+    unawaited(_processedEventStore.recordLastSeen(relayUrl, event.createdAt));
+
+    if (!await _processedEventStore.claimEvent(event.id)) {
+      return;
+    }
+
     try {
-      Log.info('Received gift wrap event: ${event.id}');
+      Log.info('Received subscription Nostr event: ${event.id}');
 
       // Unwrap the gift wrap event using NDK
       final unwrappedEvent = await _ndk!.giftWrap.fromGiftWrap(giftWrap: event);
@@ -255,7 +313,10 @@ class NdkService {
       } else {
         Log.warning('Unknown gift wrap inner kind: ${unwrappedEvent.kind}');
       }
+
+      await _processedEventStore.recordProcessed(event.id);
     } catch (e) {
+      await _processedEventStore.releaseClaimedEvent(event.id);
       Log.error('Error handling gift wrap event ${event.id}', e);
     }
   }
@@ -569,9 +630,11 @@ class NdkService {
 
   /// Close all active subscriptions
   Future<void> closeSubscriptions() async {
-    await _giftWrapStreamSub?.cancel();
-    _giftWrapStreamSub = null;
-    _giftWrapSubscription = null;
+    for (final sub in _subscriptionStreamSubs) {
+      await sub.cancel();
+    }
+    _subscriptionStreamSubs.clear();
+    _subscriptionResponses.clear();
     Log.info('Stopped all NDK subscriptions');
   }
 

--- a/lib/services/processed_nostr_event_store.dart
+++ b/lib/services/processed_nostr_event_store.dart
@@ -10,7 +10,11 @@ import 'package:path_provider/path_provider.dart';
 import 'logger.dart';
 
 final processedNostrEventStoreProvider = Provider<ProcessedNostrEventStore>((ref) {
-  return ProcessedNostrEventStore();
+  final store = ProcessedNostrEventStore();
+  ref.onDispose(() {
+    unawaited(store.flushToDisk());
+  });
+  return store;
 });
 
 /// Normalizes relay URLs so cursor map keys stay stable across trivial spelling differences.
@@ -31,9 +35,10 @@ String normalizeRelayUrlForNostrEventCursor(String relayUrl) {
 
 /// Persists the last [maxIds] successfully processed Nostr event IDs (FIFO eviction).
 ///
-/// Uses a **snapshot** file plus an **append-only log** of IDs since the last snapshot.
-/// On app background, [mergePersistedStateOnBackground] rewrites the snapshot and clears
-/// the log so normal operation only appends small writes.
+/// Durable state is an **append-only log** ([_logName]) plus a **WAL** ([_walName]). New IDs are
+/// appended to the WAL immediately; on the debounced timer the WAL is merged into the main log and
+/// relay cursors are written. [writeStores] forces WAL→log merge and cursor
+/// write without waiting for the debounce.
 ///
 /// Also keeps the date of the most recent event from each relay so we can avoid fetching duplicate
 /// events.
@@ -47,8 +52,11 @@ String normalizeRelayUrlForNostrEventCursor(String relayUrl) {
 class ProcessedNostrEventStore {
   ProcessedNostrEventStore({this.maxIds = 99999});
 
-  static const _snapshotName = 'processed_nostr_event_ids.snapshot';
+  /// Shared debounce for relay cursors and WAL→log merge.
+  static const _persistenceDebounceTime = Duration(seconds: 10);
+
   static const _logName = 'processed_nostr_event_ids.log';
+  static const _walName = 'processed_nostr_event_ids.wal';
   static const _cursorsFileName = 'nostr_relay_subscription_cursors.json';
 
   final int maxIds;
@@ -63,14 +71,16 @@ class ProcessedNostrEventStore {
   final Map<String, int> _relayMaxSeenEventCreatedAtSec = {};
 
   Directory? _dir;
-  File? _snapshotFile;
   File? _logFile;
+  File? _walFile;
   File? _cursorsFile;
 
   bool _loaded = false;
   Future<void>? _loadFuture;
 
-  /// Serializes snapshot writes, log appends, and merge so concurrent calls do not corrupt files.
+  Timer? _persistenceDebounceTimer;
+
+  /// Serializes log/WAL appends and merge so concurrent calls do not corrupt files.
   Future<void> _chain = Future<void>.value();
 
   Future<T> _serialized<T>(Future<T> Function() fn) async {
@@ -95,16 +105,20 @@ class ProcessedNostrEventStore {
     try {
       final dir = await getApplicationSupportDirectory();
       _dir = dir;
-      _snapshotFile = File(p.join(dir.path, _snapshotName));
       _logFile = File(p.join(dir.path, _logName));
+      _walFile = File(p.join(dir.path, _walName));
       _cursorsFile = File(p.join(dir.path, _cursorsFileName));
 
-      await _removeStaleSnapshotTemp(dir);
+      Log.info(
+        'ProcessedNostrEventStore directory: ${dir.path} '
+        '(files: $_logName, $_walName, $_cursorsFileName)',
+      );
+
       await _removeStaleCursorsTemp(dir);
 
       _ids.clear();
-      await _readSnapshotIntoMemory();
       await _replayLogIntoMemory();
+      await _replayWalIntoMemory();
 
       _trimToMaxIds();
 
@@ -113,17 +127,6 @@ class ProcessedNostrEventStore {
       Log.error('ProcessedNostrEventStore load failed', e, st);
     } finally {
       _loaded = true;
-    }
-  }
-
-  Future<void> _removeStaleSnapshotTemp(Directory dir) async {
-    final tmp = File(p.join(dir.path, '$_snapshotName.tmp'));
-    if (tmp.existsSync()) {
-      try {
-        await tmp.delete();
-      } catch (e) {
-        Log.warning('ProcessedNostrEventStore: could not delete stale snapshot tmp: $e');
-      }
     }
   }
 
@@ -173,8 +176,62 @@ class ProcessedNostrEventStore {
     }
   }
 
-  Future<void> _readSnapshotIntoMemory() async {
-    final file = _snapshotFile;
+  /// Appends WAL contents to the main log and deletes the WAL (empty or missing WAL is a no-op).
+  Future<void> _mergeWalIntoLog() async {
+    final wal = _walFile;
+    final log = _logFile;
+    if (wal == null || log == null) return;
+    if (!await wal.exists()) return;
+
+    final len = await wal.length();
+    if (len == 0) {
+      await wal.delete();
+      return;
+    }
+
+    try {
+      final text = await wal.readAsString();
+      if (text.trim().isEmpty) {
+        await wal.delete();
+        return;
+      }
+      if (!await log.exists()) {
+        await log.create();
+      }
+      await log.writeAsString(text, mode: FileMode.append, flush: true);
+      await wal.delete();
+    } catch (e, st) {
+      Log.error('ProcessedNostrEventStore WAL merge into log failed', e, st);
+    }
+  }
+
+  void _cancelDebouncedPersist() {
+    _persistenceDebounceTimer?.cancel();
+    _persistenceDebounceTimer = null;
+  }
+
+  void _scheduleDebouncedPersist() {
+    _cancelDebouncedPersist();
+    _persistenceDebounceTimer = Timer(_persistenceDebounceTime, () {
+      unawaited(flushToDisk());
+    });
+  }
+
+  /// Merges the WAL into the append log and writes relay cursors (cancels any debounced flush).
+  ///
+  /// Desktop (e.g. macOS) often never reaches [AppLifecycleState.paused]; call this from
+  /// lifecycle transitions so cursors and merged log state survive restarts.
+  Future<void> flushToDisk() async {
+    _cancelDebouncedPersist();
+    await _serialized(() async {
+      await ensureLoaded();
+      await _mergeWalIntoLog();
+      await _writeCursorsJson();
+    });
+  }
+
+  Future<void> _replayLogIntoMemory() async {
+    final file = _logFile;
     if (file == null || !await file.exists()) return;
 
     await for (final line
@@ -187,8 +244,8 @@ class ProcessedNostrEventStore {
     _trimToMaxIds();
   }
 
-  Future<void> _replayLogIntoMemory() async {
-    final file = _logFile;
+  Future<void> _replayWalIntoMemory() async {
+    final file = _walFile;
     if (file == null || !await file.exists()) return;
 
     await for (final line
@@ -211,25 +268,6 @@ class ProcessedNostrEventStore {
     while (_ids.length > maxIds) {
       _ids.remove(_ids.first);
     }
-  }
-
-  Future<void> _writeSnapshotFromMemory() async {
-    final dir = _dir;
-    final snapshot = _snapshotFile;
-    if (dir == null || snapshot == null) return;
-
-    final tmp = File(p.join(dir.path, '$_snapshotName.tmp'));
-    final sink = tmp.openWrite();
-    try {
-      for (final id in _ids) {
-        sink.writeln(id);
-      }
-    } finally {
-      await sink.close();
-    }
-
-    // Atomic replace on POSIX; Dart removes an existing [snapshot] first when needed.
-    await tmp.rename(snapshot.path);
   }
 
   Future<bool> contains(String id) async {
@@ -262,25 +300,35 @@ class ProcessedNostrEventStore {
   }
 
   /// Call after an event has been fully handled (vault updated or idempotent skip).
+  ///
+  /// Appends the ID to the WAL immediately, then updates in-memory state. The debounced timer merges
+  /// the WAL into the main append log and flushes relay cursors; use [flushToDisk] or
+  /// [writeStores] for an immediate merge.
   Future<void> recordProcessed(String id) async {
+    var scheduleFlush = false;
     await _serialized(() async {
       await ensureLoaded();
       _claimedIds.remove(id);
       if (_ids.contains(id)) return;
 
-      _ingestId(id);
-
-      final log = _logFile;
-      if (log == null) return;
+      final wal = _walFile;
+      if (wal == null) return;
       try {
-        if (!await log.exists()) {
-          await log.create();
+        if (!await wal.exists()) {
+          await wal.create();
         }
-        await log.writeAsString('$id\n', mode: FileMode.append, flush: true);
+        await wal.writeAsString('$id\n', mode: FileMode.append, flush: true);
       } catch (e, st) {
-        Log.error('ProcessedNostrEventStore log append failed', e, st);
+        Log.error('ProcessedNostrEventStore WAL append failed', e, st);
+        return;
       }
+
+      _ingestId(id);
+      scheduleFlush = true;
     });
+    if (scheduleFlush) {
+      _scheduleDebouncedPersist();
+    }
   }
 
   /// Latest recorded outer `created_at` (unix seconds) for subscription events from [relayUrl].
@@ -291,11 +339,13 @@ class ProcessedNostrEventStore {
     return _relayMaxSeenEventCreatedAtSec[key];
   }
 
-  /// Updates the per-relay cursor if [createdAtUnix] is newer (in-memory until background merge).
+  /// Updates the per-relay cursor if [createdAtUnix] is newer, then schedules a debounced
+  /// WAL→log merge and cursor flush (see [flushToDisk]).
   Future<void> recordLastSeen(
     String relayUrl,
     int createdAtUnix,
   ) async {
+    var scheduleFlush = false;
     await _serialized(() async {
       await ensureLoaded();
       final key = normalizeRelayUrlForNostrEventCursor(relayUrl);
@@ -303,30 +353,15 @@ class ProcessedNostrEventStore {
       final existing = _relayMaxSeenEventCreatedAtSec[key] ?? 0;
       if (createdAtUnix <= existing) return;
       _relayMaxSeenEventCreatedAtSec[key] = createdAtUnix;
+      scheduleFlush = true;
     });
+    if (scheduleFlush) {
+      _scheduleDebouncedPersist();
+    }
   }
 
-  /// Rewrites the snapshot from memory and truncates the append log. Call when the app
-  /// goes to background so the log stays small and restarts stay fast.
+  /// Merges WAL→append log and writes relay cursors immediately (cancels debounced flush).
   ///
-  /// Also persists relay subscription cursors to JSON.
-  Future<void> mergePersistedStateOnBackground() async {
-    await _serialized(() async {
-      await ensureLoaded();
-      try {
-        final log = _logFile;
-        final snapshot = _snapshotFile;
-        if (snapshot != null && log != null) {
-          await _writeSnapshotFromMemory();
-          if (await log.exists()) {
-            await log.delete();
-          }
-          await log.create();
-        }
-        await _writeCursorsJson();
-      } catch (e, st) {
-        Log.error('ProcessedNostrEventStore merge (snapshot/cursors) failed', e, st);
-      }
-    });
-  }
+  /// Call when the app backgrounds or terminates so durable state is not left only in the WAL.
+  Future<void> writeStores() => flushToDisk();
 }

--- a/lib/services/processed_nostr_event_store.dart
+++ b/lib/services/processed_nostr_event_store.dart
@@ -53,7 +53,7 @@ class ProcessedNostrEventStore {
   ProcessedNostrEventStore({this.maxIds = 99999});
 
   /// Shared debounce for relay cursors and WAL→log merge.
-  static const _persistenceDebounceTime = Duration(seconds: 10);
+  static const _persistenceDebounceTime = Duration(seconds: 1);
 
   static const _logName = 'processed_nostr_event_ids.log';
   static const _walName = 'processed_nostr_event_ids.wal';

--- a/lib/services/recovery_service.dart
+++ b/lib/services/recovery_service.dart
@@ -112,10 +112,6 @@ class RecoveryService {
       if (id != null) {
         await _processedStore.recordProcessed(id);
       }
-      final firstOpen = await _initFirstOpenTime();
-      if (RecoveryLiveNotificationPolicy.shouldNotifyRecoveryRequest(recoveryRequest, firstOpen)) {
-        unawaited(_localNotifications.notifyRecoveryRequestProcessed(recoveryRequest));
-      }
     } catch (e, st) {
       Log.error(
         'Error processing incoming recovery request from stream',
@@ -138,16 +134,10 @@ class RecoveryService {
         responseEvent.approved,
         shardData: responseEvent.shardData,
         nostrEventId: responseEvent.nostrEventId,
+        recoveryResponseSourceEvent: responseEvent,
       );
       if (id != null) {
         await _processedStore.recordProcessed(id);
-      }
-      final firstOpen = await _initFirstOpenTime();
-      if (RecoveryLiveNotificationPolicy.shouldNotifyRecoveryResponse(
-        createdAt: responseEvent.createdAt,
-        firstOpenUtc: firstOpen,
-      )) {
-        unawaited(_localNotifications.notifyRecoveryResponseProcessed(responseEvent));
       }
     } catch (e, st) {
       Log.error('Error processing recovery response from stream', e, st);
@@ -160,7 +150,7 @@ class RecoveryService {
     _recoveryRequestController.close();
   }
 
-  Future<DateTime> _initFirstOpenTime() async {
+  Future<DateTime> _firstAppOpen() async {
     if (_firstOpenUtcCached != null) return _firstOpenUtcCached!;
     final prefs = await SharedPreferences.getInstance();
     final ms = prefs.getInt(_firstOpenUtcKey);
@@ -184,7 +174,7 @@ class RecoveryService {
     }
 
     try {
-      await _initFirstOpenTime();
+      await _firstAppOpen();
       await _processedStore.ensureLoaded();
       await _loadViewedNotificationIds();
     } catch (e) {
@@ -251,25 +241,26 @@ class RecoveryService {
   }
 
   /// Steward banner / counts: unresponded, not self-initiated, and "live" per
-  /// [RecoveryLiveNotificationPolicy] (matches local notification rules so relay backfill
+  /// [RecoveryNotificationPolicy] (matches local notification rules so relay backfill
   /// does not surface historical requests as pending).
   Future<List<RecoveryRequest>> _pendingRecoveryRequests() async {
     await initialize();
-    final firstOpen = await _initFirstOpenTime();
+    final firstOpen = await _firstAppOpen();
     final currentPubkey = await _ndkService.getCurrentPubkey();
     final allRequests = await repository.getAllRecoveryRequests();
 
     return allRequests.where((req) {
-      if (currentPubkey != null && req.initiatorPubkey == currentPubkey) {
-        return false;
-      }
       if (currentPubkey != null) {
         final userResponse = req.stewardResponses[currentPubkey];
         if (userResponse != null && userResponse.status.isResolved) {
           return false;
         }
       }
-      if (!RecoveryLiveNotificationPolicy.shouldNotifyRecoveryRequest(req, firstOpen)) {
+      if (!RecoveryNotificationPolicy.shouldNotifyRecoveryRequest(
+        req,
+        firstOpen,
+        currentPubkeyHex: currentPubkey,
+      )) {
         return false;
       }
       return true;
@@ -495,6 +486,8 @@ class RecoveryService {
   ///
   /// Unlike [initiateRecovery], this does not create a new request id—it persists an event
   /// the relays delivered. Since events are immutable, we skip if this request id already exists locally.
+  ///
+  /// After a new request is persisted, may show a local OS notification per [RecoveryNotificationPolicy].
   Future<void> processRecoveryRequest(RecoveryRequest request) async {
     await initialize();
 
@@ -518,6 +511,16 @@ class RecoveryService {
 
     // Emit notification update
     await _emitNotificationUpdate();
+
+    final firstOpen = await _firstAppOpen();
+    final myPubkey = await _ndkService.getCurrentPubkey();
+    if (RecoveryNotificationPolicy.shouldNotifyRecoveryRequest(
+      request,
+      firstOpen,
+      currentPubkeyHex: myPubkey,
+    )) {
+      unawaited(_localNotifications.notifyRecoveryRequestProcessed(request));
+    }
   }
 
   /// Get all recovery requests for the current user
@@ -590,12 +593,16 @@ class RecoveryService {
   /// Merges one steward's recovery response into local vault state (from Nostr or from this device).
   ///
   /// Since events are immutable, we skip processing if the response already exists.
+  ///
+  /// When [recoveryResponseSourceEvent] is set (relay-delivered event), may show a local OS
+  /// notification per [RecoveryNotificationPolicy]. Local-only applies omit it.
   Future<void> processRecoveryResponse(
     String recoveryRequestId,
     String responderPubkey,
     bool approved, {
     ShardData? shardData,
     String? nostrEventId,
+    RecoveryResponseEvent? recoveryResponseSourceEvent,
   }) async {
     await initialize();
 
@@ -673,6 +680,22 @@ class RecoveryService {
 
     // Emit notification update to refresh banner
     await _emitNotificationUpdate();
+
+    if (recoveryResponseSourceEvent != null) {
+      final firstOpen = await _firstAppOpen();
+      final myPubkey = await _ndkService.getCurrentPubkey();
+      if (RecoveryNotificationPolicy.shouldNotifyRecoveryResponse(
+        responseCreatedAt: recoveryResponseSourceEvent.createdAt,
+        firstOpenUtc: firstOpen,
+        requestBeforeApply: request,
+        currentPubkeyHex: myPubkey,
+        responseSenderPubkey: responderPubkey,
+      )) {
+        unawaited(
+          _localNotifications.notifyRecoveryResponseProcessed(recoveryResponseSourceEvent),
+        );
+      }
+    }
 
     Log.info(
       'Updated recovery request $recoveryRequestId with response from ${responderPubkey.substring(0, 8)}... (approved: $approved)',
@@ -1125,7 +1148,7 @@ class RecoveryService {
   /// Get pending (unresponded) recovery request notifications for steward UI.
   ///
   /// Excludes own requests, resolved responses, and requests outside
-  /// [RecoveryLiveNotificationPolicy] (historical relay replay).
+  /// [RecoveryNotificationPolicy] (historical relay replay).
   Future<List<RecoveryRequest>> getPendingNotifications() async {
     return _pendingRecoveryRequests();
   }
@@ -1212,23 +1235,61 @@ class RecoveryService {
 /// ([RecoveryService._pendingRecoveryRequests]).
 ///
 /// Kept next to [RecoveryService] and referenced from tests via this type.
-class RecoveryLiveNotificationPolicy {
-  RecoveryLiveNotificationPolicy._();
+class RecoveryNotificationPolicy {
+  RecoveryNotificationPolicy._();
 
   static const Duration slack = Duration(hours: 1);
 
+  /// Whether [eventUtc] is recent enough relative to first app open to surface as live
+  /// (vs relay historical replay).
+  static bool isLiveEventTime(DateTime eventUtc, DateTime firstOpenUtc) =>
+      eventUtc.isAfter(firstOpenUtc.subtract(slack));
+
   /// Prefer [RecoveryRequest.eventCreationTime]; fall back to [RecoveryRequest.requestedAt].
-  static bool shouldNotifyRecoveryRequest(RecoveryRequest request, DateTime firstOpenUtc) {
+  ///
+  /// When [currentPubkeyHex] is set and matches [RecoveryRequest.initiatorPubkey], returns false
+  /// (do not notify for your own recovery request event echoed from relays; steward UI also
+  /// excludes self-initiated requests).
+  static bool shouldNotifyRecoveryRequest(
+    RecoveryRequest request,
+    DateTime firstOpenUtc, {
+    String? currentPubkeyHex,
+  }) {
+    if (currentPubkeyHex != null && request.initiatorPubkey == currentPubkeyHex) {
+      return false;
+    }
     final anchor = request.eventCreationTime ?? request.requestedAt;
-    return anchor.isAfter(firstOpenUtc.subtract(slack));
+    return isLiveEventTime(anchor, firstOpenUtc);
   }
 
-  /// Requires inner event time; if unknown, do not notify.
+  /// Whether to show a local OS notification for an incoming recovery **response** event.
+  ///
+  /// Combines: inner [responseCreatedAt] must exist and fall in the [isLiveEventTime] window;
+  /// [requestBeforeApply] / [currentPubkeyHex] must be known; only the **initiator** is notified
+  /// of peers' responses; not when the response is the user's own relay echo; not when the
+  /// session is already terminal.
   static bool shouldNotifyRecoveryResponse({
-    required DateTime? createdAt,
+    required DateTime? responseCreatedAt,
     required DateTime firstOpenUtc,
+    required RecoveryRequest? requestBeforeApply,
+    required String? currentPubkeyHex,
+    required String responseSenderPubkey,
   }) {
-    if (createdAt == null) return false;
-    return createdAt.isAfter(firstOpenUtc.subtract(slack));
+    if (responseCreatedAt == null) {
+      return false;
+    }
+    if (!isLiveEventTime(responseCreatedAt, firstOpenUtc)) {
+      return false;
+    }
+    if (requestBeforeApply == null || currentPubkeyHex == null) {
+      return false;
+    }
+    if (responseSenderPubkey == currentPubkeyHex) {
+      return false;
+    }
+    if (requestBeforeApply.status.isTerminal) {
+      return false;
+    }
+    return requestBeforeApply.initiatorPubkey == currentPubkeyHex;
   }
 }

--- a/lib/services/recovery_service.dart
+++ b/lib/services/recovery_service.dart
@@ -246,32 +246,34 @@ class RecoveryService {
       return;
     }
 
-    // Get current user's pubkey to filter out their own recovery requests
-    final currentPubkey = await _ndkService.getCurrentPubkey();
+    final pendingRequests = await _pendingRecoveryRequests();
+    _notificationController.add(pendingRequests);
+  }
 
-    // Get all recovery requests from vault repository
+  /// Steward banner / counts: unresponded, not self-initiated, and "live" per
+  /// [RecoveryLiveNotificationPolicy] (matches local notification rules so relay backfill
+  /// does not surface historical requests as pending).
+  Future<List<RecoveryRequest>> _pendingRecoveryRequests() async {
+    await initialize();
+    final firstOpen = await _initFirstOpenTime();
+    final currentPubkey = await _ndkService.getCurrentPubkey();
     final allRequests = await repository.getAllRecoveryRequests();
 
-    // Filter out requests where the current user has already responded
-    // and requests initiated by the current user (steward's own requests)
-    final pendingRequests = allRequests.where((req) {
-      // Exclude requests initiated by the current user (steward's own requests)
+    return allRequests.where((req) {
       if (currentPubkey != null && req.initiatorPubkey == currentPubkey) {
         return false;
       }
-
-      // Exclude requests where the current user has already responded
       if (currentPubkey != null) {
         final userResponse = req.stewardResponses[currentPubkey];
         if (userResponse != null && userResponse.status.isResolved) {
           return false;
         }
       }
-
+      if (!RecoveryLiveNotificationPolicy.shouldNotifyRecoveryRequest(req, firstOpen)) {
+        return false;
+      }
       return true;
     }).toList();
-
-    _notificationController.add(pendingRequests);
   }
 
   /// Initiate recovery for a vault
@@ -1120,32 +1122,12 @@ class RecoveryService {
 
   // ========== Notification Methods ==========
 
-  /// Get pending (unresponded) recovery request notifications
-  /// Excludes recovery requests initiated by the current user (steward's own requests)
-  /// and requests where the current user has already responded
+  /// Get pending (unresponded) recovery request notifications for steward UI.
+  ///
+  /// Excludes own requests, resolved responses, and requests outside
+  /// [RecoveryLiveNotificationPolicy] (historical relay replay).
   Future<List<RecoveryRequest>> getPendingNotifications() async {
-    await initialize();
-
-    // Get current user's pubkey to filter out their own recovery requests
-    final currentPubkey = await _ndkService.getCurrentPubkey();
-
-    final allRequests = await repository.getAllRecoveryRequests();
-    return allRequests.where((request) {
-      // Exclude requests initiated by the current user (steward's own requests)
-      if (currentPubkey != null && request.initiatorPubkey == currentPubkey) {
-        return false;
-      }
-
-      // Exclude requests where the current user has already responded
-      if (currentPubkey != null) {
-        final userResponse = request.stewardResponses[currentPubkey];
-        if (userResponse != null && userResponse.status.isResolved) {
-          return false;
-        }
-      }
-
-      return true;
-    }).toList();
+    return _pendingRecoveryRequests();
   }
 
   /// Get all recovery request notifications (including viewed)
@@ -1178,31 +1160,18 @@ class RecoveryService {
     }
   }
 
-  /// Get notification count
-  /// Excludes recovery requests initiated by the current user (steward's own requests)
+  /// Get notification count (same scope as [getPendingNotifications]).
   Future<int> getNotificationCount({bool unviewedOnly = true}) async {
     await initialize();
 
-    // Get current user's pubkey to filter out their own recovery requests
-    final currentPubkey = await _ndkService.getCurrentPubkey();
-
-    final allRequests = await repository.getAllRecoveryRequests();
-
-    // Filter out requests initiated by the current user
-    final filteredRequests = allRequests.where((request) {
-      if (currentPubkey != null && request.initiatorPubkey == currentPubkey) {
-        return false;
-      }
-      return true;
-    }).toList();
+    final filteredRequests = await _pendingRecoveryRequests();
 
     if (unviewedOnly) {
       return filteredRequests
           .where((request) => !_viewedNotificationIds!.contains(request.id))
           .length;
-    } else {
-      return filteredRequests.length;
     }
+    return filteredRequests.length;
   }
 
   /// Check if a notification has been viewed
@@ -1239,7 +1208,8 @@ class RecoveryService {
   }
 }
 
-/// Live vs historical replay rules for recovery-related local notifications.
+/// Live vs historical replay rules for recovery-related local notifications and steward UI
+/// ([RecoveryService._pendingRecoveryRequests]).
 ///
 /// Kept next to [RecoveryService] and referenced from tests via this type.
 class RecoveryLiveNotificationPolicy {

--- a/test/services/nostr_subscription_cursor_test.dart
+++ b/test/services/nostr_subscription_cursor_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:horcrux/services/ndk_service.dart';
+import 'package:horcrux/services/processed_nostr_event_store.dart';
+
+void main() {
+  group('computeSinceTime', () {
+    test('no cursor yet uses epoch (0)', () {
+      final now = DateTime.utc(2026, 4, 14, 12);
+      final since = computeSinceTime(
+        nowUtc: now,
+        lastSeenEventCreatedAtUnix: null,
+      );
+      expect(since, 0);
+    });
+
+    test('zero lastSeen uses epoch', () {
+      final since = computeSinceTime(
+        nowUtc: DateTime.utc(2026, 4, 14, 12),
+        lastSeenEventCreatedAtUnix: 0,
+      );
+      expect(since, 0);
+    });
+
+    test('recent lastSeen still includes full rolling window', () {
+      final now = DateTime.utc(2026, 4, 14, 12);
+      final threeDaysAgo = now.subtract(const Duration(days: 3)).millisecondsSinceEpoch ~/ 1000;
+      final oneHourAgo = now.subtract(const Duration(hours: 1)).millisecondsSinceEpoch ~/ 1000;
+      expect(oneHourAgo > threeDaysAgo, isTrue);
+      final since = computeSinceTime(
+        nowUtc: now,
+        lastSeenEventCreatedAtUnix: oneHourAgo,
+      );
+      expect(since, threeDaysAgo);
+    });
+
+    test('stale lastSeen extends back to cursor (not capped to rolling window)', () {
+      final now = DateTime.utc(2026, 4, 14, 12);
+      final threeDaysAgo = now.subtract(const Duration(days: 3)).millisecondsSinceEpoch ~/ 1000;
+      final tenDaysAgo = now.subtract(const Duration(days: 10)).millisecondsSinceEpoch ~/ 1000;
+      expect(tenDaysAgo < threeDaysAgo, isTrue);
+      final since = computeSinceTime(
+        nowUtc: now,
+        lastSeenEventCreatedAtUnix: tenDaysAgo,
+      );
+      expect(since, tenDaysAgo);
+    });
+
+    test('very stale lastSeen (e.g. weeks) uses that bound', () {
+      final now = DateTime.utc(2026, 4, 14, 12);
+      final threeWeeksAgo = now.subtract(const Duration(days: 21)).millisecondsSinceEpoch ~/ 1000;
+      final since = computeSinceTime(
+        nowUtc: now,
+        lastSeenEventCreatedAtUnix: threeWeeksAgo,
+      );
+      expect(since, threeWeeksAgo);
+    });
+  });
+
+  group('normalizeRelayUrlForNostrEventCursor', () {
+    test('strips trailing slash on root path', () {
+      expect(
+        normalizeRelayUrlForNostrEventCursor('wss://relay.example.com/'),
+        'wss://relay.example.com',
+      );
+    });
+
+    test('preserves non-root path', () {
+      expect(
+        normalizeRelayUrlForNostrEventCursor('wss://relay.example.com/nostr'),
+        'wss://relay.example.com/nostr',
+      );
+    });
+
+    test('lowercases host and scheme', () {
+      expect(
+        normalizeRelayUrlForNostrEventCursor('WSS://Relay.EXAMPLE.com'),
+        'wss://relay.example.com',
+      );
+    });
+
+    test('equivalent URLs share the same cursor key', () {
+      expect(
+        normalizeRelayUrlForNostrEventCursor('wss://relay.example.com/'),
+        normalizeRelayUrlForNostrEventCursor('WSS://relay.example.com'),
+      );
+    });
+
+    test('different hosts do not share a cursor key', () {
+      expect(
+        normalizeRelayUrlForNostrEventCursor('wss://a.example.com'),
+        isNot(normalizeRelayUrlForNostrEventCursor('wss://b.example.com')),
+      );
+    });
+  });
+}

--- a/test/services/processed_nostr_event_store_claim_test.dart
+++ b/test/services/processed_nostr_event_store_claim_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:horcrux/services/processed_nostr_event_store.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ProcessedNostrEventStore claims', () {
+    test('second claimEvent for same id returns false until released', () async {
+      final store = ProcessedNostrEventStore();
+      const id = 'abc123';
+
+      expect(await store.claimEvent(id), isTrue);
+      expect(await store.claimEvent(id), isFalse);
+
+      await store.releaseClaimedEvent(id);
+      expect(await store.claimEvent(id), isTrue);
+      await store.releaseClaimedEvent(id);
+    });
+
+    test('claimEvent returns false after recordProcessed', () async {
+      final store = ProcessedNostrEventStore();
+      const id = 'evt1';
+
+      expect(await store.claimEvent(id), isTrue);
+      await store.recordProcessed(id);
+      expect(await store.claimEvent(id), isFalse);
+    });
+
+    test('recordProcessed clears claim without double-append', () async {
+      final store = ProcessedNostrEventStore();
+      const id = 'evt2';
+
+      expect(await store.claimEvent(id), isTrue);
+      await store.recordProcessed(id);
+      expect(await store.contains(id), isTrue);
+      await store.recordProcessed(id);
+      expect(await store.contains(id), isTrue);
+    });
+
+    test('empty id is rejected', () async {
+      final store = ProcessedNostrEventStore();
+      expect(await store.claimEvent(''), isFalse);
+    });
+  });
+}

--- a/test/services/processed_nostr_event_store_claim_test.dart
+++ b/test/services/processed_nostr_event_store_claim_test.dart
@@ -1,8 +1,34 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:horcrux/services/processed_nostr_event_store.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempSupportDir;
+
+  setUp(() {
+    tempSupportDir = Directory.systemTemp.createTempSync('horcrux_processed_store_');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (call) async {
+        if (call.method == 'getApplicationSupportDirectory') {
+          return tempSupportDir.path;
+        }
+        return null;
+      },
+    );
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(const MethodChannel('plugins.flutter.io/path_provider'), null);
+    if (tempSupportDir.existsSync()) {
+      tempSupportDir.deleteSync(recursive: true);
+    }
+  });
 
   group('ProcessedNostrEventStore claims', () {
     test('second claimEvent for same id returns false until released', () async {

--- a/test/services/recovery_live_event_policy_test.dart
+++ b/test/services/recovery_live_event_policy_test.dart
@@ -3,6 +3,34 @@ import 'package:horcrux/models/recovery_request.dart';
 import 'package:horcrux/services/recovery_service.dart';
 
 void main() {
+  group('RecoveryLiveNotificationPolicy.isLiveEventTime', () {
+    final firstOpen = DateTime.utc(2026, 4, 1, 12, 0);
+
+    test('matches slack window', () {
+      expect(
+        RecoveryNotificationPolicy.isLiveEventTime(
+          DateTime.utc(2026, 3, 1),
+          firstOpen,
+        ),
+        isFalse,
+      );
+      expect(
+        RecoveryNotificationPolicy.isLiveEventTime(
+          DateTime.utc(2026, 4, 1, 11, 30),
+          firstOpen,
+        ),
+        isTrue,
+      );
+      expect(
+        RecoveryNotificationPolicy.isLiveEventTime(
+          DateTime.utc(2026, 4, 1, 13),
+          firstOpen,
+        ),
+        isTrue,
+      );
+    });
+  });
+
   group('recovery live event policy', () {
     final firstOpen = DateTime.utc(2026, 4, 1, 12, 0);
 
@@ -17,7 +45,7 @@ void main() {
         eventCreationTime: DateTime.utc(2026, 3, 1),
       );
       expect(
-        RecoveryLiveNotificationPolicy.shouldNotifyRecoveryRequest(req, firstOpen),
+        RecoveryNotificationPolicy.shouldNotifyRecoveryRequest(req, firstOpen),
         isFalse,
       );
     });
@@ -33,7 +61,7 @@ void main() {
         eventCreationTime: DateTime.utc(2026, 4, 1, 12, 30),
       );
       expect(
-        RecoveryLiveNotificationPolicy.shouldNotifyRecoveryRequest(req, firstOpen),
+        RecoveryNotificationPolicy.shouldNotifyRecoveryRequest(req, firstOpen),
         isTrue,
       );
     });
@@ -49,29 +77,236 @@ void main() {
         eventCreationTime: DateTime.utc(2026, 4, 1, 11, 30),
       );
       expect(
-        RecoveryLiveNotificationPolicy.shouldNotifyRecoveryRequest(req, firstOpen),
+        RecoveryNotificationPolicy.shouldNotifyRecoveryRequest(req, firstOpen),
         isTrue,
       );
     });
 
-    test('should not notify response without inner created time', () {
+    test('should not notify recovery request when initiator is current user', () {
+      final me = 'a' * 64;
+      final req = RecoveryRequest(
+        id: 'r1',
+        vaultId: 'v1',
+        initiatorPubkey: me,
+        requestedAt: DateTime.utc(2026, 4, 1, 10, 0),
+        status: RecoveryRequestStatus.sent,
+        threshold: 2,
+        eventCreationTime: DateTime.utc(2026, 4, 1, 12, 30),
+      );
       expect(
-        RecoveryLiveNotificationPolicy.shouldNotifyRecoveryResponse(
-          createdAt: null,
-          firstOpenUtc: firstOpen,
+        RecoveryNotificationPolicy.shouldNotifyRecoveryRequest(
+          req,
+          firstOpen,
+          currentPubkeyHex: me,
         ),
         isFalse,
       );
     });
 
-    test('should notify response when inner time is after first open', () {
-      expect(
-        RecoveryLiveNotificationPolicy.shouldNotifyRecoveryResponse(
-          createdAt: DateTime.utc(2026, 4, 1, 13),
-          firstOpenUtc: firstOpen,
-        ),
-        isTrue,
-      );
+    group('shouldNotifyIncomingRecoveryResponseLocally', () {
+      final initiator = 'a' * 64;
+      final stewardMe = 'b' * 64;
+      final stewardOther = 'c' * 64;
+      final liveInnerTime = DateTime.utc(2026, 4, 1, 13);
+
+      RecoveryRequest baseRequest({
+        required RecoveryRequestStatus status,
+        required Map<String, RecoveryResponse> responses,
+      }) {
+        return RecoveryRequest(
+          id: 'r1',
+          vaultId: 'v1',
+          initiatorPubkey: initiator,
+          requestedAt: DateTime.utc(2026, 4, 1),
+          status: status,
+          threshold: 2,
+          stewardResponses: responses,
+        );
+      }
+
+      test('false without inner created time', () {
+        final req = baseRequest(
+          status: RecoveryRequestStatus.inProgress,
+          responses: {
+            stewardOther: RecoveryResponse(pubkey: stewardOther, approved: false),
+          },
+        );
+        expect(
+          RecoveryNotificationPolicy.shouldNotifyRecoveryResponse(
+            responseCreatedAt: null,
+            firstOpenUtc: firstOpen,
+            requestBeforeApply: req,
+            currentPubkeyHex: initiator,
+            responseSenderPubkey: stewardOther,
+          ),
+          isFalse,
+        );
+      });
+
+      test('true when live inner time and initiator hears peer response', () {
+        final req = baseRequest(
+          status: RecoveryRequestStatus.inProgress,
+          responses: {
+            initiator: RecoveryResponse(
+              pubkey: initiator,
+              approved: true,
+              respondedAt: DateTime.utc(2026, 4, 1, 11),
+            ),
+            stewardOther: RecoveryResponse(pubkey: stewardOther, approved: false),
+          },
+        );
+        expect(
+          RecoveryNotificationPolicy.shouldNotifyRecoveryResponse(
+            responseCreatedAt: liveInnerTime,
+            firstOpenUtc: firstOpen,
+            requestBeforeApply: req,
+            currentPubkeyHex: initiator,
+            responseSenderPubkey: stewardOther,
+          ),
+          isTrue,
+        );
+      });
+
+      test('false when inner time is historical even if initiator', () {
+        final req = baseRequest(
+          status: RecoveryRequestStatus.inProgress,
+          responses: {
+            initiator: RecoveryResponse(
+              pubkey: initiator,
+              approved: true,
+              respondedAt: DateTime.utc(2026, 4, 1, 11),
+            ),
+            stewardOther: RecoveryResponse(pubkey: stewardOther, approved: false),
+          },
+        );
+        expect(
+          RecoveryNotificationPolicy.shouldNotifyRecoveryResponse(
+            responseCreatedAt: DateTime.utc(2026, 3, 1),
+            firstOpenUtc: firstOpen,
+            requestBeforeApply: req,
+            currentPubkeyHex: initiator,
+            responseSenderPubkey: stewardOther,
+          ),
+          isFalse,
+        );
+      });
+
+      test('false for non-initiator steward (peer responses)', () {
+        final req = baseRequest(
+          status: RecoveryRequestStatus.inProgress,
+          responses: {
+            stewardMe: RecoveryResponse(
+              pubkey: stewardMe,
+              approved: false,
+              respondedAt: DateTime.utc(2026, 4, 1, 12),
+            ),
+            stewardOther: RecoveryResponse(pubkey: stewardOther, approved: false),
+          },
+        );
+        expect(
+          RecoveryNotificationPolicy.shouldNotifyRecoveryResponse(
+            responseCreatedAt: liveInnerTime,
+            firstOpenUtc: firstOpen,
+            requestBeforeApply: req,
+            currentPubkeyHex: stewardMe,
+            responseSenderPubkey: stewardOther,
+          ),
+          isFalse,
+        );
+      });
+
+      test('false for non-initiator steward still pending', () {
+        final req = baseRequest(
+          status: RecoveryRequestStatus.inProgress,
+          responses: {
+            stewardMe: RecoveryResponse(pubkey: stewardMe, approved: false),
+            stewardOther: RecoveryResponse(pubkey: stewardOther, approved: false),
+          },
+        );
+        expect(
+          RecoveryNotificationPolicy.shouldNotifyRecoveryResponse(
+            responseCreatedAt: liveInnerTime,
+            firstOpenUtc: firstOpen,
+            requestBeforeApply: req,
+            currentPubkeyHex: stewardMe,
+            responseSenderPubkey: stewardOther,
+          ),
+          isFalse,
+        );
+      });
+
+      test('false when response is from self', () {
+        final req = baseRequest(
+          status: RecoveryRequestStatus.inProgress,
+          responses: {
+            initiator: RecoveryResponse(
+              pubkey: initiator,
+              approved: true,
+              respondedAt: DateTime.utc(2026, 4, 1, 11),
+            ),
+            stewardOther: RecoveryResponse(pubkey: stewardOther, approved: false),
+          },
+        );
+        expect(
+          RecoveryNotificationPolicy.shouldNotifyRecoveryResponse(
+            responseCreatedAt: liveInnerTime,
+            firstOpenUtc: firstOpen,
+            requestBeforeApply: req,
+            currentPubkeyHex: initiator,
+            responseSenderPubkey: initiator,
+          ),
+          isFalse,
+        );
+      });
+
+      test('false when session already terminal', () {
+        final req = baseRequest(
+          status: RecoveryRequestStatus.archived,
+          responses: {
+            stewardMe: RecoveryResponse(
+              pubkey: stewardMe,
+              approved: false,
+              respondedAt: DateTime.utc(2026, 4, 1, 12),
+            ),
+          },
+        );
+        expect(
+          RecoveryNotificationPolicy.shouldNotifyRecoveryResponse(
+            responseCreatedAt: liveInnerTime,
+            firstOpenUtc: firstOpen,
+            requestBeforeApply: req,
+            currentPubkeyHex: stewardMe,
+            responseSenderPubkey: stewardOther,
+          ),
+          isFalse,
+        );
+      });
+
+      test('false when request or pubkey unknown', () {
+        expect(
+          RecoveryNotificationPolicy.shouldNotifyRecoveryResponse(
+            responseCreatedAt: liveInnerTime,
+            firstOpenUtc: firstOpen,
+            requestBeforeApply: null,
+            currentPubkeyHex: initiator,
+            responseSenderPubkey: stewardOther,
+          ),
+          isFalse,
+        );
+        expect(
+          RecoveryNotificationPolicy.shouldNotifyRecoveryResponse(
+            responseCreatedAt: liveInnerTime,
+            firstOpenUtc: firstOpen,
+            requestBeforeApply: baseRequest(
+              status: RecoveryRequestStatus.inProgress,
+              responses: {},
+            ),
+            currentPubkeyHex: null,
+            responseSenderPubkey: stewardOther,
+          ),
+          isFalse,
+        );
+      });
     });
   });
 }


### PR DESCRIPTION
This adds per-relay tracking of the last event we received so we can use an intelligent `since` filter and avoid downloading tons of duplicate data from relays on app launch.

I also fixed some bugs and cleaned up the code around showing recovery notifications.