### PR TITLE
claude/vscode: Navigate to RecoveryStatusScreen when tapping a recovery response notification

### DIFF
--- a/lib/services/local_notification_service.dart
+++ b/lib/services/local_notification_service.dart
@@ -10,6 +10,7 @@ import '../models/recovery_request.dart';
 import '../models/shard_data.dart';
 import '../providers/vault_provider.dart';
 import '../screens/recovery_request_detail_screen.dart';
+import '../screens/recovery_status_screen.dart';
 import '../screens/vault_detail_screen.dart';
 import '../utils/push_notification_text.dart';
 import 'logger.dart';
@@ -336,16 +337,17 @@ class LocalNotificationService {
 
   /// Navigates to the appropriate screen for the given [kind] and [id].
   ///
-  /// [vaultId] is required for shard and recovery-response kinds to open
-  /// [VaultDetailScreen]. Returns `true` if navigation succeeded, `false` if
-  /// the target could not be found or required context (e.g. vaultId) is absent.
+  /// [vaultId] is required for shard kinds to open [VaultDetailScreen].
+  /// Returns `true` if navigation succeeded, `false` if the target could not
+  /// be found or required context (e.g. vaultId) is absent.
   Future<bool> navigateForKind(NostrKind kind, String id, {String? vaultId}) async {
     switch (kind) {
       case NostrKind.recoveryRequest:
         return _navigateToRecoveryRequest(id);
+      case NostrKind.recoveryResponse:
+        return _navigateToRecoveryStatus(id);
       case NostrKind.shardData:
       case NostrKind.shardConfirmation:
-      case NostrKind.recoveryResponse:
         if (vaultId == null || vaultId.isEmpty) {
           Log.debug('No vaultId for $kind notification tap, skipping navigation');
           return false;
@@ -365,6 +367,14 @@ class LocalNotificationService {
       (context) => VaultDetailScreen(vaultId: vaultId),
       debugLabel: 'vault $vaultId',
     );
+  }
+
+  Future<bool> _navigateToRecoveryStatus(String recoveryRequestId) async {
+    await _pushRouteWhenReady(
+      (context) => RecoveryStatusScreen(recoveryRequestId: recoveryRequestId),
+      debugLabel: 'recovery status $recoveryRequestId',
+    );
+    return true;
   }
 
   Future<bool> _navigateToRecoveryRequest(String recoveryRequestId) async {


### PR DESCRIPTION
## Summary

- When the user taps a recovery response notification, navigate to RecoveryStatusScreen instead of VaultDetailScreen
- Breaks NostrKind.recoveryResponse out of the shared shard-cases block in navigateForKind so it calls the new _navigateToRecoveryStatus method
- Mirrors the existing _navigateToRecoveryRequest pattern — the recovery request ID is already encoded in the notification payload

## Test plan

- [ ] Trigger a recovery response (approval or denial) from a steward device
- [ ] Tap the resulting notification on the vault owner's device
- [ ] Confirm navigation lands on RecoveryStatusScreen showing the correct recovery request
- [ ] Confirm shard data / shard confirmation notifications still navigate to VaultDetailScreen

Generated with Claude Code