### PR TITLE
fix(recovery): suppress "session ended" dialog on user-initiated cancel/end

### DIFF
--- a/lib/screens/recovery_status_screen.dart
+++ b/lib/screens/recovery_status_screen.dart
@@ -486,6 +486,10 @@ class _RecoveryStatusScreenState extends ConsumerState<RecoveryStatusScreen> {
     );
 
     if (confirmed == true) {
+      // The user is intentionally ending the session, so suppress the
+      // "session already ended" alert that would otherwise be triggered when
+      // the request status flips to archived/cancelled.
+      _alreadyEndedAlertScheduled = true;
       try {
         // Get vaultId before exiting recovery mode
         final requestForVaultId =
@@ -559,6 +563,10 @@ class _RecoveryStatusScreenState extends ConsumerState<RecoveryStatusScreen> {
     );
 
     if (confirmed == true) {
+      // The user is intentionally cancelling, so suppress the
+      // "session already ended" alert that would otherwise be triggered when
+      // the request status flips to cancelled.
+      _alreadyEndedAlertScheduled = true;
       try {
         // Get vaultId before canceling recovery request
         final request =

--- a/lib/screens/recovery_status_screen.dart
+++ b/lib/screens/recovery_status_screen.dart
@@ -514,6 +514,9 @@ class _RecoveryStatusScreenState extends ConsumerState<RecoveryStatusScreen> {
           Navigator.pop(context);
         }
       } catch (e) {
+        // The user is still on the screen, so re-arm the alert so that a
+        // later external termination of the session is announced.
+        _alreadyEndedAlertScheduled = false;
         if (mounted) {
           ScaffoldMessenger.of(
             context,
@@ -588,6 +591,9 @@ class _RecoveryStatusScreenState extends ConsumerState<RecoveryStatusScreen> {
           Navigator.pop(context);
         }
       } catch (e) {
+        // The user is still on the screen, so re-arm the alert so that a
+        // later external termination of the session is announced.
+        _alreadyEndedAlertScheduled = false;
         if (mounted) {
           ScaffoldMessenger.of(
             context,

--- a/lib/screens/recovery_status_screen.dart
+++ b/lib/screens/recovery_status_screen.dart
@@ -21,7 +21,7 @@ class RecoveryStatusScreen extends ConsumerStatefulWidget {
 
 class _RecoveryStatusScreenState extends ConsumerState<RecoveryStatusScreen> {
   /// Avoid duplicate dialogs when [recoveryRequestByIdProvider] rebuilds.
-  bool _alreadyEndedAlertScheduled = false;
+  bool _shouldSuppressEndedAlert = false;
 
   /// Recovery is no longer manageable (cancelled, failed, or archived).
   bool _isRecoverySessionAlreadyEnded(RecoveryRequest request) {
@@ -39,9 +39,9 @@ class _RecoveryStatusScreenState extends ConsumerState<RecoveryStatusScreen> {
   }
 
   void _scheduleAlreadyEndedAlertIfNeeded(RecoveryRequest? request) {
-    if (_alreadyEndedAlertScheduled || request == null) return;
+    if (_shouldSuppressEndedAlert || request == null) return;
     if (!_isRecoverySessionAlreadyEnded(request)) return;
-    _alreadyEndedAlertScheduled = true;
+    _shouldSuppressEndedAlert = true;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       _showAlreadyEndedSessionAlertAndPop();
@@ -489,7 +489,7 @@ class _RecoveryStatusScreenState extends ConsumerState<RecoveryStatusScreen> {
       // The user is intentionally ending the session, so suppress the
       // "session already ended" alert that would otherwise be triggered when
       // the request status flips to archived/cancelled.
-      _alreadyEndedAlertScheduled = true;
+      _shouldSuppressEndedAlert = true;
       try {
         // Get vaultId before exiting recovery mode
         final requestForVaultId =
@@ -516,7 +516,7 @@ class _RecoveryStatusScreenState extends ConsumerState<RecoveryStatusScreen> {
       } catch (e) {
         // The user is still on the screen, so re-arm the alert so that a
         // later external termination of the session is announced.
-        _alreadyEndedAlertScheduled = false;
+        _shouldSuppressEndedAlert = false;
         if (mounted) {
           ScaffoldMessenger.of(
             context,
@@ -569,7 +569,7 @@ class _RecoveryStatusScreenState extends ConsumerState<RecoveryStatusScreen> {
       // The user is intentionally cancelling, so suppress the
       // "session already ended" alert that would otherwise be triggered when
       // the request status flips to cancelled.
-      _alreadyEndedAlertScheduled = true;
+      _shouldSuppressEndedAlert = true;
       try {
         // Get vaultId before canceling recovery request
         final request =
@@ -593,7 +593,7 @@ class _RecoveryStatusScreenState extends ConsumerState<RecoveryStatusScreen> {
       } catch (e) {
         // The user is still on the screen, so re-arm the alert so that a
         // later external termination of the session is announced.
-        _alreadyEndedAlertScheduled = false;
+        _shouldSuppressEndedAlert = false;
         if (mounted) {
           ScaffoldMessenger.of(
             context,


### PR DESCRIPTION
## Summary

- Cancelling a recovery request (or ending recovery/practice recovery) from `RecoveryStatusScreen` was popping up the "This recovery session has already ended." dialog. That alert is intended for users who land on the screen for a session some other actor already terminated, not for the user's own cancel/end actions.
- The status listener fires when the request flips to `cancelled`/`failed`/`archived`. When the user confirms cancel or end, we now flag the alert as already scheduled before performing the action, so the listener correctly skips the dialog for user-driven transitions while still firing for externally-ended sessions.

Fixes `horcrux_app-648`.

## Test plan

- [ ] Manual: open a pending recovery request, tap "Cancel Recovery Request", confirm — verify only the "Recovery request cancelled" snackbar shows and no "session already ended" dialog appears.
- [ ] Manual: complete a recovery and tap "End Recovery" / "End Practice" — verify the screen pops without the dialog.
- [ ] Manual: open a deep link to a recovery whose status is already `cancelled`/`failed`/`archived` — verify the "session already ended" dialog still appears as intended.
