### PR TITLE
Rename VaultState and vault owner check

### DIFF
--- a/lib/models/vault.dart
+++ b/lib/models/vault.dart
@@ -23,11 +23,15 @@ class VaultBackupConstraints {
   static const int defaultTotalKeys = 3;
 }
 
-/// Vault state enum indicating the current state of a vault
+/// Local vault material state for the current device (not who owns the vault).
+///
+/// - [unlocked]: decrypted vault content is present locally.
+/// - [holdingShard]: at least one shard is stored locally but content is not decrypted.
+/// - [awaitingShard]: no local content and no shards yet (e.g. invite accepted, shard not received).
 enum VaultState {
-  owned, // Has decrypted content
-  steward, // Has shard but no content
-  awaitingKey, // Invitee has accepted invitation but hasn't received shard yet
+  unlocked,
+  holdingShard,
+  awaitingShard,
 }
 
 /// Data model for a secure vault containing encrypted text content
@@ -62,27 +66,22 @@ class Vault with _$Vault {
 
   const Vault._();
 
-  /// Get the state of this vault based on priority:
-  /// 1. Owned (if has decrypted content)
-  /// 2. Steward (if has shards but no content)
-  /// 3. Awaiting key (if no content and no shards - invitee waiting for shard)
+  /// Derives [VaultState] from locally stored content and shards (see [VaultState]).
   ///
-  /// Note: Recovery state is user-specific (only for the initiator) and should be checked
-  /// using recoveryStatusProvider rather than vault.state, since the vault model doesn't
-  /// have access to the current user's context.
+  /// Recovery state is user-specific (only for the initiator) and should be checked with
+  /// [recoveryStatusProvider], not here.
   VaultState get state {
     if (content != null) {
-      return VaultState.owned;
+      return VaultState.unlocked;
     }
     if (shards.isNotEmpty) {
-      return VaultState.steward;
+      return VaultState.holdingShard;
     }
-    // No content and no shards - invitee is awaiting key distribution
-    return VaultState.awaitingKey;
+    return VaultState.awaitingShard;
   }
 
-  /// Check if the given hex key is the owner of this vault
-  bool isOwned(String hexKey) => ownerPubkey == hexKey;
+  /// Whether [hexPubkey] (hex-encoded Nostr public key) is this vault's owner.
+  bool isVaultOwner(String hexPubkey) => ownerPubkey == hexPubkey;
 
   /// Check if we are a steward for this vault (have shards)
   bool get isSteward => shards.isNotEmpty;

--- a/lib/screens/practice_recovery_info_screen.dart
+++ b/lib/screens/practice_recovery_info_screen.dart
@@ -44,7 +44,7 @@ class PracticeRecoveryInfoScreen extends ConsumerWidget {
             error: (error, stack) => Center(child: Text('Error loading user: $error')),
             data: (currentPubkey) {
               // Verify user is owner
-              if (currentPubkey == null || !vault.isOwned(currentPubkey)) {
+              if (currentPubkey == null || !vault.isVaultOwner(currentPubkey)) {
                 return const Center(
                   child: Padding(
                     padding: EdgeInsets.all(16.0),

--- a/lib/screens/vault_detail_screen.dart
+++ b/lib/screens/vault_detail_screen.dart
@@ -124,9 +124,9 @@ class _VaultDetailScreenState extends ConsumerState<VaultDetailScreen> {
             loading: () => const SizedBox.shrink(),
             error: (_, __) => const SizedBox.shrink(),
             data: (currentPubkey) {
-              final isOwned = currentPubkey != null && vault.isOwned(currentPubkey);
+              final isVaultOwner = currentPubkey != null && vault.isVaultOwner(currentPubkey);
               final canRedistribute =
-                  isOwned && vault.backupConfig != null && vault.backupConfig!.stewards.isNotEmpty;
+                  isVaultOwner && vault.backupConfig != null && vault.backupConfig!.stewards.isNotEmpty;
 
               return PopupMenuButton<String>(
                 itemBuilder: (context) {
@@ -179,7 +179,7 @@ class _VaultDetailScreenState extends ConsumerState<VaultDetailScreen> {
           // Determine background color based on vault state
           // We are doing some stupidly complex background color logic here to make the screen
           // look nice in all the various states.
-          final backgroundColor = vault.state == VaultState.awaitingKey
+          final backgroundColor = vault.state == VaultState.awaitingShard
               ? Theme.of(context).scaffoldBackgroundColor
               : Theme.of(context).colorScheme.surfaceContainer;
 
@@ -193,13 +193,13 @@ class _VaultDetailScreenState extends ConsumerState<VaultDetailScreen> {
                   child: SingleChildScrollView(
                     child: LayoutBuilder(
                       builder: (context, _) {
-                        // For awaitingKey state, fill remaining space with darker background
-                        final isAwaitingKey = vault.state == VaultState.awaitingKey;
+                        // For awaitingShard state, fill remaining space with darker background
+                        final isAwaitingShard = vault.state == VaultState.awaitingShard;
                         final viewportHeight = constraints.maxHeight;
 
                         return ConstrainedBox(
                           constraints: BoxConstraints(
-                            minHeight: isAwaitingKey ? viewportHeight : 0,
+                            minHeight: isAwaitingShard ? viewportHeight : 0,
                           ),
                           child: Column(
                             crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/screens/vault_detail_screen.dart
+++ b/lib/screens/vault_detail_screen.dart
@@ -125,8 +125,9 @@ class _VaultDetailScreenState extends ConsumerState<VaultDetailScreen> {
             error: (_, __) => const SizedBox.shrink(),
             data: (currentPubkey) {
               final isVaultOwner = currentPubkey != null && vault.isVaultOwner(currentPubkey);
-              final canRedistribute =
-                  isVaultOwner && vault.backupConfig != null && vault.backupConfig!.stewards.isNotEmpty;
+              final canRedistribute = isVaultOwner &&
+                  vault.backupConfig != null &&
+                  vault.backupConfig!.stewards.isNotEmpty;
 
               return PopupMenuButton<String>(
                 itemBuilder: (context) {

--- a/lib/utils/owner_push_opt_in_prompt.dart
+++ b/lib/utils/owner_push_opt_in_prompt.dart
@@ -46,7 +46,7 @@ Future<void> maybePromptOwnerForVaultPush({
     if (vault == null || !vault.pushEnabled) return;
 
     final currentPubkey = await ref.read(currentPublicKeyProvider.future);
-    if (currentPubkey == null || !vault.isOwned(currentPubkey)) return;
+    if (currentPubkey == null || !vault.isVaultOwner(currentPubkey)) return;
 
     final pushReceiver = ref.read(pushNotificationReceiverProvider);
     if (await pushReceiver.isOptedIn()) {

--- a/lib/widgets/steward_list.dart
+++ b/lib/widgets/steward_list.dart
@@ -76,10 +76,10 @@ class StewardList extends ConsumerWidget {
             ),
           ),
           data: (currentPubkey) {
-            // Hide steward list when vault is in awaitingKey state AND current user is a steward
-            // (not the owner) - stewards waiting for their key shouldn't see an empty steward list
-            final isOwner = currentPubkey != null && vault.isOwned(currentPubkey);
-            if (vault.state == VaultState.awaitingKey && !isOwner) {
+            // Hide steward list when vault is awaiting a shard and current user is a steward
+            // (not the owner) — stewards waiting for their shard shouldn't see an empty steward list
+            final isOwner = currentPubkey != null && vault.isVaultOwner(currentPubkey);
+            if (vault.state == VaultState.awaitingShard && !isOwner) {
               // Return empty widget - background fill handled at screen level
               return const SizedBox.shrink();
             }

--- a/lib/widgets/vault_card.dart
+++ b/lib/widgets/vault_card.dart
@@ -33,8 +33,7 @@ class VaultCard extends ConsumerWidget {
       data: (pubkey) => pubkey,
       orElse: () => null,
     );
-    final isVaultOwner =
-        currentPubkey != null && vault.isVaultOwner(currentPubkey);
+    final isVaultOwner = currentPubkey != null && vault.isVaultOwner(currentPubkey);
 
     // [VaultState.holdingShard] uses the key icon unless the current user owns the vault.
     IconData stateIcon;

--- a/lib/widgets/vault_card.dart
+++ b/lib/widgets/vault_card.dart
@@ -28,8 +28,15 @@ class VaultCard extends ConsumerWidget {
     final theme = Theme.of(context);
     final textTheme = theme.textTheme;
 
-    // Determine icon based on vault state
-    // Note: Recovery state is user-specific and not part of vault.state anymore
+    final currentPubkeyAsync = ref.watch(currentPublicKeyProvider);
+    final currentPubkey = currentPubkeyAsync.maybeWhen(
+      data: (pubkey) => pubkey,
+      orElse: () => null,
+    );
+    final isOwner =
+        currentPubkey != null && vault.isOwned(currentPubkey);
+
+    // Steward state uses the key icon unless the current user owns the vault.
     IconData stateIcon;
     Color? iconColor;
 
@@ -38,19 +45,12 @@ class VaultCard extends ConsumerWidget {
         stateIcon = Icons.lock_open;
         break;
       case VaultState.steward:
-        stateIcon = Icons.key;
+        stateIcon = isOwner ? Icons.lock_open : Icons.key;
         break;
       case VaultState.awaitingKey:
         stateIcon = Icons.hourglass_empty;
         break;
     }
-
-    // Get current user's pubkey and determine owner display
-    final currentPubkeyAsync = ref.watch(currentPublicKeyProvider);
-    final currentPubkey = currentPubkeyAsync.maybeWhen(
-      data: (pubkey) => pubkey,
-      orElse: () => null,
-    );
     final ownerDisplayName = _getOwnerDisplayName(currentPubkey);
     final (ownerText, ownerStyle) = NameLabel.getDisplayContent(
       name: ownerDisplayName,

--- a/lib/widgets/vault_card.dart
+++ b/lib/widgets/vault_card.dart
@@ -33,21 +33,21 @@ class VaultCard extends ConsumerWidget {
       data: (pubkey) => pubkey,
       orElse: () => null,
     );
-    final isOwner =
-        currentPubkey != null && vault.isOwned(currentPubkey);
+    final isVaultOwner =
+        currentPubkey != null && vault.isVaultOwner(currentPubkey);
 
-    // Steward state uses the key icon unless the current user owns the vault.
+    // [VaultState.holdingShard] uses the key icon unless the current user owns the vault.
     IconData stateIcon;
     Color? iconColor;
 
     switch (vault.state) {
-      case VaultState.owned:
+      case VaultState.unlocked:
         stateIcon = Icons.lock_open;
         break;
-      case VaultState.steward:
-        stateIcon = isOwner ? Icons.lock_open : Icons.key;
+      case VaultState.holdingShard:
+        stateIcon = isVaultOwner ? Icons.lock_open : Icons.key;
         break;
-      case VaultState.awaitingKey:
+      case VaultState.awaitingShard:
         stateIcon = Icons.hourglass_empty;
         break;
     }

--- a/lib/widgets/vault_detail_button_stack.dart
+++ b/lib/widgets/vault_detail_button_stack.dart
@@ -37,8 +37,9 @@ class VaultDetailButtonStack extends ConsumerWidget {
           error: (_, __) => const SizedBox.shrink(),
           data: (currentPubkey) {
             final isVaultOwner = currentPubkey != null && vault.isVaultOwner(currentPubkey);
-            final isSteward =
-                currentPubkey != null && !vault.isVaultOwner(currentPubkey) && vault.shards.isNotEmpty;
+            final isSteward = currentPubkey != null &&
+                !vault.isVaultOwner(currentPubkey) &&
+                vault.shards.isNotEmpty;
 
             // Watch vault for Generate and Distribute Keys button
             final vaultAsync = ref.watch(vaultProvider(vaultId));

--- a/lib/widgets/vault_detail_button_stack.dart
+++ b/lib/widgets/vault_detail_button_stack.dart
@@ -36,9 +36,9 @@ class VaultDetailButtonStack extends ConsumerWidget {
           loading: () => const SizedBox.shrink(),
           error: (_, __) => const SizedBox.shrink(),
           data: (currentPubkey) {
-            final isOwned = currentPubkey != null && vault.isOwned(currentPubkey);
+            final isVaultOwner = currentPubkey != null && vault.isVaultOwner(currentPubkey);
             final isSteward =
-                currentPubkey != null && !vault.isOwned(currentPubkey) && vault.shards.isNotEmpty;
+                currentPubkey != null && !vault.isVaultOwner(currentPubkey) && vault.shards.isNotEmpty;
 
             // Watch vault for Generate and Distribute Keys button
             final vaultAsync = ref.watch(vaultProvider(vaultId));
@@ -72,7 +72,7 @@ class VaultDetailButtonStack extends ConsumerWidget {
                     }
 
                     // Edit Vault Button (only show if user owns the vault)
-                    if (isOwned) {
+                    if (isVaultOwner) {
                       // Check if vault has content
                       final hasContent = currentVault?.content != null;
 
@@ -205,7 +205,7 @@ class VaultDetailButtonStack extends ConsumerWidget {
 
                     // Owner-steward state: owner has deleted content but kept shards
                     // Show special buttons for recovery
-                    final isOwnerSteward = isOwned &&
+                    final isOwnerSteward = isVaultOwner &&
                         currentVault != null &&
                         currentVault.content == null &&
                         currentVault.shards.isNotEmpty;
@@ -243,11 +243,11 @@ class VaultDetailButtonStack extends ConsumerWidget {
                     }
 
                     // Recovery buttons - only show for stewards (not owners, since owners already have contents)
-                    // Don't show recovery buttons when steward is waiting for their key (awaitingKey state)
-                    if (!isOwned &&
+                    // Don't show recovery buttons when steward is waiting for their shard
+                    if (!isVaultOwner &&
                         !isOwnerSteward &&
                         currentVault != null &&
-                        currentVault.state != VaultState.awaitingKey) {
+                        currentVault.state != VaultState.awaitingShard) {
                       // Show "Manage Recovery" if user initiated active recovery
                       if (recoveryStatus.hasActiveRecovery && recoveryStatus.isInitiator) {
                         buttons.add(

--- a/lib/widgets/vault_metadata_section.dart
+++ b/lib/widgets/vault_metadata_section.dart
@@ -87,7 +87,7 @@ class VaultMetadataSection extends ConsumerWidget {
     Vault vault,
     String? currentPubkey,
   ) {
-    final isOwner = currentPubkey == vault.ownerPubkey;
+    final isVaultOwner = currentPubkey != null && vault.isVaultOwner(currentPubkey);
     final threshold = vault.mostRecentShard?.threshold;
     final (ownerText, ownerStyle) = NameLabel.getDisplayContent(
       name: vault.ownerName,
@@ -101,8 +101,8 @@ class VaultMetadataSection extends ConsumerWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            if (isOwner) ...[
-              // Owner state
+            if (isVaultOwner) ...[
+              // Vault owner viewing their own vault
               Row(
                 children: [
                   Icon(
@@ -117,7 +117,7 @@ class VaultMetadataSection extends ConsumerWidget {
                 ],
               ),
             ] else ...[
-              // Key holder state
+              // Recovery key holder (not owner)
               Row(
                 children: [
                   Icon(

--- a/lib/widgets/vault_owner_display.dart
+++ b/lib/widgets/vault_owner_display.dart
@@ -25,7 +25,7 @@ class VaultOwnerDisplay extends ConsumerWidget {
       data: (currentPubkey) {
         final theme = Theme.of(context);
         final colorScheme = theme.colorScheme;
-        final isCurrentUser = currentPubkey != null && vault.isOwned(currentPubkey);
+        final isCurrentUser = currentPubkey != null && vault.isVaultOwner(currentPubkey);
 
         // Get owner display name
         final ownerDisplayName = isCurrentUser ? (vault.ownerName ?? 'You') : vault.ownerName;

--- a/lib/widgets/vault_status_banner.dart
+++ b/lib/widgets/vault_status_banner.dart
@@ -54,8 +54,8 @@ class VaultStatusBanner extends ConsumerWidget {
       loading: () => const SizedBox.shrink(),
       error: (_, __) => const SizedBox.shrink(),
       data: (currentPubkey) {
-        final isOwner = currentPubkey != null && vault.isOwned(currentPubkey);
-        final isSteward = currentPubkey != null && !vault.isOwned(currentPubkey);
+        final isOwner = currentPubkey != null && vault.isVaultOwner(currentPubkey);
+        final isSteward = currentPubkey != null && !vault.isVaultOwner(currentPubkey);
 
         // Only show "Recovery in progress" if the current user initiated an active recovery
         // Use the same recoveryStatusProvider that the button stack uses
@@ -264,7 +264,7 @@ class VaultStatusBanner extends ConsumerWidget {
 
   Widget _buildStewardStatus(BuildContext context, Vault vault) {
     // Awaiting key
-    if (vault.state == VaultState.awaitingKey) {
+    if (vault.state == VaultState.awaitingShard) {
       return _buildBanner(
         context,
         const _StatusData(
@@ -283,7 +283,7 @@ class VaultStatusBanner extends ConsumerWidget {
     // Key holder - stewards have received a shard
     // Note: We don't check backupConfig.status because stewards can't read it
     // (it's encrypted to the owner). If a steward has shards, they're ready to help.
-    if (vault.state == VaultState.steward) {
+    if (vault.state == VaultState.holdingShard) {
       return _buildBanner(
         context,
         const _StatusData(


### PR DESCRIPTION
## Summary
- Rename `VaultState` values to reflect **local** content/shard state: `unlocked`, `holdingShard`, `awaitingShard` (replacing `owned`, `steward`, `awaitingKey`).
- Rename `Vault.isOwned` → `Vault.isVaultOwner` to avoid confusion with `VaultState`.
- Includes vault list icon: owners see the unlocked vault icon in `holdingShard` local state.

## Notes
Spec docs under `specs/006-owner-shard/` may still reference old enum names.

Made with [Cursor](https://cursor.com)