### PR TITLE
docs: fix README privacy typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Horcrux is built on the Nostr protocol which makes strong guarantees about the a
 
 - A malicious relay can associate your IP address with your Nostr identity. Using a network-layer anonymizer like Tor or I2P can be used to mitigate this risk.
 - A malicious relay could observe the timing of published gift-wrap events to build a list of stewards (identified by their Nostr identity) for a given vault.
-- Horcrux allows vault owners to enable push notifications on a per-vault basis. For any vault that has it enabled Horcrux uses its own notification server, Google's Firebase Cloud Messaging service, and Apple's Push Notification Service in order to deliver push notifications for recovery events to stewards. These notification servers can see the content of notifications which sometimes contain steward and vault names, and could deduce who is stewarding a vault with whom. You can limit this metadata leakage by disabling push notifications, but be aware taht you will need to manually notify stewards to open the app when distributing keys or making recovery requests.
+- Horcrux allows vault owners to enable push notifications on a per-vault basis. For any vault that has it enabled Horcrux uses its own notification server, Google's Firebase Cloud Messaging service, and Apple's Push Notification Service in order to deliver push notifications for recovery events to stewards. These notification servers can see the content of notifications which sometimes contain steward and vault names, and could deduce who is stewarding a vault with whom. You can limit this metadata leakage by disabling push notifications, but be aware that you will need to manually notify stewards to open the app when distributing keys or making recovery requests.
 
 ## Development
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Bead

horcrux_app-xlo

## What

- Correct a typo in the README privacy section (`taht` -> `that`).

## Why

- Improve release `0.9` polish for user-facing documentation.

## Testing

- `rg -n "taht" README.md || true` (no matches)
- `rg "be aware that you will need to manually notify stewards" README.md` (expected corrected line present)

## Screenshots

- None — docs-only change.

## Breaking changes

- None.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d775582b-d9fc-444f-8de6-90e23ffead3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d775582b-d9fc-444f-8de6-90e23ffead3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

