### PR TITLE
Skip local notifications for self-signed shard events

### DIFF
--- a/lib/services/local_notification_service.dart
+++ b/lib/services/local_notification_service.dart
@@ -8,11 +8,13 @@ import '../app_navigator.dart';
 import '../models/nostr_kinds.dart';
 import '../models/recovery_request.dart';
 import '../models/shard_data.dart';
+import '../providers/key_provider.dart';
 import '../providers/vault_provider.dart';
 import '../screens/recovery_request_detail_screen.dart';
 import '../screens/recovery_status_screen.dart';
 import '../screens/vault_detail_screen.dart';
 import '../utils/push_notification_text.dart';
+import 'login_service.dart';
 import 'logger.dart';
 import 'ndk_service.dart' show RecoveryResponseEvent;
 import 'notification_recency.dart';
@@ -20,8 +22,10 @@ import 'recovery_service.dart' show RecoveryService, recoveryServiceProvider;
 
 final localNotificationServiceProvider = Provider<LocalNotificationService>((ref) {
   final vaultRepository = ref.watch(vaultRepositoryProvider);
+  final loginService = ref.watch(loginServiceProvider);
   final service = LocalNotificationService(
     vaultRepository: vaultRepository,
+    loginService: loginService,
     getRecoveryService: () => ref.read(recoveryServiceProvider),
   );
   ref.onDispose(() => service.dispose());
@@ -52,6 +56,7 @@ String recoveryRequestRouteName(String recoveryRequestId) => '/recovery_request/
 /// in, but recency is enforced here as the single source of truth.
 class LocalNotificationService {
   final VaultRepository _vaultRepository;
+  final LoginService _loginService;
   final RecoveryService Function() _getRecoveryService;
   final FlutterLocalNotificationsPlugin _plugin = FlutterLocalNotificationsPlugin();
 
@@ -63,8 +68,10 @@ class LocalNotificationService {
 
   LocalNotificationService({
     required VaultRepository vaultRepository,
+    required LoginService loginService,
     required RecoveryService Function() getRecoveryService,
   })  : _vaultRepository = vaultRepository,
+        _loginService = loginService,
         _getRecoveryService = getRecoveryService;
 
   /// Android notification ids are 32-bit signed. [millisecondsSinceEpoch] alone does not fit,
@@ -166,6 +173,26 @@ class LocalNotificationService {
       event: event,
       vaultId: vaultId,
     );
+  }
+
+  /// Returns whether [pubkey] matches the current user's hex public key.
+  ///
+  /// Used to suppress local notifications for events the user themselves
+  /// signed -- which happens whenever the user is a steward of their own
+  /// vault, because the publish-to-stewards loop includes their own pubkey
+  /// and the corresponding gift wrap round-trips through their own client.
+  /// Returns `false` (i.e. "not self, do notify") if the lookup fails or no
+  /// key has been initialized yet, so a transient secure-storage hiccup
+  /// degrades to "show the notification" rather than swallowing it silently.
+  Future<bool> _isCurrentUserPubkey(String pubkey) async {
+    try {
+      final current = await _loginService.getCurrentPublicKey();
+      if (current == null || current.isEmpty) return false;
+      return current.toLowerCase() == pubkey.toLowerCase();
+    } catch (e, st) {
+      Log.warning('LocalNotificationService: self-pubkey lookup failed', e, st);
+      return false;
+    }
   }
 
   /// Returns whether [eventUtc] is recent enough to notify for, logging a
@@ -295,6 +322,19 @@ class LocalNotificationService {
   }) async {
     if (vaultId == null || vaultId.isEmpty) {
       Log.debug('Skipping ${kind.name} notification: missing vault id');
+      return;
+    }
+
+    // When the user is a steward of their own vault, every shard distribution
+    // and confirmation publish round-trips through their own client. Notifying
+    // about an event the current user just signed would surface lines like
+    // "Mac has confirmed they have the latest data..." on the device that
+    // *is* Mac. Skip those before composing any text. See horcrux_app-3b0.
+    if (await _isCurrentUserPubkey(event.pubKey)) {
+      Log.debug(
+        'Skipping ${kind.name} notification ${event.id}: '
+        'event was signed by the current user',
+      );
       return;
     }
 

--- a/test/services/local_notification_service_navigation_test.dart
+++ b/test/services/local_notification_service_navigation_test.dart
@@ -8,6 +8,7 @@ import 'package:horcrux/models/nostr_kinds.dart';
 import 'package:horcrux/models/recovery_request.dart';
 import 'package:horcrux/providers/vault_provider.dart';
 import 'package:horcrux/services/local_notification_service.dart';
+import 'package:horcrux/services/login_service.dart';
 import 'package:horcrux/services/recovery_service.dart';
 
 import 'local_notification_service_navigation_test.mocks.dart';
@@ -19,6 +20,14 @@ class _FakeRecoveryService extends Fake implements RecoveryService {
 
   @override
   Future<RecoveryRequest?> getRecoveryRequest(String id) async => requests[id];
+}
+
+/// Stand-in for [LoginService] that returns no current key. The navigation
+/// tests don't exercise the self-origin filter, so a "no key" stub is
+/// sufficient and avoids touching `flutter_secure_storage`.
+class _FakeLoginService extends Fake implements LoginService {
+  @override
+  Future<String?> getCurrentPublicKey() async => null;
 }
 
 /// Records `didPush` / `didRemove` events as `'<verb>:<routeName>'` strings.
@@ -76,6 +85,7 @@ void main() {
     recoveryService = _FakeRecoveryService();
     service = LocalNotificationService(
       vaultRepository: vaultRepository,
+      loginService: _FakeLoginService(),
       getRecoveryService: () => recoveryService,
     );
   });

--- a/test/services/local_notification_service_self_origin_test.dart
+++ b/test/services/local_notification_service_self_origin_test.dart
@@ -1,0 +1,234 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ndk/ndk.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:horcrux/models/recovery_request.dart';
+import 'package:horcrux/models/shard_data.dart';
+import 'package:horcrux/models/vault.dart';
+import 'package:horcrux/providers/vault_provider.dart';
+import 'package:horcrux/services/local_notification_service.dart';
+import 'package:horcrux/services/login_service.dart';
+import 'package:horcrux/services/recovery_service.dart';
+
+import '../fixtures/test_keys.dart';
+
+/// Records every call to [getVault] so the tests can assert that the
+/// self-origin filter short-circuits before any vault lookup happens. The
+/// rest of [VaultRepository] is intentionally left unimplemented -- the
+/// service code under test only reaches `getVault` once the pre-filter
+/// passes, and the test verifies it never does for a self-signed event.
+class _SpyingVaultRepository extends Fake implements VaultRepository {
+  final List<String> getVaultCalls = <String>[];
+
+  @override
+  Future<Vault?> getVault(String id) async {
+    getVaultCalls.add(id);
+    return null;
+  }
+}
+
+/// Returns a fixed pubkey as the "current user". Returning `null` simulates
+/// "no key initialized yet"; in that mode the filter must default to
+/// "not self" so a transient secure-storage hiccup never silently swallows
+/// real notifications.
+class _FakeLoginService extends Fake implements LoginService {
+  _FakeLoginService(this._pubkey);
+
+  final String? _pubkey;
+
+  @override
+  Future<String?> getCurrentPublicKey() async => _pubkey;
+}
+
+class _FakeRecoveryService extends Fake implements RecoveryService {
+  @override
+  Future<RecoveryRequest?> getRecoveryRequest(String id) async => null;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  /// Builds a kind-1342 shard-confirmation rumor signed by [senderPubkey].
+  /// Only the fields the production code reads (`pubKey`, `id`, `createdAt`)
+  /// matter for these tests; everything else is filler.
+  Nip01Event buildShardConfirmation({
+    required String senderPubkey,
+    int createdAt = 1700000000,
+    String id = 'evt-shard-confirm-1',
+  }) {
+    return Nip01Event(
+      pubKey: senderPubkey,
+      kind: 1342,
+      tags: const [],
+      content: '{}',
+      createdAt: createdAt,
+    )..id = id;
+  }
+
+  Nip01Event buildShardData({
+    required String senderPubkey,
+    int createdAt = 1700000000,
+    String id = 'evt-shard-data-1',
+  }) {
+    return Nip01Event(
+      pubKey: senderPubkey,
+      kind: 1337,
+      tags: const [],
+      content: '{}',
+      createdAt: createdAt,
+    )..id = id;
+  }
+
+  ShardData makeShardData({String vaultId = 'vault-1'}) {
+    return ShardData(
+      shard: 'shard-payload',
+      threshold: 2,
+      shardIndex: 0,
+      totalShards: 3,
+      primeMod: TestShardData.testPrimeMod,
+      creatorPubkey: TestShardData.testCreatorPubkey,
+      createdAt: 1700000000,
+      vaultId: vaultId,
+    );
+  }
+
+  late _SpyingVaultRepository vaultRepository;
+  late _FakeRecoveryService recoveryService;
+
+  setUp(() {
+    // The shard-data and shard-confirmation paths consult `getFirstAppOpenUtc`
+    // (backed by SharedPreferences) for recency gating once the self-filter
+    // has passed. Stub it with empty values so the gating reaches the same
+    // "first open is now" branch every test, instead of throwing
+    // `MissingPluginException`.
+    SharedPreferences.setMockInitialValues({});
+    vaultRepository = _SpyingVaultRepository();
+    recoveryService = _FakeRecoveryService();
+  });
+
+  LocalNotificationService buildService({String? currentPubkey}) {
+    return LocalNotificationService(
+      vaultRepository: vaultRepository,
+      loginService: _FakeLoginService(currentPubkey),
+      getRecoveryService: () => recoveryService,
+    );
+  }
+
+  group('LocalNotificationService self-origin filter (horcrux_app-3b0)', () {
+    test(
+      'shard confirmation signed by the current user does not trigger a '
+      'vault lookup or notification',
+      () async {
+        // Owner is a steward of their own vault, so a kind-1342 they just
+        // published gets gift-wrapped to themselves and round-trips back. The
+        // filter must drop it before composing "{self} has confirmed they
+        // have the latest data..." -- the bug from horcrux_app-3b0.
+        final service = buildService(currentPubkey: TestHexPubkeys.alice);
+
+        await service.notifyShardConfirmationProcessed(
+          event: buildShardConfirmation(senderPubkey: TestHexPubkeys.alice),
+          vaultId: 'vault-1',
+        );
+
+        expect(
+          vaultRepository.getVaultCalls,
+          isEmpty,
+          reason: 'self-origin events must be dropped before vault lookup',
+        );
+      },
+    );
+
+    test(
+      'shard data signed by the current user does not trigger a vault '
+      'lookup or notification',
+      () async {
+        // Mirrors the confirmation case for the kind-1337 leg of the loop:
+        // the owner publishes shard data to every steward, which includes
+        // themselves; the gift wrap echoes back and would otherwise read
+        // "Open Horcrux to save the latest data for {self}'s vault X".
+        final service = buildService(currentPubkey: TestHexPubkeys.alice);
+
+        await service.notifyShardDataProcessed(
+          event: buildShardData(senderPubkey: TestHexPubkeys.alice),
+          shardData: makeShardData(vaultId: 'vault-1'),
+        );
+
+        expect(vaultRepository.getVaultCalls, isEmpty);
+      },
+    );
+
+    test(
+      'shard confirmation from another steward still proceeds past the '
+      'self-origin filter',
+      () async {
+        // Sanity check: with the filter in place, real cross-device
+        // confirmations from peers must keep flowing through to the rest
+        // of the notification pipeline (vault lookup, text composition,
+        // OS show). We can only observe the first hop here -- the OS-level
+        // `flutter_local_notifications` call is platform-bound and the
+        // service swallows its failure -- but reaching `getVault` proves
+        // the early-return did not fire.
+        final service = buildService(currentPubkey: TestHexPubkeys.alice);
+
+        await service.notifyShardConfirmationProcessed(
+          event: buildShardConfirmation(
+            senderPubkey: TestHexPubkeys.bob,
+            // Use "now" so the recency gate doesn't filter the event out
+            // first and mask the assertion we actually care about.
+            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+          ),
+          vaultId: 'vault-1',
+        );
+
+        expect(
+          vaultRepository.getVaultCalls,
+          equals(['vault-1']),
+          reason: 'non-self events must reach vault lookup',
+        );
+      },
+    );
+
+    test(
+      'pubkey comparison is case-insensitive',
+      () async {
+        // Hex pubkeys *should* always be lowercase by convention, but
+        // upstream relays and gift-wrap unwrappers occasionally surface a
+        // mixed-case form. Do not let a case mismatch open a hole in the
+        // self-filter -- the bug from horcrux_app-3b0 would still surface.
+        final service = buildService(
+          currentPubkey: TestHexPubkeys.alice.toLowerCase(),
+        );
+
+        await service.notifyShardConfirmationProcessed(
+          event: buildShardConfirmation(
+            senderPubkey: TestHexPubkeys.alice.toUpperCase(),
+          ),
+          vaultId: 'vault-1',
+        );
+
+        expect(vaultRepository.getVaultCalls, isEmpty);
+      },
+    );
+
+    test(
+      'no current key (e.g. login not initialized) defaults to "not self" '
+      'so notifications are not silently swallowed',
+      () async {
+        // Login can transiently report no key (cold-start race, secure
+        // storage hiccup). The safe default is to keep notifying so a flake
+        // in `LoginService` does not look like a notification regression.
+        final service = buildService(currentPubkey: null);
+
+        await service.notifyShardConfirmationProcessed(
+          event: buildShardConfirmation(
+            senderPubkey: TestHexPubkeys.alice,
+            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+          ),
+          vaultId: 'vault-1',
+        );
+
+        expect(vaultRepository.getVaultCalls, equals(['vault-1']));
+      },
+    );
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Bead**: `horcrux_app-3b0` — Notification shown for storing your own data

## What

When the user is a steward of their own vault, the publish-to-stewards loop includes their own pubkey, so kind-1337 shard distribution and kind-1342 shard confirmation gift wraps round-trip back through their own client. `NdkService._handleShardData` and `_handleShardConfirmation` called `LocalNotificationService.notifyShard*Processed` unconditionally, producing notifications like *"mac has confirmed they have the latest data for vault 'test'"* on the device that **is** mac.

This PR injects `LoginService` into `LocalNotificationService` and short-circuits `_showShardNotification` when the rumor's `pubKey` matches the current user's hex public key (case-insensitive). A null current pubkey degrades to "not self" so a transient secure-storage hiccup never silently swallows real notifications.

Recovery requests/responses already filter self-origin via `RecoveryNotificationPolicy`, so only the shard paths needed the filter.

## Why

The user filed `horcrux_app-3b0` after seeing this notification on their own macOS device while updating their vault recovery plan with self-as-steward enabled.

## Testing

- New `test/services/local_notification_service_self_origin_test.dart` covers:
  - Self-signed shard confirmation drops before vault lookup
  - Self-signed shard data drops before vault lookup
  - Peer-signed shard confirmation still reaches vault lookup (sanity check)
  - Pubkey comparison is case-insensitive
  - Missing current pubkey defaults to "not self" (don't silently swallow)
- Updated `local_notification_service_navigation_test.dart` to pass the new `loginService` dependency via a fake.
- ✅ `flutter analyze` — No issues found
- ✅ `flutter test --exclude-tags=golden` — 374 tests passed (skipping golden tests since this VM is Linux per `AGENTS.md`)
- Manual GUI verification was not performed: this Linux VM does not have a notification daemon wired through the path the bug surfaces on (macOS), and the fix is verified end-to-end via the unit tests against the exact production code path (`notifyShardConfirmationProcessed` → `_showShardNotification` → `_isCurrentUserPubkey`).

## Breaking Changes

`LocalNotificationService` now requires a `loginService` constructor argument. The Riverpod provider is updated; any test that instantiates `LocalNotificationService` directly must pass a `LoginService` (a `Fake` returning `null` from `getCurrentPublicKey()` is sufficient when self-origin is not under test, as in `local_notification_service_navigation_test.dart`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63e231a2-468d-4e19-907c-fe5d207d14d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63e231a2-468d-4e19-907c-fe5d207d14d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

