### PR TITLE
Show Manage Recovery button when owner restores content during recovery

### DIFF
--- a/lib/widgets/vault_detail_button_stack.dart
+++ b/lib/widgets/vault_detail_button_stack.dart
@@ -221,17 +221,12 @@ class VaultDetailButtonStack extends ConsumerWidget {
                           );
                         }
                       }
-                    }
 
-                    // Owner-steward state: owner has deleted content but kept shards
-                    // Show special buttons for recovery
-                    final isOwnerSteward = isVaultOwner &&
-                        currentVault != null &&
-                        currentVault.content == null &&
-                        currentVault.shards.isNotEmpty;
-
-                    if (isOwnerSteward) {
-                      // Real recovery only: practice is managed via "Manage Practice Recovery" above.
+                      // Surface "Manage Recovery" for the owner whenever they have an
+                      // active real recovery, regardless of content state. Owners can
+                      // recreate vault content (or restore it) while a recovery is still
+                      // in flight; gating on owner-steward state alone made the button
+                      // vanish in that scenario (bug horcrux_app-e0h).
                       if (showManageRealRecovery) {
                         final myRecoveryId = myActiveRealRecovery.id;
                         buttons.add(
@@ -249,15 +244,27 @@ class VaultDetailButtonStack extends ConsumerWidget {
                             text: 'Manage Recovery',
                           ),
                         );
-                      } else if (showInitiateRealRecovery) {
-                        buttons.add(
-                          RowButtonConfig(
-                            onPressed: () => _initiateRecovery(context, ref, vaultId),
-                            icon: Icons.restore,
-                            text: 'Initiate Recovery',
-                          ),
-                        );
                       }
+                    }
+
+                    // Owner-steward state: owner has deleted content but kept shards.
+                    // Only "Initiate Recovery" is gated on this state -- you can only
+                    // start a real recovery when you have shards but no content. Managing
+                    // an existing recovery is handled in the owner block above so it
+                    // survives the owner adding content back mid-recovery.
+                    final isOwnerSteward = isVaultOwner &&
+                        currentVault != null &&
+                        currentVault.content == null &&
+                        currentVault.shards.isNotEmpty;
+
+                    if (isOwnerSteward && showInitiateRealRecovery) {
+                      buttons.add(
+                        RowButtonConfig(
+                          onPressed: () => _initiateRecovery(context, ref, vaultId),
+                          icon: Icons.restore,
+                          text: 'Initiate Recovery',
+                        ),
+                      );
                     }
 
                     // Recovery buttons - only show for stewards (not owners, since owners already have contents)

--- a/test/screens/vault_detail_screen_test.dart
+++ b/test/screens/vault_detail_screen_test.dart
@@ -312,6 +312,84 @@ void main() {
     // finalizes the recovery from the same Manage screen by tapping "Recover
     // Vault". If the widget filters by `isActive` only, that path disappears
     // and the user is incorrectly offered "Initiate Recovery" again.
+    // Regression for horcrux_app-e0h: an owner who deletes content, initiates
+    // recovery, and then creates new vault content goes from owner-steward
+    // (content == null) back to a regular owner (content != null). Their real
+    // recovery is still in flight, but the "Manage Recovery" button used to be
+    // gated solely by owner-steward state and disappeared the moment content
+    // came back.
+    testWidgets(
+      'shows Manage Recovery for an owner with content and an active real recovery',
+      (tester) async {
+        final ownerShard = createShardData(
+          shard: 'owner-shard-data',
+          threshold: 2,
+          shardIndex: 0,
+          totalShards: 3,
+          primeMod: 'test-prime-mod',
+          creatorPubkey: testPubkey,
+          vaultId: 'test-vault',
+          vaultName: 'Test Vault',
+          distributionVersion: 1,
+        );
+
+        final myRequest = RecoveryRequest(
+          id: 'my-request',
+          vaultId: 'test-vault',
+          initiatorPubkey: testPubkey,
+          requestedAt: DateTime(2024, 1, 1, 10),
+          status: RecoveryRequestStatus.inProgress,
+          threshold: 2,
+        );
+
+        // Owner restored content while a real recovery they initiated is still
+        // in flight. Shards may or may not still be present after content is
+        // recreated; the bug reproduces either way, but include the owner's
+        // shard to mirror the realistic state right after content recreation.
+        final vault = Vault(
+          id: 'test-vault',
+          name: 'Test Vault',
+          content: 'New vault content',
+          createdAt: DateTime(2024, 1, 1),
+          ownerPubkey: testPubkey,
+          shards: [ownerShard],
+          recoveryRequests: [myRequest],
+        );
+
+        final container = ProviderContainer(
+          overrides: [
+            vaultProvider('test-vault').overrideWith((ref) => Stream.value(vault)),
+            currentPublicKeyProvider.overrideWith((ref) async => testPubkey),
+            recoveryStatusProvider.overrideWith((ref, vaultId) {
+              return AsyncValue.data(
+                RecoveryStatus(
+                  hasActiveRecovery: true,
+                  canRecover: false,
+                  activeRecoveryRequest: myRequest,
+                  isInitiator: true,
+                ),
+              );
+            }),
+          ],
+        );
+
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: const MaterialApp(home: VaultDetailScreen(vaultId: 'test-vault')),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        expect(find.text('Manage Recovery'), findsOneWidget);
+        // No new recovery should be initiable while one is already in flight.
+        expect(find.text('Initiate Recovery'), findsNothing);
+
+        container.dispose();
+      },
+    );
+
     testWidgets(
       'shows Manage Recovery when the current user\'s own request is completed',
       (tester) async {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Bead

`horcrux_app-e0h`

## What

Move the owner's "Manage Recovery" button out of the owner-steward gate so it stays visible whenever the current user has an active real recovery, regardless of vault content state. "Initiate Recovery" stays gated on owner-steward (you can only start a real recovery when you have shards but no content), and a regression test covering the bug repro is added.

## Why

Reproduction (from `horcrux_app-e0h`): delete vault contents, start recovery, then set new vault contents — the "Manage Recovery" button vanishes even though the recovery is still in flight.

Root cause: in `lib/widgets/vault_detail_button_stack.dart`, the owner's "Manage Recovery" was inside the `isOwnerSteward` block. `isOwnerSteward` requires `currentVault.content == null`, so as soon as the owner recreated content, the gate flipped off and the button disappeared. The status banner kept saying "Recovery in progress" because it resolves the user's session via `Vault.manageableRecoveryFor`, but the button stack didn't, leaving the banner as the only way back into the recovery.

Fix: surface "Manage Recovery" inside the owner block whenever `myActiveRealRecovery != null`, mirroring how "Manage Practice Recovery" already works alongside the practice initiator. The owner-steward block now only carries "Initiate Recovery".

## Testing

- ✅ `flutter analyze` — No issues found.
- ✅ `flutter test test/screens/vault_detail_screen_test.dart --exclude-tags=golden` — 6/6 (includes new regression test `shows Manage Recovery for an owner with content and an active real recovery`).
- ✅ Confirmed the new test fails on `main` (button missing) and passes after the fix.
- ✅ `flutter test --exclude-tags=golden` — 370/370 passing.
- ⚠️ Manual GUI repro skipped: this is a small, well-isolated state-machine fix with a regression test that exercises the exact widget path; running the Linux app to drive the multi-step bug repro (delete content → initiate recovery → recreate content) would not add signal beyond the widget test.

## Screenshots

n/a — visual change is only the visibility of an existing button in a state where it was previously hidden; covered by the widget regression test.

## Breaking changes

None.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3bbfa83c-8c24-49ec-8e08-b925c8ab3cd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3bbfa83c-8c24-49ec-8e08-b925c8ab3cd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

