### PR TITLE
fix(RowButton): clear home indicator with external bottom margin

### DIFF
--- a/lib/widgets/row_button.dart
+++ b/lib/widgets/row_button.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'dart:io' show Platform;
 
 /// A full-width button with an icon and text in a row layout
 class RowButton extends StatelessWidget {
@@ -11,8 +10,11 @@ class RowButton extends StatelessWidget {
   final double? iconSize;
   final TextStyle? textStyle;
   final EdgeInsets? padding;
-  final bool
-      addBottomSafeArea; // Pads past the bottom system inset (iOS home indicator, Android nav/gesture bar)
+  final bool addBottomSafeArea; // Pushes the button up past the system bottom
+  // inset (iOS home indicator, Android nav/gesture bar) so the button rectangle
+  // clears it. When the screen wraps the button in a SafeArea that consumes
+  // the bottom inset, MediaQuery.padding.bottom is 0 here and no extra space
+  // is added.
 
   const RowButton({
     super.key,
@@ -55,25 +57,9 @@ class RowButton extends StatelessWidget {
     final shadowColor =
         isDark ? borderColor.withValues(alpha: 0.1) : borderColor.withValues(alpha: 0.1);
 
-    // Pad past the system inset at the bottom of the screen (iOS home indicator
-    // or Android gesture/navigation bar) so the button isn't covered by it.
-    final systemBottomInset = MediaQuery.of(context).padding.bottom;
-    final bottomSafeArea = switch ((Platform.operatingSystem, addBottomSafeArea)) {
-      ('ios', true) => 8.0,
-      ('android', true) => systemBottomInset,
-      _ => 0.0,
-    };
+    final effectivePadding = padding ?? const EdgeInsets.symmetric(vertical: 20, horizontal: 20);
 
-    final effectivePadding = padding != null
-        ? padding!.copyWith(bottom: padding!.bottom + bottomSafeArea)
-        : EdgeInsets.only(
-            top: 20,
-            bottom: 20 + bottomSafeArea,
-            left: 20,
-            right: 20,
-          );
-
-    return InkWell(
+    final button = InkWell(
       onTap: onPressed,
       child: Opacity(
         opacity: isDisabled ? 0.6 : 1.0,
@@ -110,6 +96,17 @@ class RowButton extends StatelessWidget {
           ),
         ),
       ),
+    );
+
+    // Push the whole button up past the system bottom inset so the button
+    // rectangle (not just its content) clears the home indicator / nav bar.
+    final bottomMargin = addBottomSafeArea ? MediaQuery.of(context).padding.bottom : 0.0;
+    if (bottomMargin == 0) {
+      return button;
+    }
+    return Padding(
+      padding: EdgeInsets.only(bottom: bottomMargin),
+      child: button,
     );
   }
 }

--- a/test/screens/account_created_screen_safe_area_test.dart
+++ b/test/screens/account_created_screen_safe_area_test.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:horcrux/screens/account_created_screen.dart';
+import 'package:horcrux/screens/onboarding_screen.dart';
+import 'package:horcrux/widgets/row_button.dart';
+import 'package:horcrux/widgets/theme.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../helpers/secure_storage_mock.dart';
+
+/// Pumps [child] with a MediaQuery that simulates an iPhone with a home
+/// indicator (34pt bottom view padding).
+Future<void> pumpWithIPhoneHomeIndicator(
+  WidgetTester tester,
+  Widget child,
+) async {
+  // iPhone 14 logical size with 34pt bottom safe area (home indicator).
+  const screenSize = Size(390, 844);
+  const homeIndicatorInset = 34.0;
+
+  await tester.binding.setSurfaceSize(screenSize);
+  tester.view.physicalSize = screenSize * tester.view.devicePixelRatio;
+  tester.view.padding = FakeViewPadding(
+    bottom: homeIndicatorInset * tester.view.devicePixelRatio,
+  );
+  addTearDown(() {
+    tester.view.resetPhysicalSize();
+    tester.view.resetPadding();
+    tester.binding.setSurfaceSize(null);
+  });
+
+  await tester.pumpWidget(
+    MediaQuery(
+      data: const MediaQueryData(
+        size: screenSize,
+        padding: EdgeInsets.only(bottom: homeIndicatorInset),
+      ),
+      child: MaterialApp(
+        theme: horcrux3Dark.copyWith(platform: TargetPlatform.iOS),
+        home: child,
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final secureStorageMock = SecureStorageMock();
+
+  setUpAll(() {
+    secureStorageMock.setUpAll();
+  });
+
+  tearDownAll(() {
+    secureStorageMock.tearDownAll();
+  });
+
+  setUp(() {
+    secureStorageMock.clear();
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('Bottom RowButton clears iPhone home indicator', () {
+    const homeIndicatorInset = 34.0;
+    const screenHeight = 844.0;
+    // The bottom edge of the *visible* button rectangle must sit at or above
+    // the home-indicator boundary. Allow 1px tolerance for layout rounding.
+    const tolerance = 1.0;
+
+    Future<void> expectBottomRowButtonClearsHomeIndicator(
+      WidgetTester tester,
+    ) async {
+      final rowButtons = find.byType(RowButton);
+      expect(rowButtons, findsWidgets);
+
+      // The visible button rectangle is the InkWell inside RowButton; the
+      // RowButton itself may wrap an external Padding for safe area.
+      final lastInkWell =
+          find.descendant(of: rowButtons.last, matching: find.byType(InkWell)).evaluate().first;
+      final renderBox = lastInkWell.renderObject! as RenderBox;
+      final bottomLeft = renderBox.localToGlobal(
+        Offset(0, renderBox.size.height),
+      );
+      final distanceFromScreenBottom = screenHeight - bottomLeft.dy;
+
+      expect(
+        distanceFromScreenBottom,
+        greaterThanOrEqualTo(homeIndicatorInset - tolerance),
+        reason: 'Bottom RowButton sits ${distanceFromScreenBottom.toStringAsFixed(1)}pt '
+            'above the screen bottom but should sit at or above '
+            'the ${homeIndicatorInset}pt home indicator inset.',
+      );
+    }
+
+    testWidgets(
+      'AccountCreatedScreen on iOS leaves room for home indicator',
+      (tester) async {
+        const testNsec = 'nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsnlfe5';
+
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+
+        await pumpWithIPhoneHomeIndicator(
+          tester,
+          UncontrolledProviderScope(
+            container: container,
+            child: const AccountCreatedScreen(nsec: testNsec),
+          ),
+        );
+
+        await expectBottomRowButtonClearsHomeIndicator(tester);
+      },
+    );
+
+    testWidgets(
+      'OnboardingScreen on iOS leaves room for home indicator',
+      (tester) async {
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+
+        await pumpWithIPhoneHomeIndicator(
+          tester,
+          UncontrolledProviderScope(
+            container: container,
+            child: const OnboardingScreen(),
+          ),
+        );
+
+        await expectBottomRowButtonClearsHomeIndicator(tester);
+      },
+    );
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Bead:** `horcrux_app-83p` — _Account Created screen: iOS bottom safe area / home indicator padding_

## Summary

`RowButton.addBottomSafeArea` previously added the system bottom inset to the button's **internal** padding, which only made the button taller without moving its visible rectangle above the iPhone home indicator / Android nav bar. On iOS the value was also hardcoded to `8pt`, so on screens that opt out of bottom `SafeArea` (e.g. `OnboardingScreen` using `SafeArea(bottom: false)`) the bottom RowButton sat flush with the screen edge and overlapped the home indicator.

The fix applies the inset as an **external margin** wrapping the button, and uses `MediaQuery.padding.bottom` uniformly so the same code works on iOS and Android. When a screen wraps the button in a full `SafeArea` that consumes the inset, `MediaQuery.padding.bottom` is `0` here and no extra space is added — so `AccountCreatedScreen` (which uses full `SafeArea`) keeps its existing layout while `OnboardingScreen` (which uses `SafeArea(bottom: false)`) is now correctly pushed up.

## Bug investigation

The bead title says "Account Created screen", but a layout test simulating an iPhone X+ (390x844, 34pt bottom inset) shows the actual broken screen is `OnboardingScreen`:

```
BEFORE FIX, on simulated iPhone X+ (34pt home indicator inset):

AccountCreatedScreen (uses full SafeArea):
  Bottom RowButton bottom edge sits 34pt above screen bottom   ✓ clears

OnboardingScreen (uses SafeArea(bottom: false)):
  Bottom RowButton bottom edge sits  0pt above screen bottom   ✗ overlaps indicator
```

`AccountCreatedScreen` actually clears the indicator today because its `SafeArea` consumes the bottom inset. `OnboardingScreen` does not — the previous logic added the inset as internal padding (button taller, but bottom edge unchanged) so the visible button rectangle still hugged the screen edge.

After the fix both screens land at 34pt above the screen bottom.

[Before: OnboardingScreen Get Started button flush against screen bottom (existing golden, iPhone SE size, no inset). On a device with a home indicator the button rectangle would extend underneath the indicator.](https://cursor.com/agents/bc-1d1009be-9974-4955-bb31-c649ea18cc12/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbefore_onboarding_button_flush_with_screen_bottom.png)

The existing golden above (rendered at iPhone SE 375×667 with no inset) shows the button rectangle docked to the screen edge — that's exactly the geometry that overlaps the home indicator on iPhone X+. With the fix, on devices with a 34pt bottom inset the entire button rectangle is shifted up by 34pt; on devices with no inset the rendering is unchanged, so this golden continues to match.

[safe_area_test_results.log](https://cursor.com/agents/bc-1d1009be-9974-4955-bb31-c649ea18cc12/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsafe_area_test_results.log)

## Changes

- `lib/widgets/row_button.dart`: apply `addBottomSafeArea` as an external `Padding` margin (push the button up) instead of as internal padding (make it taller). Drop the `dart:io` Platform branch — `MediaQuery.padding.bottom` already returns `0` inside a full `SafeArea` and the system inset elsewhere, so no platform check is needed.
- `test/screens/account_created_screen_safe_area_test.dart`: new layout test that pumps `AccountCreatedScreen` and `OnboardingScreen` with a simulated 34pt bottom view padding and asserts the bottom `RowButton`'s visible `InkWell` sits at or above the home-indicator boundary. Caught the regression on the pre-fix code.

## Testing

- ✅ `flutter test test/screens/account_created_screen_safe_area_test.dart` — both screens pass after the fix; `OnboardingScreen` failed on the pre-fix code (`Actual: <0.0>`).
- ✅ `flutter test --exclude-tags=golden` — 371 tests pass.
- ✅ `flutter analyze` — _No issues found!_
- ✅ `dart format .` — no diff.
- ⚠️ Manual reproduction on real iOS hardware was not possible from this Linux cloud VM. Reproduced and verified via the new layout test (which fails before the fix and passes after) plus the inspector measurements above.
- ⚠️ Golden tests are macOS-only and were not re-run; existing goldens are taken at iPhone SE / no-inset sizes where `MediaQuery.padding.bottom` is `0`, so the rendered output is unchanged by this fix.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d1009be-9974-4955-bb31-c649ea18cc12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d1009be-9974-4955-bb31-c649ea18cc12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

