### PR TITLE
Notification tap navigation and quieter foreground notifications

### DIFF
--- a/lib/services/local_notification_service.dart
+++ b/lib/services/local_notification_service.dart
@@ -10,6 +10,7 @@ import '../models/recovery_request.dart';
 import '../models/shard_data.dart';
 import '../providers/vault_provider.dart';
 import '../screens/recovery_request_detail_screen.dart';
+import '../screens/recovery_status_screen.dart';
 import '../screens/vault_detail_screen.dart';
 import '../utils/push_notification_text.dart';
 import 'logger.dart';
@@ -336,16 +337,27 @@ class LocalNotificationService {
 
   /// Navigates to the appropriate screen for the given [kind] and [id].
   ///
-  /// [vaultId] is required for shard and recovery-response kinds to open
-  /// [VaultDetailScreen]. Returns `true` if navigation succeeded, `false` if
-  /// the target could not be found or required context (e.g. vaultId) is absent.
+  /// - [NostrKind.recoveryRequest]: opens [RecoveryRequestDetailScreen] for [id]
+  ///   (the recovery request id).
+  /// - [NostrKind.recoveryResponse]: opens [RecoveryStatusScreen] (a.k.a. the
+  ///   "Manage Recovery" screen) for [id] (the recovery request id), so the
+  ///   recovery initiator lands directly on the request whose status just
+  ///   changed. Falls back to [VaultDetailScreen] when the recovery request
+  ///   can't be found locally.
+  /// - [NostrKind.shardData] / [NostrKind.shardConfirmation]: opens
+  ///   [VaultDetailScreen] for [vaultId].
+  ///
+  /// [vaultId] is required for shard kinds and used as a fallback for recovery
+  /// responses. Returns `true` if navigation succeeded, `false` if the target
+  /// could not be found or required context (e.g. vaultId) is absent.
   Future<bool> navigateForKind(NostrKind kind, String id, {String? vaultId}) async {
     switch (kind) {
       case NostrKind.recoveryRequest:
         return _navigateToRecoveryRequest(id);
+      case NostrKind.recoveryResponse:
+        return _navigateToRecoveryStatus(id, fallbackVaultId: vaultId);
       case NostrKind.shardData:
       case NostrKind.shardConfirmation:
-      case NostrKind.recoveryResponse:
         if (vaultId == null || vaultId.isEmpty) {
           Log.debug('No vaultId for $kind notification tap, skipping navigation');
           return false;
@@ -377,6 +389,29 @@ class LocalNotificationService {
     await _pushRouteWhenReady(
       (context) => RecoveryRequestDetailScreen(recoveryRequest: request),
       debugLabel: 'recovery request $recoveryRequestId',
+    );
+    return true;
+  }
+
+  /// Opens [RecoveryStatusScreen] for [recoveryRequestId] when the request is
+  /// known locally; otherwise falls back to [navigateToVault] using
+  /// [fallbackVaultId] if provided.
+  Future<bool> _navigateToRecoveryStatus(
+    String recoveryRequestId, {
+    String? fallbackVaultId,
+  }) async {
+    final request = await _getRecoveryService().getRecoveryRequest(recoveryRequestId);
+    if (request == null) {
+      Log.warning(
+        'Notification: recovery request $recoveryRequestId not found for response navigation',
+      );
+      if (fallbackVaultId == null || fallbackVaultId.isEmpty) return false;
+      await navigateToVault(fallbackVaultId);
+      return true;
+    }
+    await _pushRouteWhenReady(
+      (context) => RecoveryStatusScreen(recoveryRequestId: recoveryRequestId),
+      debugLabel: 'recovery status $recoveryRequestId',
     );
     return true;
   }

--- a/lib/services/local_notification_service.dart
+++ b/lib/services/local_notification_service.dart
@@ -7,7 +7,6 @@ import 'package:ndk/ndk.dart';
 import '../app_navigator.dart';
 import '../models/nostr_kinds.dart';
 import '../models/recovery_request.dart';
-import '../models/shard_data.dart';
 import '../providers/vault_provider.dart';
 import '../screens/recovery_request_detail_screen.dart';
 import '../screens/recovery_status_screen.dart';
@@ -109,26 +108,6 @@ class LocalNotificationService {
       return;
     }
     await _showRecoveryResponseNotification(response);
-  }
-
-  /// Called by [NdkService] after a kind-1337 shard-data event is processed successfully.
-  ///
-  /// Shows a local notification on the steward's device announcing that the
-  /// owner has sent them a (re)distributed shard. [event] is the unwrapped
-  /// rumor (not the outer gift wrap) so [Nip01Event.createdAt] and
-  /// [Nip01Event.pubKey] identify the real sender and creation time.
-  ///
-  /// Recency-gated via [isEventRecent] so relay backfill of historical events
-  /// does not spam notifications on first launch.
-  Future<void> notifyShardDataProcessed({
-    required Nip01Event event,
-    required ShardData shardData,
-  }) async {
-    await _showShardNotification(
-      kind: NostrKind.shardData,
-      event: event,
-      vaultId: shardData.vaultId,
-    );
   }
 
   /// Called by [NdkService] after a kind-1342 shard-confirmation event is processed successfully.

--- a/lib/services/ndk_service.dart
+++ b/lib/services/ndk_service.dart
@@ -732,66 +732,6 @@ class NdkService {
     }
   }
 
-  /// Publish a recovery response
-  Future<String?> publishRecoveryResponse({
-    required String initiatorPubkey,
-    required String recoveryRequestId,
-    required bool approved,
-    String? shardDataJson,
-  }) async {
-    if (!_isInitialized || _ndk == null) {
-      throw Exception('NDK not initialized');
-    }
-
-    try {
-      final keyPair = await _loginService.getStoredNostrKey();
-      if (keyPair == null) {
-        throw Exception('No key pair available');
-      }
-
-      // Create response payload
-      final responsePayload = {
-        'recoveryRequestId': recoveryRequestId,
-        'approved': approved,
-        'shardData': shardDataJson,
-        'respondedAt': DateTime.now().toIso8601String(),
-      };
-
-      final responseJson = json.encode(responsePayload);
-
-      // Encrypt for initiator
-      final encryptedContent = await _loginService.encryptForRecipient(
-        plaintext: responseJson,
-        recipientPubkey: initiatorPubkey,
-      );
-
-      // Create kind 4 DM event
-      final dmEvent = Nip01Event(
-        kind: NostrKind.recoveryResponse.value,
-        pubKey: keyPair.publicKey,
-        content: encryptedContent,
-        tags: [
-          ['p', initiatorPubkey], // Send to initiator
-          ['e', recoveryRequestId], // Reference to original request
-        ],
-        createdAt: secondsSinceEpoch(),
-      );
-
-      // Sign and broadcast the event
-      await _ndk!.accounts.sign(dmEvent);
-      _ndk!.broadcast.broadcast(
-        nostrEvent: dmEvent,
-        specificRelays: _activeRelays.isNotEmpty ? _activeRelays : null,
-      );
-
-      Log.info('Published recovery response: ${dmEvent.id}');
-      return dmEvent.id;
-    } catch (e) {
-      Log.error('Error publishing recovery response', e);
-      return null;
-    }
-  }
-
   /// Close all active subscriptions
   Future<void> closeSubscriptions() async {
     for (final sub in _subscriptionStreamSubs) {

--- a/lib/services/ndk_service.dart
+++ b/lib/services/ndk_service.dart
@@ -380,20 +380,29 @@ class NdkService {
     }
   }
 
-  /// Best-effort recovery_request_id for navigation after a push — unwraps
-  /// once and reads inner JSON. Returns `null` when the inner kind is not a
-  /// recovery request or unwrap fails.
-  Future<String?> resolveRecoveryRequestIdForGiftWrap(
+  /// Best-effort recovery navigation target for a gift-wrapped event — unwraps
+  /// once and reads the inner JSON to surface both the inner [NostrKind] and
+  /// the `recovery_request_id` payload field, so push-tap callers can route to
+  /// the right recovery screen (request detail vs. recovery status).
+  ///
+  /// Supports inner kinds [NostrKind.recoveryRequest] (1338) and
+  /// [NostrKind.recoveryResponse] (1339). Returns `null` when the inner kind
+  /// is something else, the payload is missing the id, or unwrap fails.
+  Future<({NostrKind kind, String recoveryRequestId})?> resolveRecoveryRequestIdForGiftWrap(
     Nip01Event giftWrap,
   ) async {
     await _ensureInitialized();
     if (_ndk == null) return null;
     try {
       final inner = await _ndk!.giftWrap.fromGiftWrap(giftWrap: giftWrap);
-      if (inner.kind != 1338) return null; // [NostrKind.recoveryRequest]
-      final m = json.decode(inner.content) as Map<String, dynamic>;
-      final id = m['recovery_request_id'] as String?;
-      return (id != null && id.isNotEmpty) ? id : null;
+      final kind = NostrKind.fromValue(inner.kind);
+      if (kind != NostrKind.recoveryRequest && kind != NostrKind.recoveryResponse) {
+        return null;
+      }
+      final payload = json.decode(inner.content) as Map<String, dynamic>;
+      final id = payload['recovery_request_id'] as String?;
+      if (id == null || id.isEmpty) return null;
+      return (kind: kind!, recoveryRequestId: id);
     } catch (e, st) {
       Log.debug('resolveRecoveryRequestIdForGiftWrap failed', e, st);
       return null;

--- a/lib/services/ndk_service.dart
+++ b/lib/services/ndk_service.dart
@@ -9,6 +9,7 @@ import '../providers/key_provider.dart';
 import '../utils/date_time_extensions.dart';
 import 'local_notification_service.dart';
 import 'login_service.dart';
+import 'recovery_service.dart';
 import 'vault_share_service.dart';
 import 'invitation_service.dart';
 import 'shard_distribution_service.dart';
@@ -100,18 +101,6 @@ class NdkService {
   final List<String> _activeRelays = [];
 
   late final PublishService _publishService;
-
-  // Event streams for recovery-related events (breaking circular dependency)
-  final StreamController<RecoveryRequest> _recoveryRequestController =
-      StreamController<RecoveryRequest>.broadcast();
-  final StreamController<RecoveryResponseEvent> _recoveryResponseController =
-      StreamController<RecoveryResponseEvent>.broadcast();
-
-  /// Stream of incoming recovery requests
-  Stream<RecoveryRequest> get recoveryRequestStream => _recoveryRequestController.stream;
-
-  /// Stream of incoming recovery responses
-  Stream<RecoveryResponseEvent> get recoveryResponseStream => _recoveryResponseController.stream;
 
   NdkService({
     required Ref ref,
@@ -509,101 +498,106 @@ class NdkService {
   }
 
   /// Handle incoming recovery request data (kind 1338)
+  ///
+  /// Persists the request through [RecoveryService.processRecoveryRequest] so callers
+  /// that immediately read the request (e.g. the FCM cold-start tap path which
+  /// navigates as soon as [processGiftWrapFromForegroundPush] resolves) always observe
+  /// it. Errors propagate to [_handleIncomingNostrEvent] so a failed handler releases
+  /// its claim and is not durably marked processed.
   Future<void> _handleRecoveryRequestData(Nip01Event event) async {
-    try {
-      // Parse the recovery request from the unwrapped content
-      final requestData = json.decode(event.content) as Map<String, dynamic>;
-      final senderPubkey = event.pubKey;
+    final requestData = json.decode(event.content) as Map<String, dynamic>;
+    final senderPubkey = event.pubKey;
 
-      // Create RecoveryRequest object (Nostr content uses snake_case keys).
-      final requestedAtRaw = requestData['requested_at'] as String?;
-      final expiresRaw = requestData['expires_at'] as String?;
-      final thresholdRaw = requestData['threshold'];
-      final threshold = thresholdRaw is int
-          ? thresholdRaw
-          : thresholdRaw is num
-              ? thresholdRaw.toInt()
-              : 1;
+    final requestedAtRaw = requestData['requested_at'] as String?;
+    final expiresRaw = requestData['expires_at'] as String?;
+    final thresholdRaw = requestData['threshold'];
+    final threshold = thresholdRaw is int
+        ? thresholdRaw
+        : thresholdRaw is num
+            ? thresholdRaw.toInt()
+            : 1;
 
-      final recoveryRequest = RecoveryRequest(
-        id: (requestData['recovery_request_id'] as String?) ?? event.id,
-        vaultId: requestData['vault_id'] as String,
-        initiatorPubkey: senderPubkey,
-        requestedAt: DateTime.parse(requestedAtRaw!),
-        status: RecoveryRequestStatus.sent,
-        threshold: threshold,
-        nostrEventId: event.id,
-        eventCreationTime: DateTime.fromMillisecondsSinceEpoch(
-          event.createdAt * 1000,
-          isUtc: true,
-        ),
-        expiresAt: expiresRaw != null ? DateTime.parse(expiresRaw) : null,
-        stewardResponses: {}, // Will be populated later
-        isPractice: requestData['is_practice'] as bool? ?? false,
-      );
+    final recoveryRequest = RecoveryRequest(
+      id: (requestData['recovery_request_id'] as String?) ?? event.id,
+      vaultId: requestData['vault_id'] as String,
+      initiatorPubkey: senderPubkey,
+      requestedAt: DateTime.parse(requestedAtRaw!),
+      status: RecoveryRequestStatus.sent,
+      threshold: threshold,
+      nostrEventId: event.id,
+      eventCreationTime: DateTime.fromMillisecondsSinceEpoch(
+        event.createdAt * 1000,
+        isUtc: true,
+      ),
+      expiresAt: expiresRaw != null ? DateTime.parse(expiresRaw) : null,
+      stewardResponses: {},
+      isPractice: requestData['is_practice'] as bool? ?? false,
+    );
 
-      // Emit recovery request to stream (RecoveryService will listen)
-      _recoveryRequestController.add(recoveryRequest);
+    await _ref.read(recoveryServiceProvider).processRecoveryRequest(recoveryRequest);
 
-      Log.info('Emitted incoming recovery request to stream: ${event.id}');
-    } catch (e) {
-      Log.error('Error handling recovery request data', e);
-    }
+    Log.info('Persisted incoming recovery request: ${event.id}');
   }
 
   /// Handle incoming recovery response data (kind 1339)
+  ///
+  /// Persists the response through [RecoveryService.processRecoveryResponse] so the
+  /// FCM cold-start tap path (which navigates as soon as
+  /// [processGiftWrapFromForegroundPush] resolves) sees the updated request. Errors
+  /// propagate to [_handleIncomingNostrEvent] so a failed handler releases its claim
+  /// and is not durably marked processed.
   Future<void> _handleRecoveryResponseData(Nip01Event event) async {
-    try {
-      // Parse the recovery response from the unwrapped content
-      final responseData = json.decode(event.content) as Map<String, dynamic>;
-      final senderPubkey = event.pubKey;
+    final responseData = json.decode(event.content) as Map<String, dynamic>;
+    final senderPubkey = event.pubKey;
 
-      final recoveryRequestId = responseData['recovery_request_id'] as String;
-      final vaultId = responseData['vault_id'] as String;
-      final approved = responseData['approved'] as bool;
+    final recoveryRequestId = responseData['recovery_request_id'] as String;
+    final vaultId = responseData['vault_id'] as String;
+    final approved = responseData['approved'] as bool;
 
-      Log.info(
-        'Received recovery response from $senderPubkey for vault $vaultId: approved=$approved',
-      );
+    Log.info(
+      'Received recovery response from $senderPubkey for vault $vaultId: approved=$approved',
+    );
 
-      ShardData? shardData;
+    ShardData? shardData;
 
-      // If approved, extract and store the shard data FOR RECOVERY
-      final shardPayload = responseData['shard_data'];
-      if (approved && shardPayload != null) {
-        final shardDataJson = shardPayload as Map<String, dynamic>;
-        shardData = shardDataFromJson(shardDataJson);
+    final shardPayload = responseData['shard_data'];
+    if (approved && shardPayload != null) {
+      final shardDataJson = shardPayload as Map<String, dynamic>;
+      shardData = shardDataFromJson(shardDataJson);
 
-        // Store as a recovery shard (not a steward shard)
-        final vaultShareService = _ref.read(vaultShareServiceProvider);
-        await vaultShareService.addRecoveryShard(recoveryRequestId, shardData);
-
-        Log.info(
-          'Stored recovery shard from $senderPubkey for recovery request $recoveryRequestId',
-        );
-      }
-
-      // Emit recovery response to stream (RecoveryService will listen)
-      final responseEvent = RecoveryResponseEvent(
-        recoveryRequestId: recoveryRequestId,
-        vaultId: vaultId,
-        senderPubkey: senderPubkey,
-        approved: approved,
-        shardData: shardData,
-        nostrEventId: event.id,
-        createdAt: DateTime.fromMillisecondsSinceEpoch(
-          event.createdAt * 1000,
-          isUtc: true,
-        ),
-      );
-      _recoveryResponseController.add(responseEvent);
+      final vaultShareService = _ref.read(vaultShareServiceProvider);
+      await vaultShareService.addRecoveryShard(recoveryRequestId, shardData);
 
       Log.info(
-        'Emitted recovery response to stream: $recoveryRequestId from $senderPubkey',
+        'Stored recovery shard from $senderPubkey for recovery request $recoveryRequestId',
       );
-    } catch (e) {
-      Log.error('Error handling recovery response data', e);
     }
+
+    final responseEvent = RecoveryResponseEvent(
+      recoveryRequestId: recoveryRequestId,
+      vaultId: vaultId,
+      senderPubkey: senderPubkey,
+      approved: approved,
+      shardData: shardData,
+      nostrEventId: event.id,
+      createdAt: DateTime.fromMillisecondsSinceEpoch(
+        event.createdAt * 1000,
+        isUtc: true,
+      ),
+    );
+
+    await _ref.read(recoveryServiceProvider).processRecoveryResponse(
+          recoveryRequestId,
+          senderPubkey,
+          approved,
+          shardData: shardData,
+          nostrEventId: event.id,
+          recoveryResponseSourceEvent: responseEvent,
+        );
+
+    Log.info(
+      'Persisted recovery response: $recoveryRequestId from $senderPubkey',
+    );
   }
 
   /// Handle incoming invitation acceptance event (kind 1340)
@@ -993,10 +987,6 @@ class NdkService {
   Future<void> dispose() async {
     // Stop listening to all subscriptions first
     await closeSubscriptions();
-
-    // Close event streams
-    await _recoveryRequestController.close();
-    await _recoveryResponseController.close();
 
     // Dispose publish service
     await _publishService.dispose();

--- a/lib/services/ndk_service.dart
+++ b/lib/services/ndk_service.dart
@@ -488,10 +488,10 @@ class NdkService {
       final vaultShareService = _ref.read(vaultShareServiceProvider);
       await vaultShareService.processVaultShare(vaultId, shardData);
 
-      await _ref.read(localNotificationServiceProvider).notifyShardDataProcessed(
-            event: event,
-            shardData: shardData,
-          );
+      // No local notification here: "Vault updated" is purely informational
+      // and the user is already in the app on this code path (relay-delivered
+      // or foreground FCM). The OS-shown push from horcrux-notifier covers
+      // the backgrounded case.
     } catch (e) {
       Log.error('Error handling shard data event ${event.id}', e);
     }

--- a/lib/services/push_notification_receiver.dart
+++ b/lib/services/push_notification_receiver.dart
@@ -10,7 +10,6 @@ import 'package:ndk/ndk.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../firebase_options.dart';
-import '../models/nostr_kinds.dart';
 import 'horcrux_notification_service.dart';
 import 'local_notification_service.dart';
 import 'logger.dart';
@@ -410,20 +409,24 @@ class PushNotificationReceiver {
     }
 
     final vaultId = await _ndkService.resolveVaultIdForGiftWrap(giftWrap);
-    final recoveryRequestId = await _ndkService.resolveRecoveryRequestIdForGiftWrap(giftWrap);
+    final recoveryTarget = await _ndkService.resolveRecoveryRequestIdForGiftWrap(giftWrap);
     try {
       await _ndkService.processGiftWrapFromForegroundPush(giftWrap);
     } catch (e, st) {
       Log.warning('FCM tap: gift wrap processing failed', e, st);
     }
 
-    if (recoveryRequestId != null) {
+    if (recoveryTarget != null) {
       final navigated = await _localNotifications.navigateForKind(
-        NostrKind.recoveryRequest,
-        recoveryRequestId,
+        recoveryTarget.kind,
+        recoveryTarget.recoveryRequestId,
+        vaultId: vaultId,
       );
       if (navigated) return;
-      Log.warning('FCM tap: recovery request $recoveryRequestId not found, falling back to vault');
+      Log.warning(
+        'FCM tap: ${recoveryTarget.kind.name} ${recoveryTarget.recoveryRequestId} '
+        'navigation failed, falling back to vault',
+      );
     }
     if (vaultId != null) {
       await _localNotifications.navigateToVault(vaultId);

--- a/lib/services/push_notification_receiver.dart
+++ b/lib/services/push_notification_receiver.dart
@@ -298,7 +298,7 @@ class PushNotificationReceiver {
     );
   }
 
-  Future<void> _registerWithNotifierIfNeeded({bool force = false}) async {
+  Future<void> _registerWithNotifierIfNeeded({bool force = true}) async {
     final token = _cachedToken;
     if (token == null || token.isEmpty) return;
 

--- a/lib/services/recovery_service.dart
+++ b/lib/services/recovery_service.dart
@@ -82,69 +82,6 @@ class RecoveryService {
     this._notificationService,
   ) {
     _loadViewedNotificationIds();
-    _setupNdkStreamListeners();
-  }
-
-  /// Set up listeners for incoming NDK events
-  void _setupNdkStreamListeners() {
-    _ndkService.recoveryRequestStream.listen(
-      _onIncomingRecoveryRequestFromNdk,
-      onError: (error) {
-        Log.error('Error in recovery request stream', error);
-      },
-    );
-
-    _ndkService.recoveryResponseStream.listen(
-      _onIncomingRecoveryResponseFromNdk,
-      onError: (error) {
-        Log.error('Error in recovery response stream', error);
-      },
-    );
-
-    Log.info('RecoveryService listening to NdkService event streams');
-  }
-
-  Future<void> _onIncomingRecoveryRequestFromNdk(RecoveryRequest recoveryRequest) async {
-    final id = recoveryRequest.nostrEventId;
-    if (id != null && await _processedStore.contains(id)) {
-      Log.debug('Skipping already-processed recovery request event $id');
-      return;
-    }
-    try {
-      await processRecoveryRequest(recoveryRequest);
-      if (id != null) {
-        await _processedStore.recordProcessed(id);
-      }
-    } catch (e, st) {
-      Log.error(
-        'Error processing incoming recovery request from stream',
-        e,
-        st,
-      );
-    }
-  }
-
-  Future<void> _onIncomingRecoveryResponseFromNdk(RecoveryResponseEvent responseEvent) async {
-    final id = responseEvent.nostrEventId;
-    if (id != null && await _processedStore.contains(id)) {
-      Log.debug('Skipping already-processed recovery response event $id');
-      return;
-    }
-    try {
-      await processRecoveryResponse(
-        responseEvent.recoveryRequestId,
-        responseEvent.senderPubkey,
-        responseEvent.approved,
-        shardData: responseEvent.shardData,
-        nostrEventId: responseEvent.nostrEventId,
-        recoveryResponseSourceEvent: responseEvent,
-      );
-      if (id != null) {
-        await _processedStore.recordProcessed(id);
-      }
-    } catch (e, st) {
-      Log.error('Error processing recovery response from stream', e, st);
-    }
   }
 
   /// Dispose resources

--- a/test/services/invitation_acceptance_format_test.mocks.dart
+++ b/test/services/invitation_acceptance_format_test.mocks.dart
@@ -5,22 +5,22 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i6;
 
-import 'package:horcrux/models/backup_status.dart' as _i13;
-import 'package:horcrux/models/nostr_kinds.dart' as _i8;
-import 'package:horcrux/models/recovery_request.dart' as _i7;
+import 'package:horcrux/models/backup_status.dart' as _i12;
+import 'package:horcrux/models/nostr_kinds.dart' as _i7;
+import 'package:horcrux/models/recovery_request.dart' as _i16;
 import 'package:horcrux/models/relay_configuration.dart' as _i18;
-import 'package:horcrux/models/shard_data.dart' as _i16;
-import 'package:horcrux/models/steward.dart' as _i14;
-import 'package:horcrux/models/steward_status.dart' as _i15;
-import 'package:horcrux/models/vault.dart' as _i12;
-import 'package:horcrux/providers/vault_provider.dart' as _i11;
+import 'package:horcrux/models/shard_data.dart' as _i15;
+import 'package:horcrux/models/steward.dart' as _i13;
+import 'package:horcrux/models/steward_status.dart' as _i14;
+import 'package:horcrux/models/vault.dart' as _i11;
+import 'package:horcrux/providers/vault_provider.dart' as _i10;
 import 'package:horcrux/services/backup_service.dart' as _i19;
 import 'package:horcrux/services/invitation_sending_service.dart' as _i17;
-import 'package:horcrux/services/login_service.dart' as _i9;
+import 'package:horcrux/services/login_service.dart' as _i8;
 import 'package:horcrux/services/ndk_service.dart' as _i4;
 import 'package:horcrux/services/relay_scan_service.dart' as _i5;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i10;
+import 'package:mockito/src/dummies.dart' as _i9;
 import 'package:ndk/ndk.dart' as _i2;
 import 'package:ndk/shared/nips/nip01/key_pair.dart' as _i3;
 
@@ -96,18 +96,6 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
   }
 
   @override
-  _i6.Stream<_i7.RecoveryRequest> get recoveryRequestStream => (super.noSuchMethod(
-        Invocation.getter(#recoveryRequestStream),
-        returnValue: _i6.Stream<_i7.RecoveryRequest>.empty(),
-      ) as _i6.Stream<_i7.RecoveryRequest>);
-
-  @override
-  _i6.Stream<_i4.RecoveryResponseEvent> get recoveryResponseStream => (super.noSuchMethod(
-        Invocation.getter(#recoveryResponseStream),
-        returnValue: _i6.Stream<_i4.RecoveryResponseEvent>.empty(),
-      ) as _i6.Stream<_i4.RecoveryResponseEvent>);
-
-  @override
   bool get isInitialized => (super.noSuchMethod(
         Invocation.getter(#isInitialized),
         returnValue: false,
@@ -180,15 +168,15 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
       ) as _i6.Future<String?>);
 
   @override
-  _i6.Future<({_i8.NostrKind kind, String recoveryRequestId})?> resolveRecoveryRequestIdForGiftWrap(
+  _i6.Future<({_i7.NostrKind kind, String recoveryRequestId})?> resolveRecoveryRequestIdForGiftWrap(
           _i2.Nip01Event? giftWrap) =>
       (super.noSuchMethod(
         Invocation.method(
           #resolveRecoveryRequestIdForGiftWrap,
           [giftWrap],
         ),
-        returnValue: _i6.Future<({_i8.NostrKind kind, String recoveryRequestId})?>.value(),
-      ) as _i6.Future<({_i8.NostrKind kind, String recoveryRequestId})?>);
+        returnValue: _i6.Future<({_i7.NostrKind kind, String recoveryRequestId})?>.value(),
+      ) as _i6.Future<({_i7.NostrKind kind, String recoveryRequestId})?>);
 
   @override
   _i6.Future<String?> publishRecoveryRequest({
@@ -346,7 +334,7 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
 /// A class which mocks [LoginService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockLoginService extends _i1.Mock implements _i9.LoginService {
+class MockLoginService extends _i1.Mock implements _i8.LoginService {
   MockLoginService() {
     _i1.throwOnMissingStub(this);
   }
@@ -444,7 +432,7 @@ class MockLoginService extends _i1.Mock implements _i9.LoginService {
           #encryptText,
           [plaintext],
         ),
-        returnValue: _i6.Future<String>.value(_i10.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i9.dummyValue<String>(
           this,
           Invocation.method(
             #encryptText,
@@ -459,7 +447,7 @@ class MockLoginService extends _i1.Mock implements _i9.LoginService {
           #decryptText,
           [encryptedText],
         ),
-        returnValue: _i6.Future<String>.value(_i10.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i9.dummyValue<String>(
           this,
           Invocation.method(
             #decryptText,
@@ -507,7 +495,7 @@ class MockLoginService extends _i1.Mock implements _i9.LoginService {
             #recipientPubkey: recipientPubkey,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i10.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i9.dummyValue<String>(
           this,
           Invocation.method(
             #encryptForRecipient,
@@ -534,7 +522,7 @@ class MockLoginService extends _i1.Mock implements _i9.LoginService {
             #senderPubkey: senderPubkey,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i10.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i9.dummyValue<String>(
           this,
           Invocation.method(
             #decryptFromSender,
@@ -551,16 +539,16 @@ class MockLoginService extends _i1.Mock implements _i9.LoginService {
 /// A class which mocks [VaultRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockVaultRepository extends _i1.Mock implements _i11.VaultRepository {
+class MockVaultRepository extends _i1.Mock implements _i10.VaultRepository {
   MockVaultRepository() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i6.Stream<List<_i12.Vault>> get vaultsStream => (super.noSuchMethod(
+  _i6.Stream<List<_i11.Vault>> get vaultsStream => (super.noSuchMethod(
         Invocation.getter(#vaultsStream),
-        returnValue: _i6.Stream<List<_i12.Vault>>.empty(),
-      ) as _i6.Stream<List<_i12.Vault>>);
+        returnValue: _i6.Stream<List<_i11.Vault>>.empty(),
+      ) as _i6.Stream<List<_i11.Vault>>);
 
   @override
   _i6.Future<void> initialize() => (super.noSuchMethod(
@@ -573,25 +561,25 @@ class MockVaultRepository extends _i1.Mock implements _i11.VaultRepository {
       ) as _i6.Future<void>);
 
   @override
-  _i6.Future<List<_i12.Vault>> getAllVaults() => (super.noSuchMethod(
+  _i6.Future<List<_i11.Vault>> getAllVaults() => (super.noSuchMethod(
         Invocation.method(
           #getAllVaults,
           [],
         ),
-        returnValue: _i6.Future<List<_i12.Vault>>.value(<_i12.Vault>[]),
-      ) as _i6.Future<List<_i12.Vault>>);
+        returnValue: _i6.Future<List<_i11.Vault>>.value(<_i11.Vault>[]),
+      ) as _i6.Future<List<_i11.Vault>>);
 
   @override
-  _i6.Future<_i12.Vault?> getVault(String? id) => (super.noSuchMethod(
+  _i6.Future<_i11.Vault?> getVault(String? id) => (super.noSuchMethod(
         Invocation.method(
           #getVault,
           [id],
         ),
-        returnValue: _i6.Future<_i12.Vault?>.value(),
-      ) as _i6.Future<_i12.Vault?>);
+        returnValue: _i6.Future<_i11.Vault?>.value(),
+      ) as _i6.Future<_i11.Vault?>);
 
   @override
-  _i6.Future<void> saveVault(_i12.Vault? vault) => (super.noSuchMethod(
+  _i6.Future<void> saveVault(_i11.Vault? vault) => (super.noSuchMethod(
         Invocation.method(
           #saveVault,
           [vault],
@@ -601,7 +589,7 @@ class MockVaultRepository extends _i1.Mock implements _i11.VaultRepository {
       ) as _i6.Future<void>);
 
   @override
-  _i6.Future<void> addVault(_i12.Vault? vault) => (super.noSuchMethod(
+  _i6.Future<void> addVault(_i11.Vault? vault) => (super.noSuchMethod(
         Invocation.method(
           #addVault,
           [vault],
@@ -689,8 +677,8 @@ class MockVaultRepository extends _i1.Mock implements _i11.VaultRepository {
       DateTime lastUpdated,
       List<String> relays,
       String specVersion,
-      _i13.BackupStatus status,
-      List<_i14.Steward> stewards,
+      _i12.BackupStatus status,
+      List<_i13.Steward> stewards,
       int threshold,
       int totalKeys,
       String vaultId
@@ -720,8 +708,8 @@ class MockVaultRepository extends _i1.Mock implements _i11.VaultRepository {
         DateTime lastUpdated,
         List<String> relays,
         String specVersion,
-        _i13.BackupStatus status,
-        List<_i14.Steward> stewards,
+        _i12.BackupStatus status,
+        List<_i13.Steward> stewards,
         int threshold,
         int totalKeys,
         String vaultId
@@ -741,8 +729,8 @@ class MockVaultRepository extends _i1.Mock implements _i11.VaultRepository {
               DateTime lastUpdated,
               List<String> relays,
               String specVersion,
-              _i13.BackupStatus status,
-              List<_i14.Steward> stewards,
+              _i12.BackupStatus status,
+              List<_i13.Steward> stewards,
               int threshold,
               int totalKeys,
               String vaultId
@@ -758,8 +746,8 @@ class MockVaultRepository extends _i1.Mock implements _i11.VaultRepository {
             DateTime lastUpdated,
             List<String> relays,
             String specVersion,
-            _i13.BackupStatus status,
-            List<_i14.Steward> stewards,
+            _i12.BackupStatus status,
+            List<_i13.Steward> stewards,
             int threshold,
             int totalKeys,
             String vaultId
@@ -769,7 +757,7 @@ class MockVaultRepository extends _i1.Mock implements _i11.VaultRepository {
   _i6.Future<void> updateStewardStatus({
     required String? vaultId,
     required String? pubkey,
-    required _i15.StewardStatus? status,
+    required _i14.StewardStatus? status,
     DateTime? acknowledgedAt,
     String? acknowledgmentEventId,
     int? acknowledgedDistributionVersion,
@@ -794,7 +782,7 @@ class MockVaultRepository extends _i1.Mock implements _i11.VaultRepository {
   @override
   _i6.Future<void> addShardToVault(
     String? vaultId,
-    _i16.ShardData? shard,
+    _i15.ShardData? shard,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -809,13 +797,13 @@ class MockVaultRepository extends _i1.Mock implements _i11.VaultRepository {
       ) as _i6.Future<void>);
 
   @override
-  _i6.Future<List<_i16.ShardData>> getShardsForVault(String? vaultId) => (super.noSuchMethod(
+  _i6.Future<List<_i15.ShardData>> getShardsForVault(String? vaultId) => (super.noSuchMethod(
         Invocation.method(
           #getShardsForVault,
           [vaultId],
         ),
-        returnValue: _i6.Future<List<_i16.ShardData>>.value(<_i16.ShardData>[]),
-      ) as _i6.Future<List<_i16.ShardData>>);
+        returnValue: _i6.Future<List<_i15.ShardData>>.value(<_i15.ShardData>[]),
+      ) as _i6.Future<List<_i15.ShardData>>);
 
   @override
   _i6.Future<void> clearShardsForVault(String? vaultId) => (super.noSuchMethod(
@@ -849,7 +837,7 @@ class MockVaultRepository extends _i1.Mock implements _i11.VaultRepository {
   @override
   _i6.Future<void> addRecoveryRequestToVault(
     String? vaultId,
-    _i7.RecoveryRequest? request,
+    _i16.RecoveryRequest? request,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -867,7 +855,7 @@ class MockVaultRepository extends _i1.Mock implements _i11.VaultRepository {
   _i6.Future<void> updateRecoveryRequestInVault(
     String? vaultId,
     String? requestId,
-    _i7.RecoveryRequest? updatedRequest,
+    _i16.RecoveryRequest? updatedRequest,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -883,32 +871,33 @@ class MockVaultRepository extends _i1.Mock implements _i11.VaultRepository {
       ) as _i6.Future<void>);
 
   @override
-  _i6.Future<List<_i7.RecoveryRequest>> getRecoveryRequestsForVault(String? vaultId) =>
+  _i6.Future<List<_i16.RecoveryRequest>> getRecoveryRequestsForVault(String? vaultId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRecoveryRequestsForVault,
           [vaultId],
         ),
-        returnValue: _i6.Future<List<_i7.RecoveryRequest>>.value(<_i7.RecoveryRequest>[]),
-      ) as _i6.Future<List<_i7.RecoveryRequest>>);
+        returnValue: _i6.Future<List<_i16.RecoveryRequest>>.value(<_i16.RecoveryRequest>[]),
+      ) as _i6.Future<List<_i16.RecoveryRequest>>);
 
   @override
-  _i6.Future<_i7.RecoveryRequest?> getActiveRecoveryRequest(String? vaultId) => (super.noSuchMethod(
+  _i6.Future<_i16.RecoveryRequest?> getActiveRecoveryRequest(String? vaultId) =>
+      (super.noSuchMethod(
         Invocation.method(
           #getActiveRecoveryRequest,
           [vaultId],
         ),
-        returnValue: _i6.Future<_i7.RecoveryRequest?>.value(),
-      ) as _i6.Future<_i7.RecoveryRequest?>);
+        returnValue: _i6.Future<_i16.RecoveryRequest?>.value(),
+      ) as _i6.Future<_i16.RecoveryRequest?>);
 
   @override
-  _i6.Future<List<_i7.RecoveryRequest>> getAllRecoveryRequests() => (super.noSuchMethod(
+  _i6.Future<List<_i16.RecoveryRequest>> getAllRecoveryRequests() => (super.noSuchMethod(
         Invocation.method(
           #getAllRecoveryRequests,
           [],
         ),
-        returnValue: _i6.Future<List<_i7.RecoveryRequest>>.value(<_i7.RecoveryRequest>[]),
-      ) as _i6.Future<List<_i7.RecoveryRequest>>);
+        returnValue: _i6.Future<List<_i16.RecoveryRequest>>.value(<_i16.RecoveryRequest>[]),
+      ) as _i6.Future<List<_i16.RecoveryRequest>>);
 
   @override
   void dispose() => super.noSuchMethod(
@@ -1258,8 +1247,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
         DateTime lastUpdated,
         List<String> relays,
         String specVersion,
-        _i13.BackupStatus status,
-        List<_i14.Steward> stewards,
+        _i12.BackupStatus status,
+        List<_i13.Steward> stewards,
         int threshold,
         int totalKeys,
         String vaultId
@@ -1267,7 +1256,7 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
     required String? vaultId,
     required int? threshold,
     required int? totalKeys,
-    required List<_i14.Steward>? stewards,
+    required List<_i13.Steward>? stewards,
     required List<String>? relays,
     String? instructions,
     String? contentHash,
@@ -1297,8 +1286,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
               DateTime lastUpdated,
               List<String> relays,
               String specVersion,
-              _i13.BackupStatus status,
-              List<_i14.Steward> stewards,
+              _i12.BackupStatus status,
+              List<_i13.Steward> stewards,
               int threshold,
               int totalKeys,
               String vaultId
@@ -1341,7 +1330,7 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
             ),
           ),
           relays: <String>[],
-          specVersion: _i10.dummyValue<String>(
+          specVersion: _i9.dummyValue<String>(
             this,
             Invocation.method(
               #createBackupConfiguration,
@@ -1357,11 +1346,11 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
               },
             ),
           ),
-          status: _i13.BackupStatus.pending,
-          stewards: <_i14.Steward>[],
+          status: _i12.BackupStatus.pending,
+          stewards: <_i13.Steward>[],
           threshold: 0,
           totalKeys: 0,
-          vaultId: _i10.dummyValue<String>(
+          vaultId: _i9.dummyValue<String>(
             this,
             Invocation.method(
               #createBackupConfiguration,
@@ -1389,8 +1378,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
             DateTime lastUpdated,
             List<String> relays,
             String specVersion,
-            _i13.BackupStatus status,
-            List<_i14.Steward> stewards,
+            _i12.BackupStatus status,
+            List<_i13.Steward> stewards,
             int threshold,
             int totalKeys,
             String vaultId
@@ -1408,8 +1397,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
         DateTime lastUpdated,
         List<String> relays,
         String specVersion,
-        _i13.BackupStatus status,
-        List<_i14.Steward> stewards,
+        _i12.BackupStatus status,
+        List<_i13.Steward> stewards,
         int threshold,
         int totalKeys,
         String vaultId
@@ -1429,8 +1418,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
               DateTime lastUpdated,
               List<String> relays,
               String specVersion,
-              _i13.BackupStatus status,
-              List<_i14.Steward> stewards,
+              _i12.BackupStatus status,
+              List<_i13.Steward> stewards,
               int threshold,
               int totalKeys,
               String vaultId
@@ -1446,8 +1435,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
             DateTime lastUpdated,
             List<String> relays,
             String specVersion,
-            _i13.BackupStatus status,
-            List<_i14.Steward> stewards,
+            _i12.BackupStatus status,
+            List<_i13.Steward> stewards,
             int threshold,
             int totalKeys,
             String vaultId
@@ -1466,8 +1455,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
             DateTime lastUpdated,
             List<String> relays,
             String specVersion,
-            _i13.BackupStatus status,
-            List<_i14.Steward> stewards,
+            _i12.BackupStatus status,
+            List<_i13.Steward> stewards,
             int threshold,
             int totalKeys,
             String vaultId
@@ -1488,8 +1477,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
                   DateTime lastUpdated,
                   List<String> relays,
                   String specVersion,
-                  _i13.BackupStatus status,
-                  List<_i14.Steward> stewards,
+                  _i12.BackupStatus status,
+                  List<_i13.Steward> stewards,
                   int threshold,
                   int totalKeys,
                   String vaultId
@@ -1503,8 +1492,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
           DateTime lastUpdated,
           List<String> relays,
           String specVersion,
-          _i13.BackupStatus status,
-          List<_i14.Steward> stewards,
+          _i12.BackupStatus status,
+          List<_i13.Steward> stewards,
           int threshold,
           int totalKeys,
           String vaultId
@@ -1521,8 +1510,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
                 DateTime lastUpdated,
                 List<String> relays,
                 String specVersion,
-                _i13.BackupStatus status,
-                List<_i14.Steward> stewards,
+                _i12.BackupStatus status,
+                List<_i13.Steward> stewards,
                 int threshold,
                 int totalKeys,
                 String vaultId
@@ -1540,8 +1529,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
             DateTime lastUpdated,
             List<String> relays,
             String specVersion,
-            _i13.BackupStatus status,
-            List<_i14.Steward> stewards,
+            _i12.BackupStatus status,
+            List<_i13.Steward> stewards,
             int threshold,
             int totalKeys,
             String vaultId
@@ -1566,7 +1555,7 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
       ) as _i6.Future<void>);
 
   @override
-  _i6.Future<List<_i16.ShardData>> generateShamirShares({
+  _i6.Future<List<_i15.ShardData>> generateShamirShares({
     required String? content,
     required int? threshold,
     required int? totalShards,
@@ -1595,18 +1584,18 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
             #pushEnabled: pushEnabled,
           },
         ),
-        returnValue: _i6.Future<List<_i16.ShardData>>.value(<_i16.ShardData>[]),
-      ) as _i6.Future<List<_i16.ShardData>>);
+        returnValue: _i6.Future<List<_i15.ShardData>>.value(<_i15.ShardData>[]),
+      ) as _i6.Future<List<_i15.ShardData>>);
 
   @override
-  _i6.Future<String> reconstructFromShares({required List<_i16.ShardData>? shares}) =>
+  _i6.Future<String> reconstructFromShares({required List<_i15.ShardData>? shares}) =>
       (super.noSuchMethod(
         Invocation.method(
           #reconstructFromShares,
           [],
           {#shares: shares},
         ),
-        returnValue: _i6.Future<String>.value(_i10.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i9.dummyValue<String>(
           this,
           Invocation.method(
             #reconstructFromShares,
@@ -1619,7 +1608,7 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
   @override
   _i6.Future<void> updateBackupStatus(
     String? vaultId,
-    _i13.BackupStatus? status,
+    _i12.BackupStatus? status,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1637,7 +1626,7 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
   _i6.Future<void> updateStewardStatus({
     required String? vaultId,
     required String? pubkey,
-    required _i15.StewardStatus? status,
+    required _i14.StewardStatus? status,
     DateTime? acknowledgedAt,
     String? acknowledgmentEventId,
   }) =>
@@ -1678,15 +1667,15 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
         DateTime lastUpdated,
         List<String> relays,
         String specVersion,
-        _i13.BackupStatus status,
-        List<_i14.Steward> stewards,
+        _i12.BackupStatus status,
+        List<_i13.Steward> stewards,
         int threshold,
         int totalKeys,
         String vaultId
       })> mergeBackupConfig({
     required String? vaultId,
     int? threshold,
-    List<_i14.Steward>? stewards,
+    List<_i13.Steward>? stewards,
     List<String>? relays,
     String? instructions,
   }) =>
@@ -1713,8 +1702,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
               DateTime lastUpdated,
               List<String> relays,
               String specVersion,
-              _i13.BackupStatus status,
-              List<_i14.Steward> stewards,
+              _i12.BackupStatus status,
+              List<_i13.Steward> stewards,
               int threshold,
               int totalKeys,
               String vaultId
@@ -1753,7 +1742,7 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
             ),
           ),
           relays: <String>[],
-          specVersion: _i10.dummyValue<String>(
+          specVersion: _i9.dummyValue<String>(
             this,
             Invocation.method(
               #mergeBackupConfig,
@@ -1767,11 +1756,11 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
               },
             ),
           ),
-          status: _i13.BackupStatus.pending,
-          stewards: <_i14.Steward>[],
+          status: _i12.BackupStatus.pending,
+          stewards: <_i13.Steward>[],
           threshold: 0,
           totalKeys: 0,
-          vaultId: _i10.dummyValue<String>(
+          vaultId: _i9.dummyValue<String>(
             this,
             Invocation.method(
               #mergeBackupConfig,
@@ -1797,8 +1786,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
             DateTime lastUpdated,
             List<String> relays,
             String specVersion,
-            _i13.BackupStatus status,
-            List<_i14.Steward> stewards,
+            _i12.BackupStatus status,
+            List<_i13.Steward> stewards,
             int threshold,
             int totalKeys,
             String vaultId
@@ -1848,8 +1837,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
         DateTime lastUpdated,
         List<String> relays,
         String specVersion,
-        _i13.BackupStatus status,
-        List<_i14.Steward> stewards,
+        _i12.BackupStatus status,
+        List<_i13.Steward> stewards,
         int threshold,
         int totalKeys,
         String vaultId
@@ -1857,7 +1846,7 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
     required String? vaultId,
     required int? threshold,
     required int? totalKeys,
-    required List<_i14.Steward>? stewards,
+    required List<_i13.Steward>? stewards,
     required List<String>? relays,
     String? instructions,
   }) =>
@@ -1885,8 +1874,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
               DateTime lastUpdated,
               List<String> relays,
               String specVersion,
-              _i13.BackupStatus status,
-              List<_i14.Steward> stewards,
+              _i12.BackupStatus status,
+              List<_i13.Steward> stewards,
               int threshold,
               int totalKeys,
               String vaultId
@@ -1927,7 +1916,7 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
             ),
           ),
           relays: <String>[],
-          specVersion: _i10.dummyValue<String>(
+          specVersion: _i9.dummyValue<String>(
             this,
             Invocation.method(
               #saveBackupConfig,
@@ -1942,11 +1931,11 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
               },
             ),
           ),
-          status: _i13.BackupStatus.pending,
-          stewards: <_i14.Steward>[],
+          status: _i12.BackupStatus.pending,
+          stewards: <_i13.Steward>[],
           threshold: 0,
           totalKeys: 0,
-          vaultId: _i10.dummyValue<String>(
+          vaultId: _i9.dummyValue<String>(
             this,
             Invocation.method(
               #saveBackupConfig,
@@ -1973,8 +1962,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
             DateTime lastUpdated,
             List<String> relays,
             String specVersion,
-            _i13.BackupStatus status,
-            List<_i14.Steward> stewards,
+            _i12.BackupStatus status,
+            List<_i13.Steward> stewards,
             int threshold,
             int totalKeys,
             String vaultId
@@ -1992,8 +1981,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
         DateTime lastUpdated,
         List<String> relays,
         String specVersion,
-        _i13.BackupStatus status,
-        List<_i14.Steward> stewards,
+        _i12.BackupStatus status,
+        List<_i13.Steward> stewards,
         int threshold,
         int totalKeys,
         String vaultId
@@ -2014,8 +2003,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
               DateTime lastUpdated,
               List<String> relays,
               String specVersion,
-              _i13.BackupStatus status,
-              List<_i14.Steward> stewards,
+              _i12.BackupStatus status,
+              List<_i13.Steward> stewards,
               int threshold,
               int totalKeys,
               String vaultId
@@ -2042,7 +2031,7 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
             ),
           ),
           relays: <String>[],
-          specVersion: _i10.dummyValue<String>(
+          specVersion: _i9.dummyValue<String>(
             this,
             Invocation.method(
               #createAndDistributeBackup,
@@ -2050,11 +2039,11 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
               {#vaultId: vaultId},
             ),
           ),
-          status: _i13.BackupStatus.pending,
-          stewards: <_i14.Steward>[],
+          status: _i12.BackupStatus.pending,
+          stewards: <_i13.Steward>[],
           threshold: 0,
           totalKeys: 0,
-          vaultId: _i10.dummyValue<String>(
+          vaultId: _i9.dummyValue<String>(
             this,
             Invocation.method(
               #createAndDistributeBackup,
@@ -2074,8 +2063,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
             DateTime lastUpdated,
             List<String> relays,
             String specVersion,
-            _i13.BackupStatus status,
-            List<_i14.Steward> stewards,
+            _i12.BackupStatus status,
+            List<_i13.Steward> stewards,
             int threshold,
             int totalKeys,
             String vaultId

--- a/test/services/invitation_acceptance_format_test.mocks.dart
+++ b/test/services/invitation_acceptance_format_test.mocks.dart
@@ -5,21 +5,22 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i6;
 
-import 'package:horcrux/models/backup_status.dart' as _i12;
+import 'package:horcrux/models/backup_status.dart' as _i13;
+import 'package:horcrux/models/nostr_kinds.dart' as _i8;
 import 'package:horcrux/models/recovery_request.dart' as _i7;
-import 'package:horcrux/models/relay_configuration.dart' as _i17;
-import 'package:horcrux/models/shard_data.dart' as _i15;
-import 'package:horcrux/models/steward.dart' as _i13;
-import 'package:horcrux/models/steward_status.dart' as _i14;
-import 'package:horcrux/models/vault.dart' as _i11;
-import 'package:horcrux/providers/vault_provider.dart' as _i10;
-import 'package:horcrux/services/backup_service.dart' as _i18;
-import 'package:horcrux/services/invitation_sending_service.dart' as _i16;
-import 'package:horcrux/services/login_service.dart' as _i8;
+import 'package:horcrux/models/relay_configuration.dart' as _i18;
+import 'package:horcrux/models/shard_data.dart' as _i16;
+import 'package:horcrux/models/steward.dart' as _i14;
+import 'package:horcrux/models/steward_status.dart' as _i15;
+import 'package:horcrux/models/vault.dart' as _i12;
+import 'package:horcrux/providers/vault_provider.dart' as _i11;
+import 'package:horcrux/services/backup_service.dart' as _i19;
+import 'package:horcrux/services/invitation_sending_service.dart' as _i17;
+import 'package:horcrux/services/login_service.dart' as _i9;
 import 'package:horcrux/services/ndk_service.dart' as _i4;
 import 'package:horcrux/services/relay_scan_service.dart' as _i5;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i9;
+import 'package:mockito/src/dummies.dart' as _i10;
 import 'package:ndk/ndk.dart' as _i2;
 import 'package:ndk/shared/nips/nip01/key_pair.dart' as _i3;
 
@@ -179,14 +180,15 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
       ) as _i6.Future<String?>);
 
   @override
-  _i6.Future<String?> resolveRecoveryRequestIdForGiftWrap(_i2.Nip01Event? giftWrap) =>
+  _i6.Future<({_i8.NostrKind kind, String recoveryRequestId})?> resolveRecoveryRequestIdForGiftWrap(
+          _i2.Nip01Event? giftWrap) =>
       (super.noSuchMethod(
         Invocation.method(
           #resolveRecoveryRequestIdForGiftWrap,
           [giftWrap],
         ),
-        returnValue: _i6.Future<String?>.value(),
-      ) as _i6.Future<String?>);
+        returnValue: _i6.Future<({_i8.NostrKind kind, String recoveryRequestId})?>.value(),
+      ) as _i6.Future<({_i8.NostrKind kind, String recoveryRequestId})?>);
 
   @override
   _i6.Future<String?> publishRecoveryRequest({
@@ -344,7 +346,7 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
 /// A class which mocks [LoginService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockLoginService extends _i1.Mock implements _i8.LoginService {
+class MockLoginService extends _i1.Mock implements _i9.LoginService {
   MockLoginService() {
     _i1.throwOnMissingStub(this);
   }
@@ -442,7 +444,7 @@ class MockLoginService extends _i1.Mock implements _i8.LoginService {
           #encryptText,
           [plaintext],
         ),
-        returnValue: _i6.Future<String>.value(_i9.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i10.dummyValue<String>(
           this,
           Invocation.method(
             #encryptText,
@@ -457,7 +459,7 @@ class MockLoginService extends _i1.Mock implements _i8.LoginService {
           #decryptText,
           [encryptedText],
         ),
-        returnValue: _i6.Future<String>.value(_i9.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i10.dummyValue<String>(
           this,
           Invocation.method(
             #decryptText,
@@ -505,7 +507,7 @@ class MockLoginService extends _i1.Mock implements _i8.LoginService {
             #recipientPubkey: recipientPubkey,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i9.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i10.dummyValue<String>(
           this,
           Invocation.method(
             #encryptForRecipient,
@@ -532,7 +534,7 @@ class MockLoginService extends _i1.Mock implements _i8.LoginService {
             #senderPubkey: senderPubkey,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i9.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i10.dummyValue<String>(
           this,
           Invocation.method(
             #decryptFromSender,
@@ -549,16 +551,16 @@ class MockLoginService extends _i1.Mock implements _i8.LoginService {
 /// A class which mocks [VaultRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockVaultRepository extends _i1.Mock implements _i10.VaultRepository {
+class MockVaultRepository extends _i1.Mock implements _i11.VaultRepository {
   MockVaultRepository() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i6.Stream<List<_i11.Vault>> get vaultsStream => (super.noSuchMethod(
+  _i6.Stream<List<_i12.Vault>> get vaultsStream => (super.noSuchMethod(
         Invocation.getter(#vaultsStream),
-        returnValue: _i6.Stream<List<_i11.Vault>>.empty(),
-      ) as _i6.Stream<List<_i11.Vault>>);
+        returnValue: _i6.Stream<List<_i12.Vault>>.empty(),
+      ) as _i6.Stream<List<_i12.Vault>>);
 
   @override
   _i6.Future<void> initialize() => (super.noSuchMethod(
@@ -571,25 +573,25 @@ class MockVaultRepository extends _i1.Mock implements _i10.VaultRepository {
       ) as _i6.Future<void>);
 
   @override
-  _i6.Future<List<_i11.Vault>> getAllVaults() => (super.noSuchMethod(
+  _i6.Future<List<_i12.Vault>> getAllVaults() => (super.noSuchMethod(
         Invocation.method(
           #getAllVaults,
           [],
         ),
-        returnValue: _i6.Future<List<_i11.Vault>>.value(<_i11.Vault>[]),
-      ) as _i6.Future<List<_i11.Vault>>);
+        returnValue: _i6.Future<List<_i12.Vault>>.value(<_i12.Vault>[]),
+      ) as _i6.Future<List<_i12.Vault>>);
 
   @override
-  _i6.Future<_i11.Vault?> getVault(String? id) => (super.noSuchMethod(
+  _i6.Future<_i12.Vault?> getVault(String? id) => (super.noSuchMethod(
         Invocation.method(
           #getVault,
           [id],
         ),
-        returnValue: _i6.Future<_i11.Vault?>.value(),
-      ) as _i6.Future<_i11.Vault?>);
+        returnValue: _i6.Future<_i12.Vault?>.value(),
+      ) as _i6.Future<_i12.Vault?>);
 
   @override
-  _i6.Future<void> saveVault(_i11.Vault? vault) => (super.noSuchMethod(
+  _i6.Future<void> saveVault(_i12.Vault? vault) => (super.noSuchMethod(
         Invocation.method(
           #saveVault,
           [vault],
@@ -599,7 +601,7 @@ class MockVaultRepository extends _i1.Mock implements _i10.VaultRepository {
       ) as _i6.Future<void>);
 
   @override
-  _i6.Future<void> addVault(_i11.Vault? vault) => (super.noSuchMethod(
+  _i6.Future<void> addVault(_i12.Vault? vault) => (super.noSuchMethod(
         Invocation.method(
           #addVault,
           [vault],
@@ -687,8 +689,8 @@ class MockVaultRepository extends _i1.Mock implements _i10.VaultRepository {
       DateTime lastUpdated,
       List<String> relays,
       String specVersion,
-      _i12.BackupStatus status,
-      List<_i13.Steward> stewards,
+      _i13.BackupStatus status,
+      List<_i14.Steward> stewards,
       int threshold,
       int totalKeys,
       String vaultId
@@ -718,8 +720,8 @@ class MockVaultRepository extends _i1.Mock implements _i10.VaultRepository {
         DateTime lastUpdated,
         List<String> relays,
         String specVersion,
-        _i12.BackupStatus status,
-        List<_i13.Steward> stewards,
+        _i13.BackupStatus status,
+        List<_i14.Steward> stewards,
         int threshold,
         int totalKeys,
         String vaultId
@@ -739,8 +741,8 @@ class MockVaultRepository extends _i1.Mock implements _i10.VaultRepository {
               DateTime lastUpdated,
               List<String> relays,
               String specVersion,
-              _i12.BackupStatus status,
-              List<_i13.Steward> stewards,
+              _i13.BackupStatus status,
+              List<_i14.Steward> stewards,
               int threshold,
               int totalKeys,
               String vaultId
@@ -756,8 +758,8 @@ class MockVaultRepository extends _i1.Mock implements _i10.VaultRepository {
             DateTime lastUpdated,
             List<String> relays,
             String specVersion,
-            _i12.BackupStatus status,
-            List<_i13.Steward> stewards,
+            _i13.BackupStatus status,
+            List<_i14.Steward> stewards,
             int threshold,
             int totalKeys,
             String vaultId
@@ -767,7 +769,7 @@ class MockVaultRepository extends _i1.Mock implements _i10.VaultRepository {
   _i6.Future<void> updateStewardStatus({
     required String? vaultId,
     required String? pubkey,
-    required _i14.StewardStatus? status,
+    required _i15.StewardStatus? status,
     DateTime? acknowledgedAt,
     String? acknowledgmentEventId,
     int? acknowledgedDistributionVersion,
@@ -792,7 +794,7 @@ class MockVaultRepository extends _i1.Mock implements _i10.VaultRepository {
   @override
   _i6.Future<void> addShardToVault(
     String? vaultId,
-    _i15.ShardData? shard,
+    _i16.ShardData? shard,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -807,13 +809,13 @@ class MockVaultRepository extends _i1.Mock implements _i10.VaultRepository {
       ) as _i6.Future<void>);
 
   @override
-  _i6.Future<List<_i15.ShardData>> getShardsForVault(String? vaultId) => (super.noSuchMethod(
+  _i6.Future<List<_i16.ShardData>> getShardsForVault(String? vaultId) => (super.noSuchMethod(
         Invocation.method(
           #getShardsForVault,
           [vaultId],
         ),
-        returnValue: _i6.Future<List<_i15.ShardData>>.value(<_i15.ShardData>[]),
-      ) as _i6.Future<List<_i15.ShardData>>);
+        returnValue: _i6.Future<List<_i16.ShardData>>.value(<_i16.ShardData>[]),
+      ) as _i6.Future<List<_i16.ShardData>>);
 
   @override
   _i6.Future<void> clearShardsForVault(String? vaultId) => (super.noSuchMethod(
@@ -921,7 +923,7 @@ class MockVaultRepository extends _i1.Mock implements _i10.VaultRepository {
 /// A class which mocks [InvitationSendingService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockInvitationSendingService extends _i1.Mock implements _i16.InvitationSendingService {
+class MockInvitationSendingService extends _i1.Mock implements _i17.InvitationSendingService {
   MockInvitationSendingService() {
     _i1.throwOnMissingStub(this);
   }
@@ -1090,28 +1092,28 @@ class MockRelayScanService extends _i1.Mock implements _i5.RelayScanService {
       ) as _i6.Future<void>);
 
   @override
-  _i6.Future<List<_i17.RelayConfiguration>> getRelayConfigurations({bool? enabledOnly}) =>
+  _i6.Future<List<_i18.RelayConfiguration>> getRelayConfigurations({bool? enabledOnly}) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRelayConfigurations,
           [],
           {#enabledOnly: enabledOnly},
         ),
-        returnValue: _i6.Future<List<_i17.RelayConfiguration>>.value(<_i17.RelayConfiguration>[]),
-      ) as _i6.Future<List<_i17.RelayConfiguration>>);
+        returnValue: _i6.Future<List<_i18.RelayConfiguration>>.value(<_i18.RelayConfiguration>[]),
+      ) as _i6.Future<List<_i18.RelayConfiguration>>);
 
   @override
-  _i6.Future<_i17.RelayConfiguration?> getRelayConfiguration(String? relayId) =>
+  _i6.Future<_i18.RelayConfiguration?> getRelayConfiguration(String? relayId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRelayConfiguration,
           [relayId],
         ),
-        returnValue: _i6.Future<_i17.RelayConfiguration?>.value(),
-      ) as _i6.Future<_i17.RelayConfiguration?>);
+        returnValue: _i6.Future<_i18.RelayConfiguration?>.value(),
+      ) as _i6.Future<_i18.RelayConfiguration?>);
 
   @override
-  _i6.Future<void> addRelayConfiguration(_i17.RelayConfiguration? relay) => (super.noSuchMethod(
+  _i6.Future<void> addRelayConfiguration(_i18.RelayConfiguration? relay) => (super.noSuchMethod(
         Invocation.method(
           #addRelayConfiguration,
           [relay],
@@ -1121,7 +1123,7 @@ class MockRelayScanService extends _i1.Mock implements _i5.RelayScanService {
       ) as _i6.Future<void>);
 
   @override
-  _i6.Future<void> updateRelayConfiguration(_i17.RelayConfiguration? relay) => (super.noSuchMethod(
+  _i6.Future<void> updateRelayConfiguration(_i18.RelayConfiguration? relay) => (super.noSuchMethod(
         Invocation.method(
           #updateRelayConfiguration,
           [relay],
@@ -1239,7 +1241,7 @@ class MockRelayScanService extends _i1.Mock implements _i5.RelayScanService {
 /// A class which mocks [BackupService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockBackupService extends _i1.Mock implements _i18.BackupService {
+class MockBackupService extends _i1.Mock implements _i19.BackupService {
   MockBackupService() {
     _i1.throwOnMissingStub(this);
   }
@@ -1256,8 +1258,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
         DateTime lastUpdated,
         List<String> relays,
         String specVersion,
-        _i12.BackupStatus status,
-        List<_i13.Steward> stewards,
+        _i13.BackupStatus status,
+        List<_i14.Steward> stewards,
         int threshold,
         int totalKeys,
         String vaultId
@@ -1265,7 +1267,7 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
     required String? vaultId,
     required int? threshold,
     required int? totalKeys,
-    required List<_i13.Steward>? stewards,
+    required List<_i14.Steward>? stewards,
     required List<String>? relays,
     String? instructions,
     String? contentHash,
@@ -1295,8 +1297,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
               DateTime lastUpdated,
               List<String> relays,
               String specVersion,
-              _i12.BackupStatus status,
-              List<_i13.Steward> stewards,
+              _i13.BackupStatus status,
+              List<_i14.Steward> stewards,
               int threshold,
               int totalKeys,
               String vaultId
@@ -1339,7 +1341,7 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
             ),
           ),
           relays: <String>[],
-          specVersion: _i9.dummyValue<String>(
+          specVersion: _i10.dummyValue<String>(
             this,
             Invocation.method(
               #createBackupConfiguration,
@@ -1355,11 +1357,11 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
               },
             ),
           ),
-          status: _i12.BackupStatus.pending,
-          stewards: <_i13.Steward>[],
+          status: _i13.BackupStatus.pending,
+          stewards: <_i14.Steward>[],
           threshold: 0,
           totalKeys: 0,
-          vaultId: _i9.dummyValue<String>(
+          vaultId: _i10.dummyValue<String>(
             this,
             Invocation.method(
               #createBackupConfiguration,
@@ -1387,8 +1389,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
             DateTime lastUpdated,
             List<String> relays,
             String specVersion,
-            _i12.BackupStatus status,
-            List<_i13.Steward> stewards,
+            _i13.BackupStatus status,
+            List<_i14.Steward> stewards,
             int threshold,
             int totalKeys,
             String vaultId
@@ -1406,8 +1408,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
         DateTime lastUpdated,
         List<String> relays,
         String specVersion,
-        _i12.BackupStatus status,
-        List<_i13.Steward> stewards,
+        _i13.BackupStatus status,
+        List<_i14.Steward> stewards,
         int threshold,
         int totalKeys,
         String vaultId
@@ -1427,8 +1429,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
               DateTime lastUpdated,
               List<String> relays,
               String specVersion,
-              _i12.BackupStatus status,
-              List<_i13.Steward> stewards,
+              _i13.BackupStatus status,
+              List<_i14.Steward> stewards,
               int threshold,
               int totalKeys,
               String vaultId
@@ -1444,8 +1446,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
             DateTime lastUpdated,
             List<String> relays,
             String specVersion,
-            _i12.BackupStatus status,
-            List<_i13.Steward> stewards,
+            _i13.BackupStatus status,
+            List<_i14.Steward> stewards,
             int threshold,
             int totalKeys,
             String vaultId
@@ -1464,8 +1466,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
             DateTime lastUpdated,
             List<String> relays,
             String specVersion,
-            _i12.BackupStatus status,
-            List<_i13.Steward> stewards,
+            _i13.BackupStatus status,
+            List<_i14.Steward> stewards,
             int threshold,
             int totalKeys,
             String vaultId
@@ -1486,8 +1488,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
                   DateTime lastUpdated,
                   List<String> relays,
                   String specVersion,
-                  _i12.BackupStatus status,
-                  List<_i13.Steward> stewards,
+                  _i13.BackupStatus status,
+                  List<_i14.Steward> stewards,
                   int threshold,
                   int totalKeys,
                   String vaultId
@@ -1501,8 +1503,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
           DateTime lastUpdated,
           List<String> relays,
           String specVersion,
-          _i12.BackupStatus status,
-          List<_i13.Steward> stewards,
+          _i13.BackupStatus status,
+          List<_i14.Steward> stewards,
           int threshold,
           int totalKeys,
           String vaultId
@@ -1519,8 +1521,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
                 DateTime lastUpdated,
                 List<String> relays,
                 String specVersion,
-                _i12.BackupStatus status,
-                List<_i13.Steward> stewards,
+                _i13.BackupStatus status,
+                List<_i14.Steward> stewards,
                 int threshold,
                 int totalKeys,
                 String vaultId
@@ -1538,8 +1540,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
             DateTime lastUpdated,
             List<String> relays,
             String specVersion,
-            _i12.BackupStatus status,
-            List<_i13.Steward> stewards,
+            _i13.BackupStatus status,
+            List<_i14.Steward> stewards,
             int threshold,
             int totalKeys,
             String vaultId
@@ -1564,7 +1566,7 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
       ) as _i6.Future<void>);
 
   @override
-  _i6.Future<List<_i15.ShardData>> generateShamirShares({
+  _i6.Future<List<_i16.ShardData>> generateShamirShares({
     required String? content,
     required int? threshold,
     required int? totalShards,
@@ -1593,18 +1595,18 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
             #pushEnabled: pushEnabled,
           },
         ),
-        returnValue: _i6.Future<List<_i15.ShardData>>.value(<_i15.ShardData>[]),
-      ) as _i6.Future<List<_i15.ShardData>>);
+        returnValue: _i6.Future<List<_i16.ShardData>>.value(<_i16.ShardData>[]),
+      ) as _i6.Future<List<_i16.ShardData>>);
 
   @override
-  _i6.Future<String> reconstructFromShares({required List<_i15.ShardData>? shares}) =>
+  _i6.Future<String> reconstructFromShares({required List<_i16.ShardData>? shares}) =>
       (super.noSuchMethod(
         Invocation.method(
           #reconstructFromShares,
           [],
           {#shares: shares},
         ),
-        returnValue: _i6.Future<String>.value(_i9.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i10.dummyValue<String>(
           this,
           Invocation.method(
             #reconstructFromShares,
@@ -1617,7 +1619,7 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
   @override
   _i6.Future<void> updateBackupStatus(
     String? vaultId,
-    _i12.BackupStatus? status,
+    _i13.BackupStatus? status,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1635,7 +1637,7 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
   _i6.Future<void> updateStewardStatus({
     required String? vaultId,
     required String? pubkey,
-    required _i14.StewardStatus? status,
+    required _i15.StewardStatus? status,
     DateTime? acknowledgedAt,
     String? acknowledgmentEventId,
   }) =>
@@ -1676,15 +1678,15 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
         DateTime lastUpdated,
         List<String> relays,
         String specVersion,
-        _i12.BackupStatus status,
-        List<_i13.Steward> stewards,
+        _i13.BackupStatus status,
+        List<_i14.Steward> stewards,
         int threshold,
         int totalKeys,
         String vaultId
       })> mergeBackupConfig({
     required String? vaultId,
     int? threshold,
-    List<_i13.Steward>? stewards,
+    List<_i14.Steward>? stewards,
     List<String>? relays,
     String? instructions,
   }) =>
@@ -1711,8 +1713,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
               DateTime lastUpdated,
               List<String> relays,
               String specVersion,
-              _i12.BackupStatus status,
-              List<_i13.Steward> stewards,
+              _i13.BackupStatus status,
+              List<_i14.Steward> stewards,
               int threshold,
               int totalKeys,
               String vaultId
@@ -1751,7 +1753,7 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
             ),
           ),
           relays: <String>[],
-          specVersion: _i9.dummyValue<String>(
+          specVersion: _i10.dummyValue<String>(
             this,
             Invocation.method(
               #mergeBackupConfig,
@@ -1765,11 +1767,11 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
               },
             ),
           ),
-          status: _i12.BackupStatus.pending,
-          stewards: <_i13.Steward>[],
+          status: _i13.BackupStatus.pending,
+          stewards: <_i14.Steward>[],
           threshold: 0,
           totalKeys: 0,
-          vaultId: _i9.dummyValue<String>(
+          vaultId: _i10.dummyValue<String>(
             this,
             Invocation.method(
               #mergeBackupConfig,
@@ -1795,8 +1797,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
             DateTime lastUpdated,
             List<String> relays,
             String specVersion,
-            _i12.BackupStatus status,
-            List<_i13.Steward> stewards,
+            _i13.BackupStatus status,
+            List<_i14.Steward> stewards,
             int threshold,
             int totalKeys,
             String vaultId
@@ -1846,8 +1848,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
         DateTime lastUpdated,
         List<String> relays,
         String specVersion,
-        _i12.BackupStatus status,
-        List<_i13.Steward> stewards,
+        _i13.BackupStatus status,
+        List<_i14.Steward> stewards,
         int threshold,
         int totalKeys,
         String vaultId
@@ -1855,7 +1857,7 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
     required String? vaultId,
     required int? threshold,
     required int? totalKeys,
-    required List<_i13.Steward>? stewards,
+    required List<_i14.Steward>? stewards,
     required List<String>? relays,
     String? instructions,
   }) =>
@@ -1883,8 +1885,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
               DateTime lastUpdated,
               List<String> relays,
               String specVersion,
-              _i12.BackupStatus status,
-              List<_i13.Steward> stewards,
+              _i13.BackupStatus status,
+              List<_i14.Steward> stewards,
               int threshold,
               int totalKeys,
               String vaultId
@@ -1925,7 +1927,7 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
             ),
           ),
           relays: <String>[],
-          specVersion: _i9.dummyValue<String>(
+          specVersion: _i10.dummyValue<String>(
             this,
             Invocation.method(
               #saveBackupConfig,
@@ -1940,11 +1942,11 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
               },
             ),
           ),
-          status: _i12.BackupStatus.pending,
-          stewards: <_i13.Steward>[],
+          status: _i13.BackupStatus.pending,
+          stewards: <_i14.Steward>[],
           threshold: 0,
           totalKeys: 0,
-          vaultId: _i9.dummyValue<String>(
+          vaultId: _i10.dummyValue<String>(
             this,
             Invocation.method(
               #saveBackupConfig,
@@ -1971,8 +1973,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
             DateTime lastUpdated,
             List<String> relays,
             String specVersion,
-            _i12.BackupStatus status,
-            List<_i13.Steward> stewards,
+            _i13.BackupStatus status,
+            List<_i14.Steward> stewards,
             int threshold,
             int totalKeys,
             String vaultId
@@ -1990,8 +1992,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
         DateTime lastUpdated,
         List<String> relays,
         String specVersion,
-        _i12.BackupStatus status,
-        List<_i13.Steward> stewards,
+        _i13.BackupStatus status,
+        List<_i14.Steward> stewards,
         int threshold,
         int totalKeys,
         String vaultId
@@ -2012,8 +2014,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
               DateTime lastUpdated,
               List<String> relays,
               String specVersion,
-              _i12.BackupStatus status,
-              List<_i13.Steward> stewards,
+              _i13.BackupStatus status,
+              List<_i14.Steward> stewards,
               int threshold,
               int totalKeys,
               String vaultId
@@ -2040,7 +2042,7 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
             ),
           ),
           relays: <String>[],
-          specVersion: _i9.dummyValue<String>(
+          specVersion: _i10.dummyValue<String>(
             this,
             Invocation.method(
               #createAndDistributeBackup,
@@ -2048,11 +2050,11 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
               {#vaultId: vaultId},
             ),
           ),
-          status: _i12.BackupStatus.pending,
-          stewards: <_i13.Steward>[],
+          status: _i13.BackupStatus.pending,
+          stewards: <_i14.Steward>[],
           threshold: 0,
           totalKeys: 0,
-          vaultId: _i9.dummyValue<String>(
+          vaultId: _i10.dummyValue<String>(
             this,
             Invocation.method(
               #createAndDistributeBackup,
@@ -2072,8 +2074,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
             DateTime lastUpdated,
             List<String> relays,
             String specVersion,
-            _i12.BackupStatus status,
-            List<_i13.Steward> stewards,
+            _i13.BackupStatus status,
+            List<_i14.Steward> stewards,
             int threshold,
             int totalKeys,
             String vaultId

--- a/test/services/invitation_acceptance_format_test.mocks.dart
+++ b/test/services/invitation_acceptance_format_test.mocks.dart
@@ -198,27 +198,6 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
       ) as _i6.Future<String?>);
 
   @override
-  _i6.Future<String?> publishRecoveryResponse({
-    required String? initiatorPubkey,
-    required String? recoveryRequestId,
-    required bool? approved,
-    String? shardDataJson,
-  }) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #publishRecoveryResponse,
-          [],
-          {
-            #initiatorPubkey: initiatorPubkey,
-            #recoveryRequestId: recoveryRequestId,
-            #approved: approved,
-            #shardDataJson: shardDataJson,
-          },
-        ),
-        returnValue: _i6.Future<String?>.value(),
-      ) as _i6.Future<String?>);
-
-  @override
   _i6.Future<void> closeSubscriptions() => (super.noSuchMethod(
         Invocation.method(
           #closeSubscriptions,

--- a/test/services/invitation_service_test.mocks.dart
+++ b/test/services/invitation_service_test.mocks.dart
@@ -5,22 +5,22 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i6;
 
-import 'package:horcrux/models/backup_status.dart' as _i13;
-import 'package:horcrux/models/nostr_kinds.dart' as _i8;
-import 'package:horcrux/models/recovery_request.dart' as _i7;
+import 'package:horcrux/models/backup_status.dart' as _i12;
+import 'package:horcrux/models/nostr_kinds.dart' as _i7;
+import 'package:horcrux/models/recovery_request.dart' as _i16;
 import 'package:horcrux/models/relay_configuration.dart' as _i18;
-import 'package:horcrux/models/shard_data.dart' as _i16;
-import 'package:horcrux/models/steward.dart' as _i14;
-import 'package:horcrux/models/steward_status.dart' as _i15;
-import 'package:horcrux/models/vault.dart' as _i12;
-import 'package:horcrux/providers/vault_provider.dart' as _i11;
+import 'package:horcrux/models/shard_data.dart' as _i15;
+import 'package:horcrux/models/steward.dart' as _i13;
+import 'package:horcrux/models/steward_status.dart' as _i14;
+import 'package:horcrux/models/vault.dart' as _i11;
+import 'package:horcrux/providers/vault_provider.dart' as _i10;
 import 'package:horcrux/services/backup_service.dart' as _i19;
 import 'package:horcrux/services/invitation_sending_service.dart' as _i17;
-import 'package:horcrux/services/login_service.dart' as _i9;
+import 'package:horcrux/services/login_service.dart' as _i8;
 import 'package:horcrux/services/ndk_service.dart' as _i4;
 import 'package:horcrux/services/relay_scan_service.dart' as _i5;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i10;
+import 'package:mockito/src/dummies.dart' as _i9;
 import 'package:ndk/ndk.dart' as _i2;
 import 'package:ndk/shared/nips/nip01/key_pair.dart' as _i3;
 
@@ -96,18 +96,6 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
   }
 
   @override
-  _i6.Stream<_i7.RecoveryRequest> get recoveryRequestStream => (super.noSuchMethod(
-        Invocation.getter(#recoveryRequestStream),
-        returnValue: _i6.Stream<_i7.RecoveryRequest>.empty(),
-      ) as _i6.Stream<_i7.RecoveryRequest>);
-
-  @override
-  _i6.Stream<_i4.RecoveryResponseEvent> get recoveryResponseStream => (super.noSuchMethod(
-        Invocation.getter(#recoveryResponseStream),
-        returnValue: _i6.Stream<_i4.RecoveryResponseEvent>.empty(),
-      ) as _i6.Stream<_i4.RecoveryResponseEvent>);
-
-  @override
   bool get isInitialized => (super.noSuchMethod(
         Invocation.getter(#isInitialized),
         returnValue: false,
@@ -180,15 +168,15 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
       ) as _i6.Future<String?>);
 
   @override
-  _i6.Future<({_i8.NostrKind kind, String recoveryRequestId})?> resolveRecoveryRequestIdForGiftWrap(
+  _i6.Future<({_i7.NostrKind kind, String recoveryRequestId})?> resolveRecoveryRequestIdForGiftWrap(
           _i2.Nip01Event? giftWrap) =>
       (super.noSuchMethod(
         Invocation.method(
           #resolveRecoveryRequestIdForGiftWrap,
           [giftWrap],
         ),
-        returnValue: _i6.Future<({_i8.NostrKind kind, String recoveryRequestId})?>.value(),
-      ) as _i6.Future<({_i8.NostrKind kind, String recoveryRequestId})?>);
+        returnValue: _i6.Future<({_i7.NostrKind kind, String recoveryRequestId})?>.value(),
+      ) as _i6.Future<({_i7.NostrKind kind, String recoveryRequestId})?>);
 
   @override
   _i6.Future<String?> publishRecoveryRequest({
@@ -346,7 +334,7 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
 /// A class which mocks [LoginService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockLoginService extends _i1.Mock implements _i9.LoginService {
+class MockLoginService extends _i1.Mock implements _i8.LoginService {
   MockLoginService() {
     _i1.throwOnMissingStub(this);
   }
@@ -444,7 +432,7 @@ class MockLoginService extends _i1.Mock implements _i9.LoginService {
           #encryptText,
           [plaintext],
         ),
-        returnValue: _i6.Future<String>.value(_i10.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i9.dummyValue<String>(
           this,
           Invocation.method(
             #encryptText,
@@ -459,7 +447,7 @@ class MockLoginService extends _i1.Mock implements _i9.LoginService {
           #decryptText,
           [encryptedText],
         ),
-        returnValue: _i6.Future<String>.value(_i10.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i9.dummyValue<String>(
           this,
           Invocation.method(
             #decryptText,
@@ -507,7 +495,7 @@ class MockLoginService extends _i1.Mock implements _i9.LoginService {
             #recipientPubkey: recipientPubkey,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i10.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i9.dummyValue<String>(
           this,
           Invocation.method(
             #encryptForRecipient,
@@ -534,7 +522,7 @@ class MockLoginService extends _i1.Mock implements _i9.LoginService {
             #senderPubkey: senderPubkey,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i10.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i9.dummyValue<String>(
           this,
           Invocation.method(
             #decryptFromSender,
@@ -551,16 +539,16 @@ class MockLoginService extends _i1.Mock implements _i9.LoginService {
 /// A class which mocks [VaultRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockVaultRepository extends _i1.Mock implements _i11.VaultRepository {
+class MockVaultRepository extends _i1.Mock implements _i10.VaultRepository {
   MockVaultRepository() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i6.Stream<List<_i12.Vault>> get vaultsStream => (super.noSuchMethod(
+  _i6.Stream<List<_i11.Vault>> get vaultsStream => (super.noSuchMethod(
         Invocation.getter(#vaultsStream),
-        returnValue: _i6.Stream<List<_i12.Vault>>.empty(),
-      ) as _i6.Stream<List<_i12.Vault>>);
+        returnValue: _i6.Stream<List<_i11.Vault>>.empty(),
+      ) as _i6.Stream<List<_i11.Vault>>);
 
   @override
   _i6.Future<void> initialize() => (super.noSuchMethod(
@@ -573,25 +561,25 @@ class MockVaultRepository extends _i1.Mock implements _i11.VaultRepository {
       ) as _i6.Future<void>);
 
   @override
-  _i6.Future<List<_i12.Vault>> getAllVaults() => (super.noSuchMethod(
+  _i6.Future<List<_i11.Vault>> getAllVaults() => (super.noSuchMethod(
         Invocation.method(
           #getAllVaults,
           [],
         ),
-        returnValue: _i6.Future<List<_i12.Vault>>.value(<_i12.Vault>[]),
-      ) as _i6.Future<List<_i12.Vault>>);
+        returnValue: _i6.Future<List<_i11.Vault>>.value(<_i11.Vault>[]),
+      ) as _i6.Future<List<_i11.Vault>>);
 
   @override
-  _i6.Future<_i12.Vault?> getVault(String? id) => (super.noSuchMethod(
+  _i6.Future<_i11.Vault?> getVault(String? id) => (super.noSuchMethod(
         Invocation.method(
           #getVault,
           [id],
         ),
-        returnValue: _i6.Future<_i12.Vault?>.value(),
-      ) as _i6.Future<_i12.Vault?>);
+        returnValue: _i6.Future<_i11.Vault?>.value(),
+      ) as _i6.Future<_i11.Vault?>);
 
   @override
-  _i6.Future<void> saveVault(_i12.Vault? vault) => (super.noSuchMethod(
+  _i6.Future<void> saveVault(_i11.Vault? vault) => (super.noSuchMethod(
         Invocation.method(
           #saveVault,
           [vault],
@@ -601,7 +589,7 @@ class MockVaultRepository extends _i1.Mock implements _i11.VaultRepository {
       ) as _i6.Future<void>);
 
   @override
-  _i6.Future<void> addVault(_i12.Vault? vault) => (super.noSuchMethod(
+  _i6.Future<void> addVault(_i11.Vault? vault) => (super.noSuchMethod(
         Invocation.method(
           #addVault,
           [vault],
@@ -689,8 +677,8 @@ class MockVaultRepository extends _i1.Mock implements _i11.VaultRepository {
       DateTime lastUpdated,
       List<String> relays,
       String specVersion,
-      _i13.BackupStatus status,
-      List<_i14.Steward> stewards,
+      _i12.BackupStatus status,
+      List<_i13.Steward> stewards,
       int threshold,
       int totalKeys,
       String vaultId
@@ -720,8 +708,8 @@ class MockVaultRepository extends _i1.Mock implements _i11.VaultRepository {
         DateTime lastUpdated,
         List<String> relays,
         String specVersion,
-        _i13.BackupStatus status,
-        List<_i14.Steward> stewards,
+        _i12.BackupStatus status,
+        List<_i13.Steward> stewards,
         int threshold,
         int totalKeys,
         String vaultId
@@ -741,8 +729,8 @@ class MockVaultRepository extends _i1.Mock implements _i11.VaultRepository {
               DateTime lastUpdated,
               List<String> relays,
               String specVersion,
-              _i13.BackupStatus status,
-              List<_i14.Steward> stewards,
+              _i12.BackupStatus status,
+              List<_i13.Steward> stewards,
               int threshold,
               int totalKeys,
               String vaultId
@@ -758,8 +746,8 @@ class MockVaultRepository extends _i1.Mock implements _i11.VaultRepository {
             DateTime lastUpdated,
             List<String> relays,
             String specVersion,
-            _i13.BackupStatus status,
-            List<_i14.Steward> stewards,
+            _i12.BackupStatus status,
+            List<_i13.Steward> stewards,
             int threshold,
             int totalKeys,
             String vaultId
@@ -769,7 +757,7 @@ class MockVaultRepository extends _i1.Mock implements _i11.VaultRepository {
   _i6.Future<void> updateStewardStatus({
     required String? vaultId,
     required String? pubkey,
-    required _i15.StewardStatus? status,
+    required _i14.StewardStatus? status,
     DateTime? acknowledgedAt,
     String? acknowledgmentEventId,
     int? acknowledgedDistributionVersion,
@@ -794,7 +782,7 @@ class MockVaultRepository extends _i1.Mock implements _i11.VaultRepository {
   @override
   _i6.Future<void> addShardToVault(
     String? vaultId,
-    _i16.ShardData? shard,
+    _i15.ShardData? shard,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -809,13 +797,13 @@ class MockVaultRepository extends _i1.Mock implements _i11.VaultRepository {
       ) as _i6.Future<void>);
 
   @override
-  _i6.Future<List<_i16.ShardData>> getShardsForVault(String? vaultId) => (super.noSuchMethod(
+  _i6.Future<List<_i15.ShardData>> getShardsForVault(String? vaultId) => (super.noSuchMethod(
         Invocation.method(
           #getShardsForVault,
           [vaultId],
         ),
-        returnValue: _i6.Future<List<_i16.ShardData>>.value(<_i16.ShardData>[]),
-      ) as _i6.Future<List<_i16.ShardData>>);
+        returnValue: _i6.Future<List<_i15.ShardData>>.value(<_i15.ShardData>[]),
+      ) as _i6.Future<List<_i15.ShardData>>);
 
   @override
   _i6.Future<void> clearShardsForVault(String? vaultId) => (super.noSuchMethod(
@@ -849,7 +837,7 @@ class MockVaultRepository extends _i1.Mock implements _i11.VaultRepository {
   @override
   _i6.Future<void> addRecoveryRequestToVault(
     String? vaultId,
-    _i7.RecoveryRequest? request,
+    _i16.RecoveryRequest? request,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -867,7 +855,7 @@ class MockVaultRepository extends _i1.Mock implements _i11.VaultRepository {
   _i6.Future<void> updateRecoveryRequestInVault(
     String? vaultId,
     String? requestId,
-    _i7.RecoveryRequest? updatedRequest,
+    _i16.RecoveryRequest? updatedRequest,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -883,32 +871,33 @@ class MockVaultRepository extends _i1.Mock implements _i11.VaultRepository {
       ) as _i6.Future<void>);
 
   @override
-  _i6.Future<List<_i7.RecoveryRequest>> getRecoveryRequestsForVault(String? vaultId) =>
+  _i6.Future<List<_i16.RecoveryRequest>> getRecoveryRequestsForVault(String? vaultId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRecoveryRequestsForVault,
           [vaultId],
         ),
-        returnValue: _i6.Future<List<_i7.RecoveryRequest>>.value(<_i7.RecoveryRequest>[]),
-      ) as _i6.Future<List<_i7.RecoveryRequest>>);
+        returnValue: _i6.Future<List<_i16.RecoveryRequest>>.value(<_i16.RecoveryRequest>[]),
+      ) as _i6.Future<List<_i16.RecoveryRequest>>);
 
   @override
-  _i6.Future<_i7.RecoveryRequest?> getActiveRecoveryRequest(String? vaultId) => (super.noSuchMethod(
+  _i6.Future<_i16.RecoveryRequest?> getActiveRecoveryRequest(String? vaultId) =>
+      (super.noSuchMethod(
         Invocation.method(
           #getActiveRecoveryRequest,
           [vaultId],
         ),
-        returnValue: _i6.Future<_i7.RecoveryRequest?>.value(),
-      ) as _i6.Future<_i7.RecoveryRequest?>);
+        returnValue: _i6.Future<_i16.RecoveryRequest?>.value(),
+      ) as _i6.Future<_i16.RecoveryRequest?>);
 
   @override
-  _i6.Future<List<_i7.RecoveryRequest>> getAllRecoveryRequests() => (super.noSuchMethod(
+  _i6.Future<List<_i16.RecoveryRequest>> getAllRecoveryRequests() => (super.noSuchMethod(
         Invocation.method(
           #getAllRecoveryRequests,
           [],
         ),
-        returnValue: _i6.Future<List<_i7.RecoveryRequest>>.value(<_i7.RecoveryRequest>[]),
-      ) as _i6.Future<List<_i7.RecoveryRequest>>);
+        returnValue: _i6.Future<List<_i16.RecoveryRequest>>.value(<_i16.RecoveryRequest>[]),
+      ) as _i6.Future<List<_i16.RecoveryRequest>>);
 
   @override
   void dispose() => super.noSuchMethod(
@@ -1258,8 +1247,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
         DateTime lastUpdated,
         List<String> relays,
         String specVersion,
-        _i13.BackupStatus status,
-        List<_i14.Steward> stewards,
+        _i12.BackupStatus status,
+        List<_i13.Steward> stewards,
         int threshold,
         int totalKeys,
         String vaultId
@@ -1267,7 +1256,7 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
     required String? vaultId,
     required int? threshold,
     required int? totalKeys,
-    required List<_i14.Steward>? stewards,
+    required List<_i13.Steward>? stewards,
     required List<String>? relays,
     String? instructions,
     String? contentHash,
@@ -1297,8 +1286,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
               DateTime lastUpdated,
               List<String> relays,
               String specVersion,
-              _i13.BackupStatus status,
-              List<_i14.Steward> stewards,
+              _i12.BackupStatus status,
+              List<_i13.Steward> stewards,
               int threshold,
               int totalKeys,
               String vaultId
@@ -1341,7 +1330,7 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
             ),
           ),
           relays: <String>[],
-          specVersion: _i10.dummyValue<String>(
+          specVersion: _i9.dummyValue<String>(
             this,
             Invocation.method(
               #createBackupConfiguration,
@@ -1357,11 +1346,11 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
               },
             ),
           ),
-          status: _i13.BackupStatus.pending,
-          stewards: <_i14.Steward>[],
+          status: _i12.BackupStatus.pending,
+          stewards: <_i13.Steward>[],
           threshold: 0,
           totalKeys: 0,
-          vaultId: _i10.dummyValue<String>(
+          vaultId: _i9.dummyValue<String>(
             this,
             Invocation.method(
               #createBackupConfiguration,
@@ -1389,8 +1378,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
             DateTime lastUpdated,
             List<String> relays,
             String specVersion,
-            _i13.BackupStatus status,
-            List<_i14.Steward> stewards,
+            _i12.BackupStatus status,
+            List<_i13.Steward> stewards,
             int threshold,
             int totalKeys,
             String vaultId
@@ -1408,8 +1397,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
         DateTime lastUpdated,
         List<String> relays,
         String specVersion,
-        _i13.BackupStatus status,
-        List<_i14.Steward> stewards,
+        _i12.BackupStatus status,
+        List<_i13.Steward> stewards,
         int threshold,
         int totalKeys,
         String vaultId
@@ -1429,8 +1418,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
               DateTime lastUpdated,
               List<String> relays,
               String specVersion,
-              _i13.BackupStatus status,
-              List<_i14.Steward> stewards,
+              _i12.BackupStatus status,
+              List<_i13.Steward> stewards,
               int threshold,
               int totalKeys,
               String vaultId
@@ -1446,8 +1435,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
             DateTime lastUpdated,
             List<String> relays,
             String specVersion,
-            _i13.BackupStatus status,
-            List<_i14.Steward> stewards,
+            _i12.BackupStatus status,
+            List<_i13.Steward> stewards,
             int threshold,
             int totalKeys,
             String vaultId
@@ -1466,8 +1455,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
             DateTime lastUpdated,
             List<String> relays,
             String specVersion,
-            _i13.BackupStatus status,
-            List<_i14.Steward> stewards,
+            _i12.BackupStatus status,
+            List<_i13.Steward> stewards,
             int threshold,
             int totalKeys,
             String vaultId
@@ -1488,8 +1477,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
                   DateTime lastUpdated,
                   List<String> relays,
                   String specVersion,
-                  _i13.BackupStatus status,
-                  List<_i14.Steward> stewards,
+                  _i12.BackupStatus status,
+                  List<_i13.Steward> stewards,
                   int threshold,
                   int totalKeys,
                   String vaultId
@@ -1503,8 +1492,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
           DateTime lastUpdated,
           List<String> relays,
           String specVersion,
-          _i13.BackupStatus status,
-          List<_i14.Steward> stewards,
+          _i12.BackupStatus status,
+          List<_i13.Steward> stewards,
           int threshold,
           int totalKeys,
           String vaultId
@@ -1521,8 +1510,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
                 DateTime lastUpdated,
                 List<String> relays,
                 String specVersion,
-                _i13.BackupStatus status,
-                List<_i14.Steward> stewards,
+                _i12.BackupStatus status,
+                List<_i13.Steward> stewards,
                 int threshold,
                 int totalKeys,
                 String vaultId
@@ -1540,8 +1529,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
             DateTime lastUpdated,
             List<String> relays,
             String specVersion,
-            _i13.BackupStatus status,
-            List<_i14.Steward> stewards,
+            _i12.BackupStatus status,
+            List<_i13.Steward> stewards,
             int threshold,
             int totalKeys,
             String vaultId
@@ -1566,7 +1555,7 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
       ) as _i6.Future<void>);
 
   @override
-  _i6.Future<List<_i16.ShardData>> generateShamirShares({
+  _i6.Future<List<_i15.ShardData>> generateShamirShares({
     required String? content,
     required int? threshold,
     required int? totalShards,
@@ -1595,18 +1584,18 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
             #pushEnabled: pushEnabled,
           },
         ),
-        returnValue: _i6.Future<List<_i16.ShardData>>.value(<_i16.ShardData>[]),
-      ) as _i6.Future<List<_i16.ShardData>>);
+        returnValue: _i6.Future<List<_i15.ShardData>>.value(<_i15.ShardData>[]),
+      ) as _i6.Future<List<_i15.ShardData>>);
 
   @override
-  _i6.Future<String> reconstructFromShares({required List<_i16.ShardData>? shares}) =>
+  _i6.Future<String> reconstructFromShares({required List<_i15.ShardData>? shares}) =>
       (super.noSuchMethod(
         Invocation.method(
           #reconstructFromShares,
           [],
           {#shares: shares},
         ),
-        returnValue: _i6.Future<String>.value(_i10.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i9.dummyValue<String>(
           this,
           Invocation.method(
             #reconstructFromShares,
@@ -1619,7 +1608,7 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
   @override
   _i6.Future<void> updateBackupStatus(
     String? vaultId,
-    _i13.BackupStatus? status,
+    _i12.BackupStatus? status,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1637,7 +1626,7 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
   _i6.Future<void> updateStewardStatus({
     required String? vaultId,
     required String? pubkey,
-    required _i15.StewardStatus? status,
+    required _i14.StewardStatus? status,
     DateTime? acknowledgedAt,
     String? acknowledgmentEventId,
   }) =>
@@ -1678,15 +1667,15 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
         DateTime lastUpdated,
         List<String> relays,
         String specVersion,
-        _i13.BackupStatus status,
-        List<_i14.Steward> stewards,
+        _i12.BackupStatus status,
+        List<_i13.Steward> stewards,
         int threshold,
         int totalKeys,
         String vaultId
       })> mergeBackupConfig({
     required String? vaultId,
     int? threshold,
-    List<_i14.Steward>? stewards,
+    List<_i13.Steward>? stewards,
     List<String>? relays,
     String? instructions,
   }) =>
@@ -1713,8 +1702,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
               DateTime lastUpdated,
               List<String> relays,
               String specVersion,
-              _i13.BackupStatus status,
-              List<_i14.Steward> stewards,
+              _i12.BackupStatus status,
+              List<_i13.Steward> stewards,
               int threshold,
               int totalKeys,
               String vaultId
@@ -1753,7 +1742,7 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
             ),
           ),
           relays: <String>[],
-          specVersion: _i10.dummyValue<String>(
+          specVersion: _i9.dummyValue<String>(
             this,
             Invocation.method(
               #mergeBackupConfig,
@@ -1767,11 +1756,11 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
               },
             ),
           ),
-          status: _i13.BackupStatus.pending,
-          stewards: <_i14.Steward>[],
+          status: _i12.BackupStatus.pending,
+          stewards: <_i13.Steward>[],
           threshold: 0,
           totalKeys: 0,
-          vaultId: _i10.dummyValue<String>(
+          vaultId: _i9.dummyValue<String>(
             this,
             Invocation.method(
               #mergeBackupConfig,
@@ -1797,8 +1786,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
             DateTime lastUpdated,
             List<String> relays,
             String specVersion,
-            _i13.BackupStatus status,
-            List<_i14.Steward> stewards,
+            _i12.BackupStatus status,
+            List<_i13.Steward> stewards,
             int threshold,
             int totalKeys,
             String vaultId
@@ -1848,8 +1837,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
         DateTime lastUpdated,
         List<String> relays,
         String specVersion,
-        _i13.BackupStatus status,
-        List<_i14.Steward> stewards,
+        _i12.BackupStatus status,
+        List<_i13.Steward> stewards,
         int threshold,
         int totalKeys,
         String vaultId
@@ -1857,7 +1846,7 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
     required String? vaultId,
     required int? threshold,
     required int? totalKeys,
-    required List<_i14.Steward>? stewards,
+    required List<_i13.Steward>? stewards,
     required List<String>? relays,
     String? instructions,
   }) =>
@@ -1885,8 +1874,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
               DateTime lastUpdated,
               List<String> relays,
               String specVersion,
-              _i13.BackupStatus status,
-              List<_i14.Steward> stewards,
+              _i12.BackupStatus status,
+              List<_i13.Steward> stewards,
               int threshold,
               int totalKeys,
               String vaultId
@@ -1927,7 +1916,7 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
             ),
           ),
           relays: <String>[],
-          specVersion: _i10.dummyValue<String>(
+          specVersion: _i9.dummyValue<String>(
             this,
             Invocation.method(
               #saveBackupConfig,
@@ -1942,11 +1931,11 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
               },
             ),
           ),
-          status: _i13.BackupStatus.pending,
-          stewards: <_i14.Steward>[],
+          status: _i12.BackupStatus.pending,
+          stewards: <_i13.Steward>[],
           threshold: 0,
           totalKeys: 0,
-          vaultId: _i10.dummyValue<String>(
+          vaultId: _i9.dummyValue<String>(
             this,
             Invocation.method(
               #saveBackupConfig,
@@ -1973,8 +1962,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
             DateTime lastUpdated,
             List<String> relays,
             String specVersion,
-            _i13.BackupStatus status,
-            List<_i14.Steward> stewards,
+            _i12.BackupStatus status,
+            List<_i13.Steward> stewards,
             int threshold,
             int totalKeys,
             String vaultId
@@ -1992,8 +1981,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
         DateTime lastUpdated,
         List<String> relays,
         String specVersion,
-        _i13.BackupStatus status,
-        List<_i14.Steward> stewards,
+        _i12.BackupStatus status,
+        List<_i13.Steward> stewards,
         int threshold,
         int totalKeys,
         String vaultId
@@ -2014,8 +2003,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
               DateTime lastUpdated,
               List<String> relays,
               String specVersion,
-              _i13.BackupStatus status,
-              List<_i14.Steward> stewards,
+              _i12.BackupStatus status,
+              List<_i13.Steward> stewards,
               int threshold,
               int totalKeys,
               String vaultId
@@ -2042,7 +2031,7 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
             ),
           ),
           relays: <String>[],
-          specVersion: _i10.dummyValue<String>(
+          specVersion: _i9.dummyValue<String>(
             this,
             Invocation.method(
               #createAndDistributeBackup,
@@ -2050,11 +2039,11 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
               {#vaultId: vaultId},
             ),
           ),
-          status: _i13.BackupStatus.pending,
-          stewards: <_i14.Steward>[],
+          status: _i12.BackupStatus.pending,
+          stewards: <_i13.Steward>[],
           threshold: 0,
           totalKeys: 0,
-          vaultId: _i10.dummyValue<String>(
+          vaultId: _i9.dummyValue<String>(
             this,
             Invocation.method(
               #createAndDistributeBackup,
@@ -2074,8 +2063,8 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
             DateTime lastUpdated,
             List<String> relays,
             String specVersion,
-            _i13.BackupStatus status,
-            List<_i14.Steward> stewards,
+            _i12.BackupStatus status,
+            List<_i13.Steward> stewards,
             int threshold,
             int totalKeys,
             String vaultId

--- a/test/services/invitation_service_test.mocks.dart
+++ b/test/services/invitation_service_test.mocks.dart
@@ -5,21 +5,22 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i6;
 
-import 'package:horcrux/models/backup_status.dart' as _i12;
+import 'package:horcrux/models/backup_status.dart' as _i13;
+import 'package:horcrux/models/nostr_kinds.dart' as _i8;
 import 'package:horcrux/models/recovery_request.dart' as _i7;
-import 'package:horcrux/models/relay_configuration.dart' as _i17;
-import 'package:horcrux/models/shard_data.dart' as _i15;
-import 'package:horcrux/models/steward.dart' as _i13;
-import 'package:horcrux/models/steward_status.dart' as _i14;
-import 'package:horcrux/models/vault.dart' as _i11;
-import 'package:horcrux/providers/vault_provider.dart' as _i10;
-import 'package:horcrux/services/backup_service.dart' as _i18;
-import 'package:horcrux/services/invitation_sending_service.dart' as _i16;
-import 'package:horcrux/services/login_service.dart' as _i8;
+import 'package:horcrux/models/relay_configuration.dart' as _i18;
+import 'package:horcrux/models/shard_data.dart' as _i16;
+import 'package:horcrux/models/steward.dart' as _i14;
+import 'package:horcrux/models/steward_status.dart' as _i15;
+import 'package:horcrux/models/vault.dart' as _i12;
+import 'package:horcrux/providers/vault_provider.dart' as _i11;
+import 'package:horcrux/services/backup_service.dart' as _i19;
+import 'package:horcrux/services/invitation_sending_service.dart' as _i17;
+import 'package:horcrux/services/login_service.dart' as _i9;
 import 'package:horcrux/services/ndk_service.dart' as _i4;
 import 'package:horcrux/services/relay_scan_service.dart' as _i5;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i9;
+import 'package:mockito/src/dummies.dart' as _i10;
 import 'package:ndk/ndk.dart' as _i2;
 import 'package:ndk/shared/nips/nip01/key_pair.dart' as _i3;
 
@@ -179,14 +180,15 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
       ) as _i6.Future<String?>);
 
   @override
-  _i6.Future<String?> resolveRecoveryRequestIdForGiftWrap(_i2.Nip01Event? giftWrap) =>
+  _i6.Future<({_i8.NostrKind kind, String recoveryRequestId})?> resolveRecoveryRequestIdForGiftWrap(
+          _i2.Nip01Event? giftWrap) =>
       (super.noSuchMethod(
         Invocation.method(
           #resolveRecoveryRequestIdForGiftWrap,
           [giftWrap],
         ),
-        returnValue: _i6.Future<String?>.value(),
-      ) as _i6.Future<String?>);
+        returnValue: _i6.Future<({_i8.NostrKind kind, String recoveryRequestId})?>.value(),
+      ) as _i6.Future<({_i8.NostrKind kind, String recoveryRequestId})?>);
 
   @override
   _i6.Future<String?> publishRecoveryRequest({
@@ -344,7 +346,7 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
 /// A class which mocks [LoginService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockLoginService extends _i1.Mock implements _i8.LoginService {
+class MockLoginService extends _i1.Mock implements _i9.LoginService {
   MockLoginService() {
     _i1.throwOnMissingStub(this);
   }
@@ -442,7 +444,7 @@ class MockLoginService extends _i1.Mock implements _i8.LoginService {
           #encryptText,
           [plaintext],
         ),
-        returnValue: _i6.Future<String>.value(_i9.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i10.dummyValue<String>(
           this,
           Invocation.method(
             #encryptText,
@@ -457,7 +459,7 @@ class MockLoginService extends _i1.Mock implements _i8.LoginService {
           #decryptText,
           [encryptedText],
         ),
-        returnValue: _i6.Future<String>.value(_i9.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i10.dummyValue<String>(
           this,
           Invocation.method(
             #decryptText,
@@ -505,7 +507,7 @@ class MockLoginService extends _i1.Mock implements _i8.LoginService {
             #recipientPubkey: recipientPubkey,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i9.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i10.dummyValue<String>(
           this,
           Invocation.method(
             #encryptForRecipient,
@@ -532,7 +534,7 @@ class MockLoginService extends _i1.Mock implements _i8.LoginService {
             #senderPubkey: senderPubkey,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i9.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i10.dummyValue<String>(
           this,
           Invocation.method(
             #decryptFromSender,
@@ -549,16 +551,16 @@ class MockLoginService extends _i1.Mock implements _i8.LoginService {
 /// A class which mocks [VaultRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockVaultRepository extends _i1.Mock implements _i10.VaultRepository {
+class MockVaultRepository extends _i1.Mock implements _i11.VaultRepository {
   MockVaultRepository() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i6.Stream<List<_i11.Vault>> get vaultsStream => (super.noSuchMethod(
+  _i6.Stream<List<_i12.Vault>> get vaultsStream => (super.noSuchMethod(
         Invocation.getter(#vaultsStream),
-        returnValue: _i6.Stream<List<_i11.Vault>>.empty(),
-      ) as _i6.Stream<List<_i11.Vault>>);
+        returnValue: _i6.Stream<List<_i12.Vault>>.empty(),
+      ) as _i6.Stream<List<_i12.Vault>>);
 
   @override
   _i6.Future<void> initialize() => (super.noSuchMethod(
@@ -571,25 +573,25 @@ class MockVaultRepository extends _i1.Mock implements _i10.VaultRepository {
       ) as _i6.Future<void>);
 
   @override
-  _i6.Future<List<_i11.Vault>> getAllVaults() => (super.noSuchMethod(
+  _i6.Future<List<_i12.Vault>> getAllVaults() => (super.noSuchMethod(
         Invocation.method(
           #getAllVaults,
           [],
         ),
-        returnValue: _i6.Future<List<_i11.Vault>>.value(<_i11.Vault>[]),
-      ) as _i6.Future<List<_i11.Vault>>);
+        returnValue: _i6.Future<List<_i12.Vault>>.value(<_i12.Vault>[]),
+      ) as _i6.Future<List<_i12.Vault>>);
 
   @override
-  _i6.Future<_i11.Vault?> getVault(String? id) => (super.noSuchMethod(
+  _i6.Future<_i12.Vault?> getVault(String? id) => (super.noSuchMethod(
         Invocation.method(
           #getVault,
           [id],
         ),
-        returnValue: _i6.Future<_i11.Vault?>.value(),
-      ) as _i6.Future<_i11.Vault?>);
+        returnValue: _i6.Future<_i12.Vault?>.value(),
+      ) as _i6.Future<_i12.Vault?>);
 
   @override
-  _i6.Future<void> saveVault(_i11.Vault? vault) => (super.noSuchMethod(
+  _i6.Future<void> saveVault(_i12.Vault? vault) => (super.noSuchMethod(
         Invocation.method(
           #saveVault,
           [vault],
@@ -599,7 +601,7 @@ class MockVaultRepository extends _i1.Mock implements _i10.VaultRepository {
       ) as _i6.Future<void>);
 
   @override
-  _i6.Future<void> addVault(_i11.Vault? vault) => (super.noSuchMethod(
+  _i6.Future<void> addVault(_i12.Vault? vault) => (super.noSuchMethod(
         Invocation.method(
           #addVault,
           [vault],
@@ -687,8 +689,8 @@ class MockVaultRepository extends _i1.Mock implements _i10.VaultRepository {
       DateTime lastUpdated,
       List<String> relays,
       String specVersion,
-      _i12.BackupStatus status,
-      List<_i13.Steward> stewards,
+      _i13.BackupStatus status,
+      List<_i14.Steward> stewards,
       int threshold,
       int totalKeys,
       String vaultId
@@ -718,8 +720,8 @@ class MockVaultRepository extends _i1.Mock implements _i10.VaultRepository {
         DateTime lastUpdated,
         List<String> relays,
         String specVersion,
-        _i12.BackupStatus status,
-        List<_i13.Steward> stewards,
+        _i13.BackupStatus status,
+        List<_i14.Steward> stewards,
         int threshold,
         int totalKeys,
         String vaultId
@@ -739,8 +741,8 @@ class MockVaultRepository extends _i1.Mock implements _i10.VaultRepository {
               DateTime lastUpdated,
               List<String> relays,
               String specVersion,
-              _i12.BackupStatus status,
-              List<_i13.Steward> stewards,
+              _i13.BackupStatus status,
+              List<_i14.Steward> stewards,
               int threshold,
               int totalKeys,
               String vaultId
@@ -756,8 +758,8 @@ class MockVaultRepository extends _i1.Mock implements _i10.VaultRepository {
             DateTime lastUpdated,
             List<String> relays,
             String specVersion,
-            _i12.BackupStatus status,
-            List<_i13.Steward> stewards,
+            _i13.BackupStatus status,
+            List<_i14.Steward> stewards,
             int threshold,
             int totalKeys,
             String vaultId
@@ -767,7 +769,7 @@ class MockVaultRepository extends _i1.Mock implements _i10.VaultRepository {
   _i6.Future<void> updateStewardStatus({
     required String? vaultId,
     required String? pubkey,
-    required _i14.StewardStatus? status,
+    required _i15.StewardStatus? status,
     DateTime? acknowledgedAt,
     String? acknowledgmentEventId,
     int? acknowledgedDistributionVersion,
@@ -792,7 +794,7 @@ class MockVaultRepository extends _i1.Mock implements _i10.VaultRepository {
   @override
   _i6.Future<void> addShardToVault(
     String? vaultId,
-    _i15.ShardData? shard,
+    _i16.ShardData? shard,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -807,13 +809,13 @@ class MockVaultRepository extends _i1.Mock implements _i10.VaultRepository {
       ) as _i6.Future<void>);
 
   @override
-  _i6.Future<List<_i15.ShardData>> getShardsForVault(String? vaultId) => (super.noSuchMethod(
+  _i6.Future<List<_i16.ShardData>> getShardsForVault(String? vaultId) => (super.noSuchMethod(
         Invocation.method(
           #getShardsForVault,
           [vaultId],
         ),
-        returnValue: _i6.Future<List<_i15.ShardData>>.value(<_i15.ShardData>[]),
-      ) as _i6.Future<List<_i15.ShardData>>);
+        returnValue: _i6.Future<List<_i16.ShardData>>.value(<_i16.ShardData>[]),
+      ) as _i6.Future<List<_i16.ShardData>>);
 
   @override
   _i6.Future<void> clearShardsForVault(String? vaultId) => (super.noSuchMethod(
@@ -921,7 +923,7 @@ class MockVaultRepository extends _i1.Mock implements _i10.VaultRepository {
 /// A class which mocks [InvitationSendingService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockInvitationSendingService extends _i1.Mock implements _i16.InvitationSendingService {
+class MockInvitationSendingService extends _i1.Mock implements _i17.InvitationSendingService {
   MockInvitationSendingService() {
     _i1.throwOnMissingStub(this);
   }
@@ -1090,28 +1092,28 @@ class MockRelayScanService extends _i1.Mock implements _i5.RelayScanService {
       ) as _i6.Future<void>);
 
   @override
-  _i6.Future<List<_i17.RelayConfiguration>> getRelayConfigurations({bool? enabledOnly}) =>
+  _i6.Future<List<_i18.RelayConfiguration>> getRelayConfigurations({bool? enabledOnly}) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRelayConfigurations,
           [],
           {#enabledOnly: enabledOnly},
         ),
-        returnValue: _i6.Future<List<_i17.RelayConfiguration>>.value(<_i17.RelayConfiguration>[]),
-      ) as _i6.Future<List<_i17.RelayConfiguration>>);
+        returnValue: _i6.Future<List<_i18.RelayConfiguration>>.value(<_i18.RelayConfiguration>[]),
+      ) as _i6.Future<List<_i18.RelayConfiguration>>);
 
   @override
-  _i6.Future<_i17.RelayConfiguration?> getRelayConfiguration(String? relayId) =>
+  _i6.Future<_i18.RelayConfiguration?> getRelayConfiguration(String? relayId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRelayConfiguration,
           [relayId],
         ),
-        returnValue: _i6.Future<_i17.RelayConfiguration?>.value(),
-      ) as _i6.Future<_i17.RelayConfiguration?>);
+        returnValue: _i6.Future<_i18.RelayConfiguration?>.value(),
+      ) as _i6.Future<_i18.RelayConfiguration?>);
 
   @override
-  _i6.Future<void> addRelayConfiguration(_i17.RelayConfiguration? relay) => (super.noSuchMethod(
+  _i6.Future<void> addRelayConfiguration(_i18.RelayConfiguration? relay) => (super.noSuchMethod(
         Invocation.method(
           #addRelayConfiguration,
           [relay],
@@ -1121,7 +1123,7 @@ class MockRelayScanService extends _i1.Mock implements _i5.RelayScanService {
       ) as _i6.Future<void>);
 
   @override
-  _i6.Future<void> updateRelayConfiguration(_i17.RelayConfiguration? relay) => (super.noSuchMethod(
+  _i6.Future<void> updateRelayConfiguration(_i18.RelayConfiguration? relay) => (super.noSuchMethod(
         Invocation.method(
           #updateRelayConfiguration,
           [relay],
@@ -1239,7 +1241,7 @@ class MockRelayScanService extends _i1.Mock implements _i5.RelayScanService {
 /// A class which mocks [BackupService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockBackupService extends _i1.Mock implements _i18.BackupService {
+class MockBackupService extends _i1.Mock implements _i19.BackupService {
   MockBackupService() {
     _i1.throwOnMissingStub(this);
   }
@@ -1256,8 +1258,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
         DateTime lastUpdated,
         List<String> relays,
         String specVersion,
-        _i12.BackupStatus status,
-        List<_i13.Steward> stewards,
+        _i13.BackupStatus status,
+        List<_i14.Steward> stewards,
         int threshold,
         int totalKeys,
         String vaultId
@@ -1265,7 +1267,7 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
     required String? vaultId,
     required int? threshold,
     required int? totalKeys,
-    required List<_i13.Steward>? stewards,
+    required List<_i14.Steward>? stewards,
     required List<String>? relays,
     String? instructions,
     String? contentHash,
@@ -1295,8 +1297,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
               DateTime lastUpdated,
               List<String> relays,
               String specVersion,
-              _i12.BackupStatus status,
-              List<_i13.Steward> stewards,
+              _i13.BackupStatus status,
+              List<_i14.Steward> stewards,
               int threshold,
               int totalKeys,
               String vaultId
@@ -1339,7 +1341,7 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
             ),
           ),
           relays: <String>[],
-          specVersion: _i9.dummyValue<String>(
+          specVersion: _i10.dummyValue<String>(
             this,
             Invocation.method(
               #createBackupConfiguration,
@@ -1355,11 +1357,11 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
               },
             ),
           ),
-          status: _i12.BackupStatus.pending,
-          stewards: <_i13.Steward>[],
+          status: _i13.BackupStatus.pending,
+          stewards: <_i14.Steward>[],
           threshold: 0,
           totalKeys: 0,
-          vaultId: _i9.dummyValue<String>(
+          vaultId: _i10.dummyValue<String>(
             this,
             Invocation.method(
               #createBackupConfiguration,
@@ -1387,8 +1389,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
             DateTime lastUpdated,
             List<String> relays,
             String specVersion,
-            _i12.BackupStatus status,
-            List<_i13.Steward> stewards,
+            _i13.BackupStatus status,
+            List<_i14.Steward> stewards,
             int threshold,
             int totalKeys,
             String vaultId
@@ -1406,8 +1408,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
         DateTime lastUpdated,
         List<String> relays,
         String specVersion,
-        _i12.BackupStatus status,
-        List<_i13.Steward> stewards,
+        _i13.BackupStatus status,
+        List<_i14.Steward> stewards,
         int threshold,
         int totalKeys,
         String vaultId
@@ -1427,8 +1429,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
               DateTime lastUpdated,
               List<String> relays,
               String specVersion,
-              _i12.BackupStatus status,
-              List<_i13.Steward> stewards,
+              _i13.BackupStatus status,
+              List<_i14.Steward> stewards,
               int threshold,
               int totalKeys,
               String vaultId
@@ -1444,8 +1446,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
             DateTime lastUpdated,
             List<String> relays,
             String specVersion,
-            _i12.BackupStatus status,
-            List<_i13.Steward> stewards,
+            _i13.BackupStatus status,
+            List<_i14.Steward> stewards,
             int threshold,
             int totalKeys,
             String vaultId
@@ -1464,8 +1466,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
             DateTime lastUpdated,
             List<String> relays,
             String specVersion,
-            _i12.BackupStatus status,
-            List<_i13.Steward> stewards,
+            _i13.BackupStatus status,
+            List<_i14.Steward> stewards,
             int threshold,
             int totalKeys,
             String vaultId
@@ -1486,8 +1488,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
                   DateTime lastUpdated,
                   List<String> relays,
                   String specVersion,
-                  _i12.BackupStatus status,
-                  List<_i13.Steward> stewards,
+                  _i13.BackupStatus status,
+                  List<_i14.Steward> stewards,
                   int threshold,
                   int totalKeys,
                   String vaultId
@@ -1501,8 +1503,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
           DateTime lastUpdated,
           List<String> relays,
           String specVersion,
-          _i12.BackupStatus status,
-          List<_i13.Steward> stewards,
+          _i13.BackupStatus status,
+          List<_i14.Steward> stewards,
           int threshold,
           int totalKeys,
           String vaultId
@@ -1519,8 +1521,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
                 DateTime lastUpdated,
                 List<String> relays,
                 String specVersion,
-                _i12.BackupStatus status,
-                List<_i13.Steward> stewards,
+                _i13.BackupStatus status,
+                List<_i14.Steward> stewards,
                 int threshold,
                 int totalKeys,
                 String vaultId
@@ -1538,8 +1540,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
             DateTime lastUpdated,
             List<String> relays,
             String specVersion,
-            _i12.BackupStatus status,
-            List<_i13.Steward> stewards,
+            _i13.BackupStatus status,
+            List<_i14.Steward> stewards,
             int threshold,
             int totalKeys,
             String vaultId
@@ -1564,7 +1566,7 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
       ) as _i6.Future<void>);
 
   @override
-  _i6.Future<List<_i15.ShardData>> generateShamirShares({
+  _i6.Future<List<_i16.ShardData>> generateShamirShares({
     required String? content,
     required int? threshold,
     required int? totalShards,
@@ -1593,18 +1595,18 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
             #pushEnabled: pushEnabled,
           },
         ),
-        returnValue: _i6.Future<List<_i15.ShardData>>.value(<_i15.ShardData>[]),
-      ) as _i6.Future<List<_i15.ShardData>>);
+        returnValue: _i6.Future<List<_i16.ShardData>>.value(<_i16.ShardData>[]),
+      ) as _i6.Future<List<_i16.ShardData>>);
 
   @override
-  _i6.Future<String> reconstructFromShares({required List<_i15.ShardData>? shares}) =>
+  _i6.Future<String> reconstructFromShares({required List<_i16.ShardData>? shares}) =>
       (super.noSuchMethod(
         Invocation.method(
           #reconstructFromShares,
           [],
           {#shares: shares},
         ),
-        returnValue: _i6.Future<String>.value(_i9.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i10.dummyValue<String>(
           this,
           Invocation.method(
             #reconstructFromShares,
@@ -1617,7 +1619,7 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
   @override
   _i6.Future<void> updateBackupStatus(
     String? vaultId,
-    _i12.BackupStatus? status,
+    _i13.BackupStatus? status,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1635,7 +1637,7 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
   _i6.Future<void> updateStewardStatus({
     required String? vaultId,
     required String? pubkey,
-    required _i14.StewardStatus? status,
+    required _i15.StewardStatus? status,
     DateTime? acknowledgedAt,
     String? acknowledgmentEventId,
   }) =>
@@ -1676,15 +1678,15 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
         DateTime lastUpdated,
         List<String> relays,
         String specVersion,
-        _i12.BackupStatus status,
-        List<_i13.Steward> stewards,
+        _i13.BackupStatus status,
+        List<_i14.Steward> stewards,
         int threshold,
         int totalKeys,
         String vaultId
       })> mergeBackupConfig({
     required String? vaultId,
     int? threshold,
-    List<_i13.Steward>? stewards,
+    List<_i14.Steward>? stewards,
     List<String>? relays,
     String? instructions,
   }) =>
@@ -1711,8 +1713,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
               DateTime lastUpdated,
               List<String> relays,
               String specVersion,
-              _i12.BackupStatus status,
-              List<_i13.Steward> stewards,
+              _i13.BackupStatus status,
+              List<_i14.Steward> stewards,
               int threshold,
               int totalKeys,
               String vaultId
@@ -1751,7 +1753,7 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
             ),
           ),
           relays: <String>[],
-          specVersion: _i9.dummyValue<String>(
+          specVersion: _i10.dummyValue<String>(
             this,
             Invocation.method(
               #mergeBackupConfig,
@@ -1765,11 +1767,11 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
               },
             ),
           ),
-          status: _i12.BackupStatus.pending,
-          stewards: <_i13.Steward>[],
+          status: _i13.BackupStatus.pending,
+          stewards: <_i14.Steward>[],
           threshold: 0,
           totalKeys: 0,
-          vaultId: _i9.dummyValue<String>(
+          vaultId: _i10.dummyValue<String>(
             this,
             Invocation.method(
               #mergeBackupConfig,
@@ -1795,8 +1797,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
             DateTime lastUpdated,
             List<String> relays,
             String specVersion,
-            _i12.BackupStatus status,
-            List<_i13.Steward> stewards,
+            _i13.BackupStatus status,
+            List<_i14.Steward> stewards,
             int threshold,
             int totalKeys,
             String vaultId
@@ -1846,8 +1848,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
         DateTime lastUpdated,
         List<String> relays,
         String specVersion,
-        _i12.BackupStatus status,
-        List<_i13.Steward> stewards,
+        _i13.BackupStatus status,
+        List<_i14.Steward> stewards,
         int threshold,
         int totalKeys,
         String vaultId
@@ -1855,7 +1857,7 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
     required String? vaultId,
     required int? threshold,
     required int? totalKeys,
-    required List<_i13.Steward>? stewards,
+    required List<_i14.Steward>? stewards,
     required List<String>? relays,
     String? instructions,
   }) =>
@@ -1883,8 +1885,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
               DateTime lastUpdated,
               List<String> relays,
               String specVersion,
-              _i12.BackupStatus status,
-              List<_i13.Steward> stewards,
+              _i13.BackupStatus status,
+              List<_i14.Steward> stewards,
               int threshold,
               int totalKeys,
               String vaultId
@@ -1925,7 +1927,7 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
             ),
           ),
           relays: <String>[],
-          specVersion: _i9.dummyValue<String>(
+          specVersion: _i10.dummyValue<String>(
             this,
             Invocation.method(
               #saveBackupConfig,
@@ -1940,11 +1942,11 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
               },
             ),
           ),
-          status: _i12.BackupStatus.pending,
-          stewards: <_i13.Steward>[],
+          status: _i13.BackupStatus.pending,
+          stewards: <_i14.Steward>[],
           threshold: 0,
           totalKeys: 0,
-          vaultId: _i9.dummyValue<String>(
+          vaultId: _i10.dummyValue<String>(
             this,
             Invocation.method(
               #saveBackupConfig,
@@ -1971,8 +1973,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
             DateTime lastUpdated,
             List<String> relays,
             String specVersion,
-            _i12.BackupStatus status,
-            List<_i13.Steward> stewards,
+            _i13.BackupStatus status,
+            List<_i14.Steward> stewards,
             int threshold,
             int totalKeys,
             String vaultId
@@ -1990,8 +1992,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
         DateTime lastUpdated,
         List<String> relays,
         String specVersion,
-        _i12.BackupStatus status,
-        List<_i13.Steward> stewards,
+        _i13.BackupStatus status,
+        List<_i14.Steward> stewards,
         int threshold,
         int totalKeys,
         String vaultId
@@ -2012,8 +2014,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
               DateTime lastUpdated,
               List<String> relays,
               String specVersion,
-              _i12.BackupStatus status,
-              List<_i13.Steward> stewards,
+              _i13.BackupStatus status,
+              List<_i14.Steward> stewards,
               int threshold,
               int totalKeys,
               String vaultId
@@ -2040,7 +2042,7 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
             ),
           ),
           relays: <String>[],
-          specVersion: _i9.dummyValue<String>(
+          specVersion: _i10.dummyValue<String>(
             this,
             Invocation.method(
               #createAndDistributeBackup,
@@ -2048,11 +2050,11 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
               {#vaultId: vaultId},
             ),
           ),
-          status: _i12.BackupStatus.pending,
-          stewards: <_i13.Steward>[],
+          status: _i13.BackupStatus.pending,
+          stewards: <_i14.Steward>[],
           threshold: 0,
           totalKeys: 0,
-          vaultId: _i9.dummyValue<String>(
+          vaultId: _i10.dummyValue<String>(
             this,
             Invocation.method(
               #createAndDistributeBackup,
@@ -2072,8 +2074,8 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
             DateTime lastUpdated,
             List<String> relays,
             String specVersion,
-            _i12.BackupStatus status,
-            List<_i13.Steward> stewards,
+            _i13.BackupStatus status,
+            List<_i14.Steward> stewards,
             int threshold,
             int totalKeys,
             String vaultId

--- a/test/services/invitation_service_test.mocks.dart
+++ b/test/services/invitation_service_test.mocks.dart
@@ -198,27 +198,6 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
       ) as _i6.Future<String?>);
 
   @override
-  _i6.Future<String?> publishRecoveryResponse({
-    required String? initiatorPubkey,
-    required String? recoveryRequestId,
-    required bool? approved,
-    String? shardDataJson,
-  }) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #publishRecoveryResponse,
-          [],
-          {
-            #initiatorPubkey: initiatorPubkey,
-            #recoveryRequestId: recoveryRequestId,
-            #approved: approved,
-            #shardDataJson: shardDataJson,
-          },
-        ),
-        returnValue: _i6.Future<String?>.value(),
-      ) as _i6.Future<String?>);
-
-  @override
   _i6.Future<void> closeSubscriptions() => (super.noSuchMethod(
         Invocation.method(
           #closeSubscriptions,

--- a/test/services/recovery_service_test.dart
+++ b/test/services/recovery_service_test.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
@@ -84,14 +83,6 @@ void main() {
         mockLocalNotificationService.notifyRecoveryResponseProcessed(any),
       ).thenAnswer((_) async {});
 
-      // Stub the streams that RecoveryService accesses in its constructor
-      when(
-        mockNdkService.recoveryRequestStream,
-      ).thenAnswer((_) => const Stream<RecoveryRequest>.empty());
-      when(
-        mockNdkService.recoveryResponseStream,
-      ).thenAnswer((_) => const Stream<RecoveryResponseEvent>.empty());
-      // Stub getCurrentPubkey to return the test creator pubkey
       when(
         mockNdkService.getCurrentPubkey(),
       ).thenAnswer((_) async => testCreatorPubkey);

--- a/test/services/recovery_service_test.mocks.dart
+++ b/test/services/recovery_service_test.mocks.dart
@@ -1294,14 +1294,14 @@ class MockNdkService extends _i1.Mock implements _i13.NdkService {
       ) as _i5.Future<String?>);
 
   @override
-  _i5.Future<String?> resolveRecoveryRequestIdForGiftWrap(_i2.Nip01Event? giftWrap) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #resolveRecoveryRequestIdForGiftWrap,
-          [giftWrap],
-        ),
-        returnValue: _i5.Future<String?>.value(),
-      ) as _i5.Future<String?>);
+  _i5.Future<({_i14.NostrKind kind, String recoveryRequestId})?>
+      resolveRecoveryRequestIdForGiftWrap(_i2.Nip01Event? giftWrap) => (super.noSuchMethod(
+            Invocation.method(
+              #resolveRecoveryRequestIdForGiftWrap,
+              [giftWrap],
+            ),
+            returnValue: _i5.Future<({_i14.NostrKind kind, String recoveryRequestId})?>.value(),
+          ) as _i5.Future<({_i14.NostrKind kind, String recoveryRequestId})?>);
 
   @override
   _i5.Future<String?> publishRecoveryRequest({

--- a/test/services/recovery_service_test.mocks.dart
+++ b/test/services/recovery_service_test.mocks.dart
@@ -1210,18 +1210,6 @@ class MockNdkService extends _i1.Mock implements _i13.NdkService {
   }
 
   @override
-  _i5.Stream<_i12.RecoveryRequest> get recoveryRequestStream => (super.noSuchMethod(
-        Invocation.getter(#recoveryRequestStream),
-        returnValue: _i5.Stream<_i12.RecoveryRequest>.empty(),
-      ) as _i5.Stream<_i12.RecoveryRequest>);
-
-  @override
-  _i5.Stream<_i13.RecoveryResponseEvent> get recoveryResponseStream => (super.noSuchMethod(
-        Invocation.getter(#recoveryResponseStream),
-        returnValue: _i5.Stream<_i13.RecoveryResponseEvent>.empty(),
-      ) as _i5.Stream<_i13.RecoveryResponseEvent>);
-
-  @override
   bool get isInitialized => (super.noSuchMethod(
         Invocation.getter(#isInitialized),
         returnValue: false,

--- a/test/services/recovery_service_test.mocks.dart
+++ b/test/services/recovery_service_test.mocks.dart
@@ -962,24 +962,6 @@ class MockLocalNotificationService extends _i1.Mock implements _i11.LocalNotific
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> notifyShardDataProcessed({
-    required _i2.Nip01Event? event,
-    required _i9.ShardData? shardData,
-  }) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #notifyShardDataProcessed,
-          [],
-          {
-            #event: event,
-            #shardData: shardData,
-          },
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
   _i5.Future<void> notifyShardConfirmationProcessed({
     required _i2.Nip01Event? event,
     required String? vaultId,
@@ -1305,27 +1287,6 @@ class MockNdkService extends _i1.Mock implements _i13.NdkService {
             #vaultId: vaultId,
             #stewardPubkeys: stewardPubkeys,
             #expiresAt: expiresAt,
-          },
-        ),
-        returnValue: _i5.Future<String?>.value(),
-      ) as _i5.Future<String?>);
-
-  @override
-  _i5.Future<String?> publishRecoveryResponse({
-    required String? initiatorPubkey,
-    required String? recoveryRequestId,
-    required bool? approved,
-    String? shardDataJson,
-  }) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #publishRecoveryResponse,
-          [],
-          {
-            #initiatorPubkey: initiatorPubkey,
-            #recoveryRequestId: recoveryRequestId,
-            #approved: approved,
-            #shardDataJson: shardDataJson,
           },
         ),
         returnValue: _i5.Future<String?>.value(),

--- a/test/services/shard_distribution_service_test.mocks.dart
+++ b/test/services/shard_distribution_service_test.mocks.dart
@@ -1238,18 +1238,6 @@ class MockNdkService extends _i1.Mock implements _i15.NdkService {
   }
 
   @override
-  _i4.Stream<_i13.RecoveryRequest> get recoveryRequestStream => (super.noSuchMethod(
-        Invocation.getter(#recoveryRequestStream),
-        returnValue: _i4.Stream<_i13.RecoveryRequest>.empty(),
-      ) as _i4.Stream<_i13.RecoveryRequest>);
-
-  @override
-  _i4.Stream<_i15.RecoveryResponseEvent> get recoveryResponseStream => (super.noSuchMethod(
-        Invocation.getter(#recoveryResponseStream),
-        returnValue: _i4.Stream<_i15.RecoveryResponseEvent>.empty(),
-      ) as _i4.Stream<_i15.RecoveryResponseEvent>);
-
-  @override
   bool get isInitialized => (super.noSuchMethod(
         Invocation.getter(#isInitialized),
         returnValue: false,

--- a/test/services/shard_distribution_service_test.mocks.dart
+++ b/test/services/shard_distribution_service_test.mocks.dart
@@ -6,14 +6,14 @@
 import 'dart:async' as _i4;
 
 import 'package:horcrux/models/backup_status.dart' as _i9;
-import 'package:horcrux/models/nostr_kinds.dart' as _i17;
+import 'package:horcrux/models/nostr_kinds.dart' as _i16;
 import 'package:horcrux/models/recovery_request.dart' as _i13;
 import 'package:horcrux/models/shard_data.dart' as _i12;
 import 'package:horcrux/models/steward.dart' as _i10;
 import 'package:horcrux/models/steward_status.dart' as _i11;
 import 'package:horcrux/models/vault.dart' as _i8;
 import 'package:horcrux/providers/vault_provider.dart' as _i7;
-import 'package:horcrux/services/horcrux_notification_service.dart' as _i16;
+import 'package:horcrux/services/horcrux_notification_service.dart' as _i17;
 import 'package:horcrux/services/login_service.dart' as _i14;
 import 'package:horcrux/services/ndk_service.dart' as _i15;
 import 'package:mockito/mockito.dart' as _i1;
@@ -1322,14 +1322,14 @@ class MockNdkService extends _i1.Mock implements _i15.NdkService {
       ) as _i4.Future<String?>);
 
   @override
-  _i4.Future<String?> resolveRecoveryRequestIdForGiftWrap(_i2.Nip01Event? giftWrap) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #resolveRecoveryRequestIdForGiftWrap,
-          [giftWrap],
-        ),
-        returnValue: _i4.Future<String?>.value(),
-      ) as _i4.Future<String?>);
+  _i4.Future<({_i16.NostrKind kind, String recoveryRequestId})?>
+      resolveRecoveryRequestIdForGiftWrap(_i2.Nip01Event? giftWrap) => (super.noSuchMethod(
+            Invocation.method(
+              #resolveRecoveryRequestIdForGiftWrap,
+              [giftWrap],
+            ),
+            returnValue: _i4.Future<({_i16.NostrKind kind, String recoveryRequestId})?>.value(),
+          ) as _i4.Future<({_i16.NostrKind kind, String recoveryRequestId})?>);
 
   @override
   _i4.Future<String?> publishRecoveryRequest({
@@ -1487,7 +1487,7 @@ class MockNdkService extends _i1.Mock implements _i15.NdkService {
 /// A class which mocks [HorcruxNotificationService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockHorcruxNotificationService extends _i1.Mock implements _i16.HorcruxNotificationService {
+class MockHorcruxNotificationService extends _i1.Mock implements _i17.HorcruxNotificationService {
   MockHorcruxNotificationService() {
     _i1.throwOnMissingStub(this);
   }
@@ -1520,7 +1520,7 @@ class MockHorcruxNotificationService extends _i1.Mock implements _i16.HorcruxNot
   @override
   _i4.Future<void> register({
     required String? fcmToken,
-    required _i16.NotifierPlatform? platform,
+    required _i17.NotifierPlatform? platform,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1548,7 +1548,7 @@ class MockHorcruxNotificationService extends _i1.Mock implements _i16.HorcruxNot
   @override
   _i4.Future<void> updateToken({
     required String? newToken,
-    required _i16.NotifierPlatform? platform,
+    required _i17.NotifierPlatform? platform,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1613,7 +1613,7 @@ class MockHorcruxNotificationService extends _i1.Mock implements _i16.HorcruxNot
   @override
   _i4.Future<void> tryPushForEvent({
     required _i2.Nip01Event? event,
-    required _i17.NostrKind? kind,
+    required _i16.NostrKind? kind,
     required _i8.Vault? vault,
     List<String>? relayHints,
     bool? recoveryApproved,

--- a/test/services/shard_distribution_service_test.mocks.dart
+++ b/test/services/shard_distribution_service_test.mocks.dart
@@ -1339,27 +1339,6 @@ class MockNdkService extends _i1.Mock implements _i15.NdkService {
       ) as _i4.Future<String?>);
 
   @override
-  _i4.Future<String?> publishRecoveryResponse({
-    required String? initiatorPubkey,
-    required String? recoveryRequestId,
-    required bool? approved,
-    String? shardDataJson,
-  }) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #publishRecoveryResponse,
-          [],
-          {
-            #initiatorPubkey: initiatorPubkey,
-            #recoveryRequestId: recoveryRequestId,
-            #approved: approved,
-            #shardDataJson: shardDataJson,
-          },
-        ),
-        returnValue: _i4.Future<String?>.value(),
-      ) as _i4.Future<String?>);
-
-  @override
   _i4.Future<void> closeSubscriptions() => (super.noSuchMethod(
         Invocation.method(
           #closeSubscriptions,

--- a/test/services/vault_share_service_test.mocks.dart
+++ b/test/services/vault_share_service_test.mocks.dart
@@ -5,10 +5,10 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
 
-import 'package:horcrux/models/nostr_kinds.dart' as _i11;
+import 'package:horcrux/models/nostr_kinds.dart' as _i9;
 import 'package:horcrux/models/recovery_request.dart' as _i8;
-import 'package:horcrux/models/vault.dart' as _i10;
-import 'package:horcrux/services/horcrux_notification_service.dart' as _i9;
+import 'package:horcrux/models/vault.dart' as _i11;
+import 'package:horcrux/services/horcrux_notification_service.dart' as _i10;
 import 'package:horcrux/services/login_service.dart' as _i4;
 import 'package:horcrux/services/ndk_service.dart' as _i7;
 import 'package:horcrux/services/push_notification_receiver.dart' as _i12;
@@ -348,14 +348,15 @@ class MockNdkService extends _i1.Mock implements _i7.NdkService {
       ) as _i5.Future<String?>);
 
   @override
-  _i5.Future<String?> resolveRecoveryRequestIdForGiftWrap(_i3.Nip01Event? giftWrap) =>
+  _i5.Future<({_i9.NostrKind kind, String recoveryRequestId})?> resolveRecoveryRequestIdForGiftWrap(
+          _i3.Nip01Event? giftWrap) =>
       (super.noSuchMethod(
         Invocation.method(
           #resolveRecoveryRequestIdForGiftWrap,
           [giftWrap],
         ),
-        returnValue: _i5.Future<String?>.value(),
-      ) as _i5.Future<String?>);
+        returnValue: _i5.Future<({_i9.NostrKind kind, String recoveryRequestId})?>.value(),
+      ) as _i5.Future<({_i9.NostrKind kind, String recoveryRequestId})?>);
 
   @override
   _i5.Future<String?> publishRecoveryRequest({
@@ -513,7 +514,7 @@ class MockNdkService extends _i1.Mock implements _i7.NdkService {
 /// A class which mocks [HorcruxNotificationService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockHorcruxNotificationService extends _i1.Mock implements _i9.HorcruxNotificationService {
+class MockHorcruxNotificationService extends _i1.Mock implements _i10.HorcruxNotificationService {
   MockHorcruxNotificationService() {
     _i1.throwOnMissingStub(this);
   }
@@ -546,7 +547,7 @@ class MockHorcruxNotificationService extends _i1.Mock implements _i9.HorcruxNoti
   @override
   _i5.Future<void> register({
     required String? fcmToken,
-    required _i9.NotifierPlatform? platform,
+    required _i10.NotifierPlatform? platform,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -574,7 +575,7 @@ class MockHorcruxNotificationService extends _i1.Mock implements _i9.HorcruxNoti
   @override
   _i5.Future<void> updateToken({
     required String? newToken,
-    required _i9.NotifierPlatform? platform,
+    required _i10.NotifierPlatform? platform,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -602,7 +603,7 @@ class MockHorcruxNotificationService extends _i1.Mock implements _i9.HorcruxNoti
   @override
   List<String> computeConsentList({
     required String? currentUserPubkey,
-    required List<_i10.Vault>? vaults,
+    required List<_i11.Vault>? vaults,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -639,8 +640,8 @@ class MockHorcruxNotificationService extends _i1.Mock implements _i9.HorcruxNoti
   @override
   _i5.Future<void> tryPushForEvent({
     required _i3.Nip01Event? event,
-    required _i11.NostrKind? kind,
-    required _i10.Vault? vault,
+    required _i9.NostrKind? kind,
+    required _i11.Vault? vault,
     List<String>? relayHints,
     bool? recoveryApproved,
   }) =>

--- a/test/services/vault_share_service_test.mocks.dart
+++ b/test/services/vault_share_service_test.mocks.dart
@@ -5,13 +5,12 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
 
-import 'package:horcrux/models/nostr_kinds.dart' as _i9;
-import 'package:horcrux/models/recovery_request.dart' as _i8;
-import 'package:horcrux/models/vault.dart' as _i11;
-import 'package:horcrux/services/horcrux_notification_service.dart' as _i10;
+import 'package:horcrux/models/nostr_kinds.dart' as _i8;
+import 'package:horcrux/models/vault.dart' as _i10;
+import 'package:horcrux/services/horcrux_notification_service.dart' as _i9;
 import 'package:horcrux/services/login_service.dart' as _i4;
 import 'package:horcrux/services/ndk_service.dart' as _i7;
-import 'package:horcrux/services/push_notification_receiver.dart' as _i12;
+import 'package:horcrux/services/push_notification_receiver.dart' as _i11;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i6;
 import 'package:ndk/ndk.dart' as _i3;
@@ -264,18 +263,6 @@ class MockNdkService extends _i1.Mock implements _i7.NdkService {
   }
 
   @override
-  _i5.Stream<_i8.RecoveryRequest> get recoveryRequestStream => (super.noSuchMethod(
-        Invocation.getter(#recoveryRequestStream),
-        returnValue: _i5.Stream<_i8.RecoveryRequest>.empty(),
-      ) as _i5.Stream<_i8.RecoveryRequest>);
-
-  @override
-  _i5.Stream<_i7.RecoveryResponseEvent> get recoveryResponseStream => (super.noSuchMethod(
-        Invocation.getter(#recoveryResponseStream),
-        returnValue: _i5.Stream<_i7.RecoveryResponseEvent>.empty(),
-      ) as _i5.Stream<_i7.RecoveryResponseEvent>);
-
-  @override
   bool get isInitialized => (super.noSuchMethod(
         Invocation.getter(#isInitialized),
         returnValue: false,
@@ -348,15 +335,15 @@ class MockNdkService extends _i1.Mock implements _i7.NdkService {
       ) as _i5.Future<String?>);
 
   @override
-  _i5.Future<({_i9.NostrKind kind, String recoveryRequestId})?> resolveRecoveryRequestIdForGiftWrap(
+  _i5.Future<({_i8.NostrKind kind, String recoveryRequestId})?> resolveRecoveryRequestIdForGiftWrap(
           _i3.Nip01Event? giftWrap) =>
       (super.noSuchMethod(
         Invocation.method(
           #resolveRecoveryRequestIdForGiftWrap,
           [giftWrap],
         ),
-        returnValue: _i5.Future<({_i9.NostrKind kind, String recoveryRequestId})?>.value(),
-      ) as _i5.Future<({_i9.NostrKind kind, String recoveryRequestId})?>);
+        returnValue: _i5.Future<({_i8.NostrKind kind, String recoveryRequestId})?>.value(),
+      ) as _i5.Future<({_i8.NostrKind kind, String recoveryRequestId})?>);
 
   @override
   _i5.Future<String?> publishRecoveryRequest({
@@ -514,7 +501,7 @@ class MockNdkService extends _i1.Mock implements _i7.NdkService {
 /// A class which mocks [HorcruxNotificationService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockHorcruxNotificationService extends _i1.Mock implements _i10.HorcruxNotificationService {
+class MockHorcruxNotificationService extends _i1.Mock implements _i9.HorcruxNotificationService {
   MockHorcruxNotificationService() {
     _i1.throwOnMissingStub(this);
   }
@@ -547,7 +534,7 @@ class MockHorcruxNotificationService extends _i1.Mock implements _i10.HorcruxNot
   @override
   _i5.Future<void> register({
     required String? fcmToken,
-    required _i10.NotifierPlatform? platform,
+    required _i9.NotifierPlatform? platform,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -575,7 +562,7 @@ class MockHorcruxNotificationService extends _i1.Mock implements _i10.HorcruxNot
   @override
   _i5.Future<void> updateToken({
     required String? newToken,
-    required _i10.NotifierPlatform? platform,
+    required _i9.NotifierPlatform? platform,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -603,7 +590,7 @@ class MockHorcruxNotificationService extends _i1.Mock implements _i10.HorcruxNot
   @override
   List<String> computeConsentList({
     required String? currentUserPubkey,
-    required List<_i11.Vault>? vaults,
+    required List<_i10.Vault>? vaults,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -640,8 +627,8 @@ class MockHorcruxNotificationService extends _i1.Mock implements _i10.HorcruxNot
   @override
   _i5.Future<void> tryPushForEvent({
     required _i3.Nip01Event? event,
-    required _i9.NostrKind? kind,
-    required _i11.Vault? vault,
+    required _i8.NostrKind? kind,
+    required _i10.Vault? vault,
     List<String>? relayHints,
     bool? recoveryApproved,
   }) =>
@@ -700,7 +687,7 @@ class MockHorcruxNotificationService extends _i1.Mock implements _i10.HorcruxNot
 /// A class which mocks [PushNotificationReceiver].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockPushNotificationReceiver extends _i1.Mock implements _i12.PushNotificationReceiver {
+class MockPushNotificationReceiver extends _i1.Mock implements _i11.PushNotificationReceiver {
   MockPushNotificationReceiver() {
     _i1.throwOnMissingStub(this);
   }

--- a/test/services/vault_share_service_test.mocks.dart
+++ b/test/services/vault_share_service_test.mocks.dart
@@ -365,27 +365,6 @@ class MockNdkService extends _i1.Mock implements _i7.NdkService {
       ) as _i5.Future<String?>);
 
   @override
-  _i5.Future<String?> publishRecoveryResponse({
-    required String? initiatorPubkey,
-    required String? recoveryRequestId,
-    required bool? approved,
-    String? shardDataJson,
-  }) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #publishRecoveryResponse,
-          [],
-          {
-            #initiatorPubkey: initiatorPubkey,
-            #recoveryRequestId: recoveryRequestId,
-            #approved: approved,
-            #shardDataJson: shardDataJson,
-          },
-        ),
-        returnValue: _i5.Future<String?>.value(),
-      ) as _i5.Future<String?>);
-
-  @override
   _i5.Future<void> closeSubscriptions() => (super.noSuchMethod(
         Invocation.method(
           #closeSubscriptions,


### PR DESCRIPTION
## Summary

- Tap-to-navigate for notifications: recovery requests open `RecoveryRequestDetailScreen`; recovery responses open `RecoveryStatusScreen` (falling back to the vault); shard data / shard confirmation open `VaultDetailScreen`. Works for both local notifications and push notification cold-start / foreground taps.
- Centralized navigation in `LocalNotificationService.navigateForKind`, shared by the local-notification tap handler and `PushNotificationReceiver`. Broke the resulting `LocalNotificationService` ↔ `RecoveryService` cycle with a lazy `getRecoveryService` callback.
- Replaced the `NdkService` event-stream subscriptions used to drive recovery notifications with direct calls into `LocalNotificationService` from the kind handlers, fixing dropped recovery pushes.
- Added `NdkService.resolveRecoveryRequestIdForGiftWrap` so the FCM tap path can navigate to the right recovery surface without re-decrypting downstream.
- Dropped the "Vault updated" local notification entirely. The shard-data handler only runs on the foreground path (relay delivery or FCM `onMessage`), where the user is already in-app and the update applies live; the OS-shown push from horcrux-notifier still covers the backgrounded case.

## Test plan

- [ ] Receive a recovery request → tap notification → lands on the request detail screen
- [ ] Receive a recovery response (approved and denied) → tap → lands on `RecoveryStatusScreen` for that request
- [ ] Same for cold-start (app killed) and foreground tap paths via FCM
- [ ] Receive a shard-data event while foregrounded → no "Vault updated" banner; vault still updates
- [ ] Receive a shard-data push while backgrounded → OS still shows "Vault updated"
- [ ] Receive a shard-confirmation event → "Steward confirmed" notification still appears, taps to vault detail
- [ ] `flutter analyze` clean, `flutter test` passes (incl. regenerated mocks)


Made with [Cursor](https://cursor.com)