### PR TITLE
docs: require bead ID in PR descriptions

### DIFF
--- a/.cursor/rules/beads-workflow.mdc
+++ b/.cursor/rules/beads-workflow.mdc
@@ -43,6 +43,8 @@ Set or refresh when opening a branch or PR:
 
 via `bd update <id> --metadata '{"pr_url":"…","branch":"…","worktree":"…"}'`.
 
+Put the same **bead issue ID** in the GitHub PR description (see `AGENTS.md` and `CONTRIBUTING.md`) so the PR and bd stay linked for reviewers.
+
 ## Mandatory writeback (every agent turn near completion)
 
 Before you stop or say work is done for this session:

--- a/.cursor/rules/beads.mdc
+++ b/.cursor/rules/beads.mdc
@@ -10,6 +10,7 @@ This project uses [Beads (bd)](https://github.com/steveyegge/beads) for issue tr
 
 ## Core Rules
 - Track ALL work in bd (never use markdown TODOs or comment-based task lists)
+- When opening a GitHub PR for bd-tracked work, include that **bead issue ID** in the PR description (`bd show <id>`)
 - Use `bd ready` to find available work
 - Use `bd create` to track new issues/tasks/bugs
 - Use `bd dolt push` at end of session to sync with git remote

--- a/.cursorrules
+++ b/.cursorrules
@@ -540,6 +540,8 @@ When testing changes, verify:
    - **If problems found**: Fix them, then re-run steps 1-6 above
    - **DO NOT open PR** until Marionette testing passes
 
+8. ✅ **Bead ID in PR description**: If the change is tracked in bd, the PR description MUST include that bead's issue ID (use `bd show <id>` for the exact string). If there is no bead, state that briefly (for example "No bead — chore only").
+
 **If you skip any step, the PR will fail CI and waste reviewer time.**
 
 ### Pre-PR Checklist
@@ -663,7 +665,8 @@ All commands must complete successfully AND Marionette testing must pass before 
    - Check for crashes, errors, or UI issues
    - **If problems found**: Fix them, then re-run steps 1-7 above (including Marionette testing again)
    - **DO NOT open/push PRs** until Marionette testing passes
-9. ✅ **Do NOT open/push PRs** until ALL above steps are complete
+9. ✅ **Bead ID in PR description**: If the change is tracked in bd, the PR description MUST include that bead's issue ID (`bd show <id>`). If there is no bead, state that briefly.
+10. ✅ **Do NOT open/push PRs** until ALL above steps are complete
 
 **FOR EVERY COMMIT ON AN OPEN PR**:
 - ✅ Run codegen: If you modified any `@freezed` classes or `@GenerateMocks` annotations
@@ -689,6 +692,7 @@ Before opening/pushing a PR, verify:
 - [ ] No new `*_golden_test.dart` files exist without their golden images committed
 - [ ] Marionette testing completed and all functionality verified
 - [ ] No crashes, errors, or UI issues found during Marionette testing
+- [ ] PR description includes the bd issue ID when work is bead-tracked (or explicitly says there is no bead)
 
 **Marionette Testing Workflow (MANDATORY for PRs)**:
 1. Launch app: `flutter run -d macos > /tmp/flutter_run.log 2>&1 &`
@@ -737,6 +741,7 @@ flutter test
 
 ### PR Description Guidelines
 When opening a PR, include:
+- **Bead**: Issue ID from bd when work is tracked there (for example `horcrux_app-tco`), or a one-line note that there is no bead
 - **What**: Brief description of changes
 - **Why**: Reason for the changes
 - **Testing**: How the changes were tested

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Bead
+
+<!-- Required when this PR maps to bd-tracked work. Example: horcrux_app-tco (use `bd show <id>`). Otherwise: "None — " plus a short reason. -->
+
+## What
+
+
+## Why
+
+
+## Testing
+
+
+## Screenshots
+
+<!-- UI changes only -->
+
+
+## Breaking changes
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -372,6 +372,7 @@ bd close <id>         # Complete work
 - Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists
 - Run `bd prime` for detailed command reference and session close protocol
 - Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
+- When you open a pull request for work tracked in bd, include the **bead issue ID** in the PR description (for example `horcrux_app-tco`). Use `bd show <id>` to copy the exact ID string.
 
 ### Task tracking in Cursor
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ bd close <id>         # Complete work
 - Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists
 - Run `bd prime` for detailed command reference and session close protocol
 - Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
+- When you open a pull request for work tracked in bd, include the **bead issue ID** in the PR description (for example `horcrux_app-tco`). Use `bd show <id>` to copy the exact ID string.
 
 ## Session Completion
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,9 @@
 WIP 
 Install uvx `curl -LsSf https://astral.sh/uv/install.sh | sh`
+
+## Pull requests and Beads
+
+This repository uses **bd (beads)** for issue tracking. When a pull request corresponds to bead-tracked work, put the **bead issue ID** in the PR description (for example `horcrux_app-tco`). Run `bd show <id>` to confirm the exact ID. If the PR is not tied to a bead, say so in one short line (for example "No bead — documentation-only"). GitHub also loads `.github/pull_request_template.md` as a starting outline when you open a PR.
 Install spec-kit
 Install Nostrbook MCP
 Install flutter


### PR DESCRIPTION
## Bead

horcrux_app-tco

## What

Require contributors and agents to put the bd issue ID in GitHub PR descriptions when work is tracked in beads.

## Why

Keeps PRs and bead issues linked for reviewers and CI context.

## Testing

Documentation-only change; no app tests run.

## Breaking changes

None.

Made with [Cursor](https://cursor.com)