### PR TITLE
Clear processed Nostr event stores on logout and on secure-storage corruption

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,7 +6,10 @@
     <application
         android:label="Horcrux"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:allowBackup="false"
+        android:fullBackupContent="false"
+        android:dataExtractionRules="@xml/data_extraction_rules">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Disable Android Auto Backup and Device-to-Device transfer for all app data.
+
+  Horcrux stores a Nostr private key in the platform Keystore via
+  flutter_secure_storage; the keystore entry never travels with Auto Backup
+  while ciphertext stored in SharedPreferences would, leaving us unable to
+  decrypt anything on the destination device. The same applies to the
+  on-disk processed Nostr event log/WAL/cursors under getApplicationSupport.
+
+  By excluding every domain we ensure the OS never restores caches that
+  reference an unrecoverable identity.
+-->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="root" />
+        <exclude domain="file" />
+        <exclude domain="database" />
+        <exclude domain="sharedpref" />
+        <exclude domain="external" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="root" />
+        <exclude domain="file" />
+        <exclude domain="database" />
+        <exclude domain="sharedpref" />
+        <exclude domain="external" />
+    </device-transfer>
+</data-extraction-rules>

--- a/lib/providers/key_provider.dart
+++ b/lib/providers/key_provider.dart
@@ -1,10 +1,22 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../services/login_service.dart';
+import '../services/logout_service.dart';
+import '../services/processed_nostr_event_store.dart';
 
 /// Provider for LoginService
 /// Riverpod automatically ensures this is a singleton - only one instance exists
 final loginServiceProvider = Provider<LoginService>((ref) {
-  return LoginService();
+  final loginService = LoginService();
+  // When the secure-storage read path detects corruption (e.g. keystore key is
+  // gone after a debug-over-release install or Auto Backup restore), wipe the
+  // durable caches that still reference the now-unrecoverable identity before
+  // we fall through to onboarding and generate a fresh key.
+  loginService.onSecureStorageReadFailure = () async {
+    await wipeLocalDataForCorruptedSecureStorage(
+      processedNostrEventStore: ref.read(processedNostrEventStoreProvider),
+    );
+  };
+  return loginService;
 });
 
 /// FutureProvider for the current public key in hex format

--- a/lib/providers/key_provider.dart
+++ b/lib/providers/key_provider.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../services/login_service.dart';
-import '../services/logout_service.dart';
 import '../services/processed_nostr_event_store.dart';
+import '../services/secure_storage_corruption.dart';
 
 /// Provider for LoginService
 /// Riverpod automatically ensures this is a singleton - only one instance exists

--- a/lib/services/login_service.dart
+++ b/lib/services/login_service.dart
@@ -9,10 +9,23 @@ import 'logger.dart';
 /// Login service for managing user's Nostr authentication credentials
 /// Only stores the private key - public key is derived as needed
 class LoginService {
-  static const _storage = FlutterSecureStorage();
+  /// `resetOnError: true` lets the Android plugin wipe its corrupted ciphertext
+  /// when the keystore key is gone (e.g. debug build installed over release,
+  /// or Auto Backup restored prefs without the keystore entry) instead of
+  /// leaving a half-broken state behind.
+  static const _storage = FlutterSecureStorage(
+    aOptions: AndroidOptions(resetOnError: true),
+  );
   static const String _nostrPrivateKeyKey = 'nostr_private_key';
 
   static KeyPair? _cachedKeyPair;
+
+  /// Optional hook invoked from [getStoredNostrKey] when reading the stored
+  /// Nostr private key throws (i.e. secure-storage decryption failure). Use
+  /// this to wipe local on-disk caches that would otherwise reference a key we
+  /// can no longer access. The hook runs once per failed read and any errors
+  /// it throws are logged and swallowed.
+  Future<void> Function()? onSecureStorageReadFailure;
 
   // Regular constructor - Riverpod manages the singleton behavior
   LoginService();
@@ -127,8 +140,20 @@ class LoginService {
       } else {
         Log.error('No private key found in secure storage');
       }
-    } catch (e) {
-      Log.error('Error reading stored key', e);
+    } catch (e, st) {
+      Log.error('Error reading stored key', e, st);
+      final hook = onSecureStorageReadFailure;
+      if (hook != null) {
+        try {
+          await hook();
+        } catch (e2, st2) {
+          Log.error(
+            'onSecureStorageReadFailure hook threw while wiping local caches',
+            e2,
+            st2,
+          );
+        }
+      }
     }
 
     return null;

--- a/lib/services/login_service.dart
+++ b/lib/services/login_service.dart
@@ -5,6 +5,7 @@ import 'package:ndk/shared/nips/nip44/nip44.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:meta/meta.dart';
 import 'logger.dart';
+import 'secure_storage_corruption.dart';
 
 /// Login service for managing user's Nostr authentication credentials
 /// Only stores the private key - public key is derived as needed
@@ -21,10 +22,15 @@ class LoginService {
   static KeyPair? _cachedKeyPair;
 
   /// Optional hook invoked from [getStoredNostrKey] when reading the stored
-  /// Nostr private key throws (i.e. secure-storage decryption failure). Use
-  /// this to wipe local on-disk caches that would otherwise reference a key we
-  /// can no longer access. The hook runs once per failed read and any errors
-  /// it throws are logged and swallowed.
+  /// Nostr private key fails with an error that indicates the encrypted blob
+  /// can never be decrypted again (see [isPermanentSecureStorageReadFailure]).
+  /// Use this to wipe local on-disk caches that would otherwise reference a
+  /// key we can no longer access. The hook runs once per failed read and any
+  /// errors it throws are logged and swallowed.
+  ///
+  /// Transient read failures (e.g. one-shot init races, `KeyStoreException`
+  /// not-found, `NullPointerException`) do **not** invoke the hook so we never
+  /// destroy recoverable data on a flake.
   Future<void> Function()? onSecureStorageReadFailure;
 
   // Regular constructor - Riverpod manages the singleton behavior
@@ -142,16 +148,23 @@ class LoginService {
       }
     } catch (e, st) {
       Log.error('Error reading stored key', e, st);
-      final hook = onSecureStorageReadFailure;
-      if (hook != null) {
-        try {
-          await hook();
-        } catch (e2, st2) {
-          Log.error(
-            'onSecureStorageReadFailure hook threw while wiping local caches',
-            e2,
-            st2,
-          );
+      // Only invoke the destructive wipe hook for errors that mean the
+      // ciphertext is unrecoverable (Android Keystore key gone). Transient
+      // failures fall through and let the caller / next read retry; the
+      // FlutterSecureStorage `resetOnError: true` option handles plugin-side
+      // recovery for those.
+      if (isPermanentSecureStorageReadFailure(e)) {
+        final hook = onSecureStorageReadFailure;
+        if (hook != null) {
+          try {
+            await hook();
+          } catch (e2, st2) {
+            Log.error(
+              'onSecureStorageReadFailure hook threw while wiping local caches',
+              e2,
+              st2,
+            );
+          }
         }
       }
     }

--- a/lib/services/logout_service.dart
+++ b/lib/services/logout_service.dart
@@ -1,12 +1,14 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../providers/vault_provider.dart';
 import '../providers/key_provider.dart';
-import 'vault_share_service.dart';
-import 'recovery_service.dart';
-import 'relay_scan_service.dart';
 import 'login_service.dart';
 import 'logger.dart';
+import 'processed_nostr_event_store.dart';
+import 'recovery_service.dart';
+import 'relay_scan_service.dart';
+import 'vault_share_service.dart';
 
 /// Service responsible for performing logout cleanup across data stores.
 final logoutServiceProvider = Provider<LogoutService>((ref) {
@@ -16,6 +18,7 @@ final logoutServiceProvider = Provider<LogoutService>((ref) {
     recoveryService: ref.read(recoveryServiceProvider),
     relayScanService: ref.read(relayScanServiceProvider),
     loginService: ref.read(loginServiceProvider),
+    processedNostrEventStore: ref.read(processedNostrEventStoreProvider),
   );
 });
 
@@ -25,6 +28,7 @@ class LogoutService {
   final RecoveryService _recoveryService;
   final RelayScanService _relayScanService;
   final LoginService _loginService;
+  final ProcessedNostrEventStore _processedNostrEventStore;
 
   const LogoutService({
     required VaultRepository vaultRepository,
@@ -32,11 +36,13 @@ class LogoutService {
     required RecoveryService recoveryService,
     required RelayScanService relayScanService,
     required LoginService loginService,
+    required ProcessedNostrEventStore processedNostrEventStore,
   })  : _vaultRepository = vaultRepository,
         _vaultShareService = vaultShareService,
         _recoveryService = recoveryService,
         _relayScanService = relayScanService,
-        _loginService = loginService;
+        _loginService = loginService,
+        _processedNostrEventStore = processedNostrEventStore;
 
   Future<void> logout() async {
     Log.info('LogoutService: clearing all vault data and keys');
@@ -51,11 +57,18 @@ class LogoutService {
       // Continue with logout even if this fails
     }
 
-    // Clear all service data
+    // Clear all service data (clear the on-disk processed Nostr event store
+    // after relay scanning has stopped so nothing is racing to write the WAL).
     await _vaultRepository.clearAll();
     await _vaultShareService.clearAll();
     await _recoveryService.clearAll();
     await _relayScanService.clearAll();
+    try {
+      await _processedNostrEventStore.clearAll();
+    } catch (e, st) {
+      Log.error('Error clearing processed Nostr event store during logout', e, st);
+      // Don't throw - keep going so the rest of logout can complete
+    }
     await _loginService.clearStoredKeys();
 
     // Clear all SharedPreferences to ensure complete cleanup
@@ -70,5 +83,48 @@ class LogoutService {
     }
 
     Log.info('LogoutService: logout completed');
+  }
+}
+
+/// Wipes durable on-disk caches that reference the active Nostr identity.
+///
+/// Call when secure-storage decryption fails (e.g. installing the debug build
+/// over the release build, or Android Auto Backup restoring SharedPreferences /
+/// application support files into a process whose keystore key is gone). The
+/// previous private key is unrecoverable, so any caches keyed off it -- the
+/// processed Nostr event log/WAL/cursors, vault metadata in SharedPreferences,
+/// and any half-written ciphertext in secure storage -- must be discarded
+/// before generating a fresh identity.
+///
+/// Unlike [LogoutService.logout], this does not stop relay scanning or tear
+/// down service caches: it is intended for the cold-start corruption path
+/// where no services have been initialised yet.
+Future<void> wipeLocalDataForCorruptedSecureStorage({
+  required ProcessedNostrEventStore processedNostrEventStore,
+}) async {
+  Log.warning('Wiping local caches due to corrupted secure storage');
+
+  try {
+    await processedNostrEventStore.clearAll();
+  } catch (e, st) {
+    Log.error('Failed to clear processed Nostr event store during corruption wipe', e, st);
+  }
+
+  try {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.clear();
+  } catch (e, st) {
+    Log.error('Failed to clear SharedPreferences during corruption wipe', e, st);
+  }
+
+  try {
+    // Match the LoginService secure-storage configuration so resetOnError lines
+    // up with the storage instance that holds the corrupted ciphertext.
+    const storage = FlutterSecureStorage(
+      aOptions: AndroidOptions(resetOnError: true),
+    );
+    await storage.deleteAll();
+  } catch (e, st) {
+    Log.error('Failed to deleteAll secure storage during corruption wipe', e, st);
   }
 }

--- a/lib/services/logout_service.dart
+++ b/lib/services/logout_service.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../providers/vault_provider.dart';
 import '../providers/key_provider.dart';
@@ -83,48 +82,5 @@ class LogoutService {
     }
 
     Log.info('LogoutService: logout completed');
-  }
-}
-
-/// Wipes durable on-disk caches that reference the active Nostr identity.
-///
-/// Call when secure-storage decryption fails (e.g. installing the debug build
-/// over the release build, or Android Auto Backup restoring SharedPreferences /
-/// application support files into a process whose keystore key is gone). The
-/// previous private key is unrecoverable, so any caches keyed off it -- the
-/// processed Nostr event log/WAL/cursors, vault metadata in SharedPreferences,
-/// and any half-written ciphertext in secure storage -- must be discarded
-/// before generating a fresh identity.
-///
-/// Unlike [LogoutService.logout], this does not stop relay scanning or tear
-/// down service caches: it is intended for the cold-start corruption path
-/// where no services have been initialised yet.
-Future<void> wipeLocalDataForCorruptedSecureStorage({
-  required ProcessedNostrEventStore processedNostrEventStore,
-}) async {
-  Log.warning('Wiping local caches due to corrupted secure storage');
-
-  try {
-    await processedNostrEventStore.clearAll();
-  } catch (e, st) {
-    Log.error('Failed to clear processed Nostr event store during corruption wipe', e, st);
-  }
-
-  try {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.clear();
-  } catch (e, st) {
-    Log.error('Failed to clear SharedPreferences during corruption wipe', e, st);
-  }
-
-  try {
-    // Match the LoginService secure-storage configuration so resetOnError lines
-    // up with the storage instance that holds the corrupted ciphertext.
-    const storage = FlutterSecureStorage(
-      aOptions: AndroidOptions(resetOnError: true),
-    );
-    await storage.deleteAll();
-  } catch (e, st) {
-    Log.error('Failed to deleteAll secure storage during corruption wipe', e, st);
   }
 }

--- a/lib/services/processed_nostr_event_store.dart
+++ b/lib/services/processed_nostr_event_store.dart
@@ -364,4 +364,38 @@ class ProcessedNostrEventStore {
   ///
   /// Call when the app backgrounds or terminates so durable state is not left only in the WAL.
   Future<void> writeStores() => flushToDisk();
+
+  /// Clears all in-memory state and deletes the on-disk log, WAL, cursors files
+  /// (and any leftover cursors `.tmp`).
+  ///
+  /// Use on logout or when local caches must be discarded because they no longer
+  /// match the active identity (e.g. secure-storage decryption failure where the
+  /// previous Nostr key is unrecoverable).
+  Future<void> clearAll() async {
+    _cancelDebouncedPersist();
+    await _serialized(() async {
+      await ensureLoaded();
+      _ids.clear();
+      _claimedIds.clear();
+      _relayMaxSeenEventCreatedAtSec.clear();
+
+      final dir = _dir;
+      final filesToDelete = <File?>[
+        _logFile,
+        _walFile,
+        _cursorsFile,
+        if (dir != null) File(p.join(dir.path, '$_cursorsFileName.tmp')),
+      ];
+      for (final file in filesToDelete) {
+        if (file == null) continue;
+        try {
+          if (await file.exists()) {
+            await file.delete();
+          }
+        } catch (e, st) {
+          Log.error('ProcessedNostrEventStore failed to delete ${file.path}', e, st);
+        }
+      }
+    });
+  }
 }

--- a/lib/services/processed_nostr_event_store.dart
+++ b/lib/services/processed_nostr_event_store.dart
@@ -230,10 +230,13 @@ class ProcessedNostrEventStore {
   ///
   /// No-op while a [clearAll] is in effect (until the next state-mutating call)
   /// so dispose-time flushes do not resurrect the cursors file we just deleted.
+  /// The suppression flag is checked **inside** [_serialized] so that a flush
+  /// launched concurrently with -- but ordered after -- a [clearAll] sees the
+  /// flag set by the time its body runs, instead of racing against it.
   Future<void> flushToDisk() async {
     _cancelDebouncedPersist();
-    if (_suppressFlushUntilNextWrite) return;
     await _serialized(() async {
+      if (_suppressFlushUntilNextWrite) return;
       await ensureLoaded();
       await _mergeWalIntoLog();
       await _writeCursorsJson();

--- a/lib/services/processed_nostr_event_store.dart
+++ b/lib/services/processed_nostr_event_store.dart
@@ -80,6 +80,12 @@ class ProcessedNostrEventStore {
 
   Timer? _persistenceDebounceTimer;
 
+  /// Set true by [clearAll]; cleared by the next state-mutating call. Used to
+  /// short-circuit [flushToDisk] so a dispose-time flush after a logout /
+  /// corruption wipe does not resurrect the cursors file from the now-empty
+  /// in-memory map.
+  bool _suppressFlushUntilNextWrite = false;
+
   /// Serializes log/WAL appends and merge so concurrent calls do not corrupt files.
   Future<void> _chain = Future<void>.value();
 
@@ -221,8 +227,12 @@ class ProcessedNostrEventStore {
   ///
   /// Desktop (e.g. macOS) often never reaches [AppLifecycleState.paused]; call this from
   /// lifecycle transitions so cursors and merged log state survive restarts.
+  ///
+  /// No-op while a [clearAll] is in effect (until the next state-mutating call)
+  /// so dispose-time flushes do not resurrect the cursors file we just deleted.
   Future<void> flushToDisk() async {
     _cancelDebouncedPersist();
+    if (_suppressFlushUntilNextWrite) return;
     await _serialized(() async {
       await ensureLoaded();
       await _mergeWalIntoLog();
@@ -324,6 +334,7 @@ class ProcessedNostrEventStore {
       }
 
       _ingestId(id);
+      _suppressFlushUntilNextWrite = false;
       scheduleFlush = true;
     });
     if (scheduleFlush) {
@@ -353,6 +364,7 @@ class ProcessedNostrEventStore {
       final existing = _relayMaxSeenEventCreatedAtSec[key] ?? 0;
       if (createdAtUnix <= existing) return;
       _relayMaxSeenEventCreatedAtSec[key] = createdAtUnix;
+      _suppressFlushUntilNextWrite = false;
       scheduleFlush = true;
     });
     if (scheduleFlush) {
@@ -371,6 +383,10 @@ class ProcessedNostrEventStore {
   /// Use on logout or when local caches must be discarded because they no longer
   /// match the active identity (e.g. secure-storage decryption failure where the
   /// previous Nostr key is unrecoverable).
+  ///
+  /// Subsequent [flushToDisk] calls are no-ops until a state-mutating call
+  /// (e.g. [recordProcessed], [recordLastSeen]) happens, so a dispose-time
+  /// flush after this method does not resurrect the cursors file.
   Future<void> clearAll() async {
     _cancelDebouncedPersist();
     await _serialized(() async {
@@ -396,6 +412,8 @@ class ProcessedNostrEventStore {
           Log.error('ProcessedNostrEventStore failed to delete ${file.path}', e, st);
         }
       }
+
+      _suppressFlushUntilNextWrite = true;
     });
   }
 }

--- a/lib/services/secure_storage_corruption.dart
+++ b/lib/services/secure_storage_corruption.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'logger.dart';
+import 'processed_nostr_event_store.dart';
+
+/// Wipes durable on-disk caches that reference the active Nostr identity.
+///
+/// Call when secure-storage decryption fails (e.g. installing the debug build
+/// over the release build, or Android Auto Backup restoring SharedPreferences /
+/// application support files into a process whose keystore key is gone). The
+/// previous private key is unrecoverable, so any caches keyed off it -- the
+/// processed Nostr event log/WAL/cursors, vault metadata in SharedPreferences,
+/// and any half-written ciphertext in secure storage -- must be discarded
+/// before generating a fresh identity.
+///
+/// Unlike `LogoutService.logout`, this does not stop relay scanning or tear
+/// down service caches: it is intended for the cold-start corruption path
+/// where no services have been initialised yet.
+///
+/// Lives in its own file (rather than alongside `LogoutService`) so the login
+/// path can wire it without importing logout's provider, which would create a
+/// cycle with `key_provider.dart`.
+Future<void> wipeLocalDataForCorruptedSecureStorage({
+  required ProcessedNostrEventStore processedNostrEventStore,
+}) async {
+  Log.warning('Wiping local caches due to corrupted secure storage');
+
+  try {
+    await processedNostrEventStore.clearAll();
+  } catch (e, st) {
+    Log.error('Failed to clear processed Nostr event store during corruption wipe', e, st);
+  }
+
+  try {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.clear();
+  } catch (e, st) {
+    Log.error('Failed to clear SharedPreferences during corruption wipe', e, st);
+  }
+
+  try {
+    // Match the LoginService secure-storage configuration so resetOnError lines
+    // up with the storage instance that holds the corrupted ciphertext.
+    const storage = FlutterSecureStorage(
+      aOptions: AndroidOptions(resetOnError: true),
+    );
+    await storage.deleteAll();
+  } catch (e, st) {
+    Log.error('Failed to deleteAll secure storage during corruption wipe', e, st);
+  }
+}
+
+/// True if [error] is a `PlatformException` whose underlying Java exception
+/// indicates the Android Keystore key used to encrypt secure-storage data is
+/// gone (debug build over release, OS reset, Auto Backup restore without the
+/// keystore entry, etc.).
+///
+/// Such errors are permanent: the ciphertext can never be decrypted again and
+/// any caches keyed off it are stale. Use this to decide whether to invoke
+/// [wipeLocalDataForCorruptedSecureStorage] vs. just logging and falling back.
+///
+/// Transient failures (`NullPointerException`, `KeyStoreException`,
+/// `ServiceSpecificException`, etc.) are deliberately treated as recoverable
+/// here: the FlutterSecureStorage plugin's `resetOnError: true` already gives
+/// it a chance to recover from those internally, and we do not want to wipe
+/// the user's vault data on what may be a one-shot init race.
+bool isPermanentSecureStorageReadFailure(Object error) {
+  if (error is! PlatformException) return false;
+  final haystack = [
+    error.message ?? '',
+    error.details?.toString() ?? '',
+  ].join(' ').toLowerCase();
+  // Java exception class names appear in the PlatformException message string
+  // produced by the Android implementation of flutter_secure_storage. The
+  // `bad_decrypt` token shows up inside the OpenSSL error wrapped by
+  // BadPaddingException on some devices.
+  const markers = [
+    'badpaddingexception',
+    'invalidkeyexception',
+    'unrecoverablekeyexception',
+    'bad_decrypt',
+  ];
+  return markers.any(haystack.contains);
+}

--- a/test/services/backup_service_test.mocks.dart
+++ b/test/services/backup_service_test.mocks.dart
@@ -585,6 +585,16 @@ class MockLoginService extends _i1.Mock implements _i16.LoginService {
   }
 
   @override
+  set onSecureStorageReadFailure(_i6.Future<void> Function()? _onSecureStorageReadFailure) =>
+      super.noSuchMethod(
+        Invocation.setter(
+          #onSecureStorageReadFailure,
+          _onSecureStorageReadFailure,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i6.Future<_i2.KeyPair> generateAndStoreNostrKey() => (super.noSuchMethod(
         Invocation.method(
           #generateAndStoreNostrKey,

--- a/test/services/horcrux_notification_service_test.mocks.dart
+++ b/test/services/horcrux_notification_service_test.mocks.dart
@@ -49,6 +49,16 @@ class MockLoginService extends _i1.Mock implements _i3.LoginService {
   }
 
   @override
+  set onSecureStorageReadFailure(_i4.Future<void> Function()? _onSecureStorageReadFailure) =>
+      super.noSuchMethod(
+        Invocation.setter(
+          #onSecureStorageReadFailure,
+          _onSecureStorageReadFailure,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i4.Future<_i2.KeyPair> generateAndStoreNostrKey() => (super.noSuchMethod(
         Invocation.method(
           #generateAndStoreNostrKey,

--- a/test/services/invitation_acceptance_format_test.mocks.dart
+++ b/test/services/invitation_acceptance_format_test.mocks.dart
@@ -350,6 +350,16 @@ class MockLoginService extends _i1.Mock implements _i8.LoginService {
   }
 
   @override
+  set onSecureStorageReadFailure(_i6.Future<void> Function()? _onSecureStorageReadFailure) =>
+      super.noSuchMethod(
+        Invocation.setter(
+          #onSecureStorageReadFailure,
+          _onSecureStorageReadFailure,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i6.Future<_i3.KeyPair> generateAndStoreNostrKey() => (super.noSuchMethod(
         Invocation.method(
           #generateAndStoreNostrKey,

--- a/test/services/invitation_service_test.mocks.dart
+++ b/test/services/invitation_service_test.mocks.dart
@@ -350,6 +350,16 @@ class MockLoginService extends _i1.Mock implements _i8.LoginService {
   }
 
   @override
+  set onSecureStorageReadFailure(_i6.Future<void> Function()? _onSecureStorageReadFailure) =>
+      super.noSuchMethod(
+        Invocation.setter(
+          #onSecureStorageReadFailure,
+          _onSecureStorageReadFailure,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i6.Future<_i3.KeyPair> generateAndStoreNostrKey() => (super.noSuchMethod(
         Invocation.method(
           #generateAndStoreNostrKey,

--- a/test/services/processed_nostr_event_store_clear_all_test.dart
+++ b/test/services/processed_nostr_event_store_clear_all_test.dart
@@ -1,0 +1,74 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:horcrux/services/processed_nostr_event_store.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempSupportDir;
+
+  setUp(() {
+    tempSupportDir = Directory.systemTemp.createTempSync('horcrux_processed_store_clear_');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (call) async {
+        if (call.method == 'getApplicationSupportDirectory') {
+          return tempSupportDir.path;
+        }
+        return null;
+      },
+    );
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(const MethodChannel('plugins.flutter.io/path_provider'), null);
+    if (tempSupportDir.existsSync()) {
+      tempSupportDir.deleteSync(recursive: true);
+    }
+  });
+
+  group('ProcessedNostrEventStore.clearAll', () {
+    test('removes processed ids, claims, cursors and on-disk files', () async {
+      final store = ProcessedNostrEventStore();
+
+      await store.recordProcessed('event-1');
+      await store.recordProcessed('event-2');
+      await store.recordLastSeen('wss://relay.example/', 1700000000);
+      expect(await store.claimEvent('claim-1'), isTrue);
+      await store.flushToDisk();
+
+      final logFile = File(p.join(tempSupportDir.path, 'processed_nostr_event_ids.log'));
+      final cursorsFile =
+          File(p.join(tempSupportDir.path, 'nostr_relay_subscription_cursors.json'));
+      expect(logFile.existsSync(), isTrue);
+      expect(cursorsFile.existsSync(), isTrue);
+
+      // Drop a stale cursors .tmp file to make sure clearAll picks it up too.
+      final staleTmp =
+          File(p.join(tempSupportDir.path, 'nostr_relay_subscription_cursors.json.tmp'));
+      await staleTmp.writeAsString('stale');
+      expect(staleTmp.existsSync(), isTrue);
+
+      await store.clearAll();
+
+      expect(logFile.existsSync(), isFalse);
+      expect(cursorsFile.existsSync(), isFalse);
+      expect(staleTmp.existsSync(), isFalse);
+      expect(await store.contains('event-1'), isFalse);
+      expect(await store.contains('event-2'), isFalse);
+      expect(await store.getLastSeen('wss://relay.example/'), isNull);
+      // Released claim slot is reusable again.
+      expect(await store.claimEvent('claim-1'), isTrue);
+    });
+
+    test('is safe to call before any state has been written', () async {
+      final store = ProcessedNostrEventStore();
+      await store.clearAll();
+      expect(await store.contains('anything'), isFalse);
+    });
+  });
+}

--- a/test/services/processed_nostr_event_store_clear_all_test.dart
+++ b/test/services/processed_nostr_event_store_clear_all_test.dart
@@ -65,6 +65,56 @@ void main() {
       expect(await store.claimEvent('claim-1'), isTrue);
     });
 
+    test('deletes the WAL when records have not been flushed yet', () async {
+      final store = ProcessedNostrEventStore();
+
+      // recordProcessed appends to the WAL synchronously but only schedules a
+      // debounced merge into the main log. Without a flushToDisk() the WAL is
+      // the only on-disk artifact -- exactly the case where a missing WAL
+      // cleanup in clearAll() would leak the previous identity's events.
+      await store.recordProcessed('wal-only-1');
+      await store.recordProcessed('wal-only-2');
+
+      final walFile = File(p.join(tempSupportDir.path, 'processed_nostr_event_ids.wal'));
+      final logFile = File(p.join(tempSupportDir.path, 'processed_nostr_event_ids.log'));
+      expect(walFile.existsSync(), isTrue,
+          reason: 'WAL must exist before clearAll for this test to be meaningful');
+      expect(logFile.existsSync(), isFalse,
+          reason: 'log should not exist yet -- nothing has been flushed/merged');
+
+      await store.clearAll();
+
+      expect(walFile.existsSync(), isFalse);
+      expect(await store.contains('wal-only-1'), isFalse);
+      expect(await store.contains('wal-only-2'), isFalse);
+    });
+
+    test('flushToDisk is suppressed after clearAll until the next write', () async {
+      final store = ProcessedNostrEventStore();
+
+      await store.recordProcessed('event-A');
+      await store.recordLastSeen('wss://relay.example/', 1700000000);
+      await store.flushToDisk();
+
+      final cursorsFile =
+          File(p.join(tempSupportDir.path, 'nostr_relay_subscription_cursors.json'));
+      expect(cursorsFile.existsSync(), isTrue);
+
+      await store.clearAll();
+      expect(cursorsFile.existsSync(), isFalse);
+
+      // A dispose-time flush after clearAll must not resurrect the cursors
+      // file from the now-empty in-memory map.
+      await store.flushToDisk();
+      expect(cursorsFile.existsSync(), isFalse);
+
+      // Once a real write happens again the suppression lifts and flushes
+      // resume normally.
+      await store.recordLastSeen('wss://relay.example/', 1700000001);
+      await store.flushToDisk();
+      expect(cursorsFile.existsSync(), isTrue);
+    });
+
     test('is safe to call before any state has been written', () async {
       final store = ProcessedNostrEventStore();
       await store.clearAll();

--- a/test/services/processed_nostr_event_store_clear_all_test.dart
+++ b/test/services/processed_nostr_event_store_clear_all_test.dart
@@ -89,6 +89,33 @@ void main() {
       expect(await store.contains('wal-only-2'), isFalse);
     });
 
+    test('flushToDisk launched concurrently with clearAll is still suppressed', () async {
+      // Regression for the race where flushToDisk reads the suppression flag
+      // before clearAll's body has set it, then queues behind clearAll in the
+      // serialization chain and recreates the cursors file once clearAll
+      // returns. The flag check must live inside _serialized.
+      final store = ProcessedNostrEventStore();
+
+      await store.recordProcessed('event-A');
+      await store.recordLastSeen('wss://relay.example/', 1700000000);
+      await store.flushToDisk();
+
+      final cursorsFile =
+          File(p.join(tempSupportDir.path, 'nostr_relay_subscription_cursors.json'));
+      expect(cursorsFile.existsSync(), isTrue);
+
+      // Kick off clearAll first so it owns the front of the serialization
+      // chain, then launch flushToDisk synchronously (no await between them)
+      // so it sees the flag as still-false at the time of the call but ends
+      // up queued behind clearAll. Awaiting them together drains both.
+      final clearFuture = store.clearAll();
+      final flushFuture = store.flushToDisk();
+      await Future.wait([clearFuture, flushFuture]);
+
+      expect(cursorsFile.existsSync(), isFalse,
+          reason: 'queued flushToDisk must observe clearAll suppression');
+    });
+
     test('flushToDisk is suppressed after clearAll until the next write', () async {
       final store = ProcessedNostrEventStore();
 

--- a/test/services/secure_storage_corruption_test.dart
+++ b/test/services/secure_storage_corruption_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:horcrux/services/secure_storage_corruption.dart';
+
+void main() {
+  group('isPermanentSecureStorageReadFailure', () {
+    test('false for non-PlatformException errors', () {
+      expect(isPermanentSecureStorageReadFailure(Exception('boom')), isFalse);
+      expect(isPermanentSecureStorageReadFailure(StateError('nope')), isFalse);
+      expect(isPermanentSecureStorageReadFailure('plain string'), isFalse);
+    });
+
+    test('true for BadPaddingException-wrapped PlatformException', () {
+      final err = PlatformException(
+        code: 'Exception encountered',
+        message: 'Exception encountered, read, javax.crypto.BadPaddingException: '
+            'error:1e000065:Cipher functions:OPENSSL_internal:BAD_DECRYPT',
+      );
+      expect(isPermanentSecureStorageReadFailure(err), isTrue);
+    });
+
+    test('true for InvalidKeyException-wrapped PlatformException', () {
+      final err = PlatformException(
+        code: 'Exception encountered',
+        message: 'Exception encountered, read, java.security.InvalidKeyException: Failed',
+      );
+      expect(isPermanentSecureStorageReadFailure(err), isTrue);
+    });
+
+    test('true for UnrecoverableKeyException-wrapped PlatformException', () {
+      final err = PlatformException(
+        code: 'Exception encountered',
+        message: 'Exception encountered, read, '
+            'java.security.UnrecoverableKeyException: Failed to obtain information about private key',
+      );
+      expect(isPermanentSecureStorageReadFailure(err), isTrue);
+    });
+
+    test('false for transient KeyStoreException', () {
+      final err = PlatformException(
+        code: 'Exception encountered',
+        message: 'Exception encountered, read, java.security.KeyStoreException: '
+            'AndroidKeyStore not found',
+      );
+      expect(isPermanentSecureStorageReadFailure(err), isFalse);
+    });
+
+    test('false for transient NullPointerException', () {
+      final err = PlatformException(
+        code: 'Exception encountered',
+        message: 'Exception encountered, read, java.lang.NullPointerException',
+      );
+      expect(isPermanentSecureStorageReadFailure(err), isFalse);
+    });
+
+    test('false for transient ServiceSpecificException', () {
+      final err = PlatformException(
+        code: 'Exception encountered',
+        message: 'Exception encountered, read, android.os.ServiceSpecificException: code 7',
+      );
+      expect(isPermanentSecureStorageReadFailure(err), isFalse);
+    });
+
+    test('checks details as well as message', () {
+      final err = PlatformException(
+        code: 'Exception encountered',
+        message: 'something generic',
+        details: 'wrapped: javax.crypto.BadPaddingException',
+      );
+      expect(isPermanentSecureStorageReadFailure(err), isTrue);
+    });
+
+    test('false for PlatformException with no useful payload', () {
+      final err = PlatformException(code: 'Unknown');
+      expect(isPermanentSecureStorageReadFailure(err), isFalse);
+    });
+  });
+}

--- a/test/services/shard_distribution_service_test.mocks.dart
+++ b/test/services/shard_distribution_service_test.mocks.dart
@@ -1033,6 +1033,16 @@ class MockLoginService extends _i1.Mock implements _i14.LoginService {
   }
 
   @override
+  set onSecureStorageReadFailure(_i4.Future<void> Function()? _onSecureStorageReadFailure) =>
+      super.noSuchMethod(
+        Invocation.setter(
+          #onSecureStorageReadFailure,
+          _onSecureStorageReadFailure,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i4.Future<_i3.KeyPair> generateAndStoreNostrKey() => (super.noSuchMethod(
         Invocation.method(
           #generateAndStoreNostrKey,

--- a/test/services/vault_share_service_test.mocks.dart
+++ b/test/services/vault_share_service_test.mocks.dart
@@ -59,6 +59,16 @@ class MockLoginService extends _i1.Mock implements _i4.LoginService {
   }
 
   @override
+  set onSecureStorageReadFailure(_i5.Future<void> Function()? _onSecureStorageReadFailure) =>
+      super.noSuchMethod(
+        Invocation.setter(
+          #onSecureStorageReadFailure,
+          _onSecureStorageReadFailure,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i5.Future<_i2.KeyPair> generateAndStoreNostrKey() => (super.noSuchMethod(
         Invocation.method(
           #generateAndStoreNostrKey,


### PR DESCRIPTION
## Summary

The processed Nostr event log/WAL/cursors under `getApplicationSupport` were never cleared on logout, so a fresh login still saw \"old\" event ids and per-relay cursors from the previous identity. Worse, when secure storage can no longer decrypt the stored Nostr key (e.g. installing the debug build over the release build, or Android Auto Backup restoring `SharedPreferences` and application-support files into a process whose keystore key is gone), we silently fell through to onboarding while the on-disk caches still pointed at an unrecoverable identity.

### Wiring

- `ProcessedNostrEventStore.clearAll()` — under `_serialized`, cancels the debounce timer, empties `_ids` / `_claimedIds` / `_relayMaxSeenEventCreatedAtSec`, deletes `_logFile` / `_walFile` / `_cursorsFile` and any leftover cursors `.tmp`.
- `LogoutService.logout()` now calls it after `stopRelayScanning()` so nothing is racing to write the WAL.
- `wipeLocalDataForCorruptedSecureStorage()` (top-level helper in `logout_service.dart`) just zeros the on-disk caches — `ProcessedNostrEventStore.clearAll` + `prefs.clear` + `FlutterSecureStorage.deleteAll` — for the cold-start corruption path where there is nothing to actually log out from.
- `LoginService` exposes an `onSecureStorageReadFailure` hook invoked from the existing catch around `\"Error reading stored key\"` in `getStoredNostrKey()`. `loginServiceProvider` wires it to the helper, so test call sites that construct `LoginService()` directly are unaffected.

### Android-only hardenings (so the corruption scenario stops being possible in the first place)

- `aOptions: AndroidOptions(resetOnError: true)` on `FlutterSecureStorage` — when the keystore key is gone, the plugin nukes the corrupted ciphertext instead of leaving a half-broken state behind.
- `android:allowBackup=\"false\"`, `android:fullBackupContent=\"false\"`, and a new `data_extraction_rules.xml` that excludes every domain (`root`, `file`, `database`, `sharedpref`, `external`) from both `<cloud-backup>` and `<device-transfer>` so Auto Backup / D2D never restores caches that reference a key the destination device cannot decrypt.

## Test plan

- [x] `dart format .`
- [x] `flutter analyze` — \"No issues found!\"
- [x] `flutter test --exclude-tags=golden` — 327 / 327 passing, including new `test/services/processed_nostr_event_store_clear_all_test.dart` covering in-memory clear, file deletion (incl. stale `.tmp`), reusable claim slots, and clear-before-load.
- [ ] Manual QA on macOS: log in, generate some processed-event activity (cursors written), log out, confirm files under `getApplicationSupport` are gone.
- [ ] Manual QA on Android: install debug build over a release build with stored data, confirm app gracefully wipes and lands on onboarding instead of crashing or silently using stale caches.

Made with [Cursor](https://cursor.com)