### PR TITLE
[Option C] AppBar overflow: FittedBox(scaleDown)

### DIFF
--- a/lib/screens/account_choice_screen.dart
+++ b/lib/screens/account_choice_screen.dart
@@ -5,6 +5,7 @@ import '../utils/app_initialization.dart';
 import '../screens/account_created_screen.dart';
 import '../screens/login_screen.dart';
 import '../screens/vault_list_screen.dart';
+import '../widgets/horcrux_app_bar_title.dart';
 import '../widgets/horcrux_scaffold.dart';
 
 /// Screen allowing users to choose how to set up their account
@@ -19,7 +20,10 @@ class _AccountChoiceScreenState extends ConsumerState<AccountChoiceScreen> {
   @override
   Widget build(BuildContext context) {
     return HorcruxScaffold(
-      appBar: AppBar(title: const Text('Setup'), centerTitle: false),
+      appBar: AppBar(
+        title: const HorcruxAppBarTitle('Setup'),
+        centerTitle: false,
+      ),
       body: SafeArea(
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(16),

--- a/lib/screens/account_created_screen.dart
+++ b/lib/screens/account_created_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../widgets/row_button_stack.dart';
+import '../widgets/horcrux_app_bar_title.dart';
 import '../widgets/horcrux_scaffold.dart';
 import '../screens/vault_explainer_screen.dart';
 import '../screens/vault_list_screen.dart';
@@ -95,7 +96,7 @@ class _AccountCreatedScreenState extends ConsumerState<AccountCreatedScreen> {
     return HorcruxScaffold(
       appBar: AppBar(
         automaticallyImplyLeading: false, // No back button
-        title: const Text('Account Created'),
+        title: const HorcruxAppBarTitle('Account Created'),
         centerTitle: false,
       ),
       body: SafeArea(

--- a/lib/screens/account_management_screen.dart
+++ b/lib/screens/account_management_screen.dart
@@ -8,6 +8,7 @@ import '../services/ndk_service.dart';
 import '../services/relay_scan_service.dart';
 import '../services/logger.dart';
 import '../widgets/row_button.dart';
+import '../widgets/horcrux_app_bar_title.dart';
 import '../widgets/horcrux_scaffold.dart';
 
 /// Account management screen for viewing Nostr ID and managing account
@@ -195,7 +196,7 @@ class _AccountManagementScreenState extends ConsumerState<AccountManagementScree
 
     return HorcruxScaffold(
       appBar: AppBar(
-        title: const Text('Account Management'),
+        title: const HorcruxAppBarTitle('Account Management'),
         centerTitle: false,
       ),
       body: SafeArea(

--- a/lib/screens/backup_config_screen.dart
+++ b/lib/screens/backup_config_screen.dart
@@ -17,6 +17,7 @@ import '../providers/key_provider.dart';
 import '../utils/owner_push_opt_in_prompt.dart';
 import '../widgets/row_button_stack.dart';
 import '../widgets/recovery_rules_widget.dart';
+import '../widgets/horcrux_app_bar_title.dart';
 import '../widgets/horcrux_scaffold.dart';
 import 'vault_list_screen.dart';
 import 'add_steward_screen.dart';
@@ -263,7 +264,10 @@ class _BackupConfigScreenState extends ConsumerState<BackupConfigScreen> {
   Widget build(BuildContext context) {
     if (_isLoading) {
       return HorcruxScaffold(
-        appBar: AppBar(title: const Text('Recovery Plan'), centerTitle: false),
+        appBar: AppBar(
+          title: const HorcruxAppBarTitle('Recovery Plan'),
+          centerTitle: false,
+        ),
         body: const Center(child: CircularProgressIndicator()),
       );
     }
@@ -309,7 +313,10 @@ class _BackupConfigScreenState extends ConsumerState<BackupConfigScreen> {
         }
       },
       child: HorcruxScaffold(
-        appBar: AppBar(title: const Text('Recovery Plan'), centerTitle: false),
+        appBar: AppBar(
+          title: const HorcruxAppBarTitle('Recovery Plan'),
+          centerTitle: false,
+        ),
         body: Column(
           children: [
             Expanded(

--- a/lib/screens/edit_vault_screen.dart
+++ b/lib/screens/edit_vault_screen.dart
@@ -4,6 +4,7 @@ import '../models/vault.dart';
 import '../providers/vault_provider.dart';
 import '../widgets/vault_content_form.dart';
 import '../widgets/vault_content_save_mixin.dart';
+import '../widgets/horcrux_app_bar_title.dart';
 import '../widgets/horcrux_scaffold.dart';
 
 /// Edit existing vault screen
@@ -54,14 +55,14 @@ class _EditVaultScreenState extends ConsumerState<EditVaultScreen> with VaultCon
   Widget build(BuildContext context) {
     if (_vault == null) {
       return HorcruxScaffold(
-        appBar: AppBar(title: const Text('Vault Not Found')),
+        appBar: AppBar(title: const HorcruxAppBarTitle('Vault Not Found')),
         body: const Center(child: Text('This vault no longer exists.')),
       );
     }
 
     return HorcruxScaffold(
       appBar: AppBar(
-        title: const Text('Edit Vault'),
+        title: const HorcruxAppBarTitle('Edit Vault'),
         centerTitle: false,
         actions: [
           TextButton(

--- a/lib/screens/horcrux_gallery_screen.dart
+++ b/lib/screens/horcrux_gallery_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../widgets/row_button_stack.dart';
+import '../widgets/horcrux_app_bar_title.dart';
 import '../widgets/horcrux_scaffold.dart';
 
 class HorcruxGallery extends StatefulWidget {
@@ -20,7 +21,7 @@ class _HorcruxGalleryState extends State<HorcruxGallery> {
         final cs = Theme.of(context).colorScheme;
         return HorcruxScaffold(
           appBar: AppBar(
-            title: const Text('UI Component Gallery'),
+            title: const HorcruxAppBarTitle('UI Component Gallery'),
             actions: [
               PopupMenuButton(
                 itemBuilder: (_) => const [

--- a/lib/screens/import_success_screen.dart
+++ b/lib/screens/import_success_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../widgets/row_button_stack.dart';
+import '../widgets/horcrux_app_bar_title.dart';
 import '../widgets/horcrux_scaffold.dart';
 import '../screens/vault_explainer_screen.dart';
 import '../screens/vault_list_screen.dart';
@@ -18,11 +19,7 @@ class ImportSuccessScreen extends StatelessWidget {
     return HorcruxScaffold(
       appBar: AppBar(
         automaticallyImplyLeading: false, // No back button
-        title: const Text(
-          'Account Imported Successfully',
-          maxLines: 2,
-          overflow: TextOverflow.visible,
-        ),
+        title: const HorcruxAppBarTitle('Account Imported Successfully'),
         centerTitle: false,
       ),
       body: SafeArea(

--- a/lib/screens/invitation_acceptance_screen.dart
+++ b/lib/screens/invitation_acceptance_screen.dart
@@ -8,6 +8,7 @@ import '../providers/invitation_provider.dart';
 import '../providers/key_provider.dart';
 import '../widgets/row_button_stack.dart';
 import '../widgets/row_button.dart';
+import '../widgets/horcrux_app_bar_title.dart';
 import '../widgets/horcrux_scaffold.dart';
 import '../widgets/name_label.dart';
 
@@ -36,7 +37,10 @@ class _InvitationAcceptanceScreenState extends ConsumerState<InvitationAcceptanc
     final currentPubkeyAsync = ref.watch(currentPublicKeyProvider);
 
     return HorcruxScaffold(
-      appBar: AppBar(title: const Text('Invitation'), centerTitle: false),
+      appBar: AppBar(
+        title: const HorcruxAppBarTitle('Invitation'),
+        centerTitle: false,
+      ),
       body: invitationAsync.when(
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (error, stack) => Padding(

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -5,6 +5,7 @@ import '../providers/key_provider.dart';
 import '../utils/validators.dart';
 import '../utils/app_initialization.dart';
 import '../widgets/row_button.dart';
+import '../widgets/horcrux_app_bar_title.dart';
 import '../widgets/horcrux_scaffold.dart';
 import '../screens/import_success_screen.dart';
 
@@ -118,7 +119,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
 
     return HorcruxScaffold(
       appBar: AppBar(
-        title: const Text('Login with Nostr Key'),
+        title: const HorcruxAppBarTitle('Login with Nostr Key'),
         centerTitle: false,
       ),
       body: SafeArea(

--- a/lib/screens/practice_recovery_info_screen.dart
+++ b/lib/screens/practice_recovery_info_screen.dart
@@ -9,6 +9,7 @@ import '../services/recovery_service.dart';
 import '../services/logger.dart';
 import '../screens/recovery_status_screen.dart';
 import '../widgets/row_button.dart';
+import '../widgets/horcrux_app_bar_title.dart';
 import '../widgets/horcrux_scaffold.dart';
 
 /// Screen to explain the processs for practicing recovery.
@@ -25,7 +26,7 @@ class PracticeRecoveryInfoScreen extends ConsumerWidget {
 
     return HorcruxScaffold(
       appBar: AppBar(
-        title: const Text('Practice Recovery'),
+        title: const HorcruxAppBarTitle('Practice Recovery'),
         leading: IconButton(
           icon: const Icon(Icons.close),
           onPressed: () => Navigator.pop(context),

--- a/lib/screens/push_notification_settings_screen.dart
+++ b/lib/screens/push_notification_settings_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../services/logger.dart';
 import '../services/push_notification_receiver.dart';
+import '../widgets/horcrux_app_bar_title.dart';
 import '../widgets/horcrux_scaffold.dart';
 import '../widgets/push_privacy_learn_more_text.dart';
 
@@ -90,7 +91,7 @@ class _PushNotificationSettingsScreenState extends ConsumerState<PushNotificatio
     final theme = Theme.of(context);
     return HorcruxScaffold(
       appBar: AppBar(
-        title: const Text('Push Notifications'),
+        title: const HorcruxAppBarTitle('Push Notifications'),
         centerTitle: false,
       ),
       body: _loading

--- a/lib/screens/recovered_content_screen.dart
+++ b/lib/screens/recovered_content_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+import '../widgets/horcrux_app_bar_title.dart';
 import '../widgets/horcrux_scaffold.dart';
 
 /// Full-screen view of recovered vault plaintext with copy support.
@@ -27,7 +28,7 @@ class RecoveredContentScreen extends StatelessWidget {
       showNotificationBanner: false,
       appBar: AppBar(
         centerTitle: false,
-        title: const Text('Vault Contents'),
+        title: const HorcruxAppBarTitle('Vault Contents'),
         actions: [
           Padding(
             padding: const EdgeInsets.only(right: 6),

--- a/lib/screens/recovery_request_detail_screen.dart
+++ b/lib/screens/recovery_request_detail_screen.dart
@@ -9,6 +9,7 @@ import '../providers/recovery_provider.dart';
 import '../providers/vault_provider.dart';
 import '../utils/nostr_display.dart';
 import '../widgets/row_button_stack.dart';
+import '../widgets/horcrux_app_bar_title.dart';
 import '../widgets/horcrux_scaffold.dart';
 
 /// Screen for viewing and responding to a recovery request
@@ -198,11 +199,7 @@ class _RecoveryRequestDetailScreenState extends ConsumerState<RecoveryRequestDet
 
     return HorcruxScaffold(
       appBar: AppBar(
-        title: const Text(
-          'Recovery Request',
-          overflow: TextOverflow.visible,
-          maxLines: 2,
-        ),
+        title: const HorcruxAppBarTitle('Recovery Request'),
         centerTitle: false,
       ),
       body: _isLoading

--- a/lib/screens/recovery_request_screen.dart
+++ b/lib/screens/recovery_request_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../widgets/horcrux_app_bar_title.dart';
 import '../widgets/horcrux_scaffold.dart';
 
 /// Screen for initiating recovery of a vault
@@ -21,7 +22,7 @@ class _RecoveryRequestScreenState extends State<RecoveryRequestScreen> {
   Widget build(BuildContext context) {
     return HorcruxScaffold(
       appBar: AppBar(
-        title: const Text('Initiate Recovery'),
+        title: const HorcruxAppBarTitle('Initiate Recovery'),
         backgroundColor: Theme.of(context).primaryColor,
         foregroundColor: Colors.white,
       ),

--- a/lib/screens/recovery_status_screen.dart
+++ b/lib/screens/recovery_status_screen.dart
@@ -8,6 +8,7 @@ import '../services/recovery_service.dart';
 import '../services/vault_export_service.dart';
 import 'recovered_content_screen.dart';
 import '../widgets/recovery_stewards_widget.dart';
+import '../widgets/horcrux_app_bar_title.dart';
 import '../widgets/horcrux_scaffold.dart';
 import '../widgets/row_button.dart';
 import '../widgets/vault_owner_display.dart';
@@ -83,11 +84,7 @@ class _RecoveryStatusScreenState extends ConsumerState<RecoveryStatusScreen> {
 
     return HorcruxScaffold(
       appBar: AppBar(
-        title: const Text(
-          'Recovering Vault',
-          maxLines: 2,
-          overflow: TextOverflow.visible,
-        ),
+        title: const HorcruxAppBarTitle('Recovering Vault'),
         centerTitle: false,
       ),
       body: requestAsync.when(

--- a/lib/screens/relay_management_screen.dart
+++ b/lib/screens/relay_management_screen.dart
@@ -4,6 +4,7 @@ import '../models/relay_configuration.dart';
 import '../services/relay_scan_service.dart';
 import '../services/logger.dart';
 import '../utils/invite_code_utils.dart';
+import '../widgets/horcrux_app_bar_title.dart';
 import '../widgets/horcrux_scaffold.dart';
 
 /// Screen for managing Nostr relay configurations
@@ -188,7 +189,7 @@ class _RelayManagementScreenState extends ConsumerState<RelayManagementScreen> {
   Widget build(BuildContext context) {
     return HorcruxScaffold(
       appBar: AppBar(
-        title: const Text('Relay Management'),
+        title: const HorcruxAppBarTitle('Relay Management'),
         backgroundColor: Theme.of(context).primaryColor,
         foregroundColor: Colors.white,
         actions: [

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../widgets/debug_info_sheet.dart';
+import '../widgets/horcrux_app_bar_title.dart';
 import '../widgets/horcrux_scaffold.dart';
 import 'account_management_screen.dart';
 import 'push_notification_settings_screen.dart';
@@ -24,7 +25,10 @@ class SettingsScreen extends ConsumerWidget {
     final theme = Theme.of(context);
 
     return HorcruxScaffold(
-      appBar: AppBar(title: const Text('Settings'), centerTitle: false),
+      appBar: AppBar(
+        title: const HorcruxAppBarTitle('Settings'),
+        centerTitle: false,
+      ),
       body: ListView(
         children: [
           ListTile(

--- a/lib/screens/vault_create_screen.dart
+++ b/lib/screens/vault_create_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../widgets/row_button.dart';
 import '../widgets/vault_content_form.dart';
 import '../widgets/vault_content_save_mixin.dart';
+import '../widgets/horcrux_app_bar_title.dart';
 import '../widgets/horcrux_scaffold.dart';
 import 'backup_config_screen.dart';
 import 'vault_list_screen.dart';
@@ -53,7 +54,10 @@ class _VaultCreateScreenState extends ConsumerState<VaultCreateScreen> with Vaul
   @override
   Widget build(BuildContext context) {
     return HorcruxScaffold(
-      appBar: AppBar(title: const Text('New Vault'), centerTitle: false),
+      appBar: AppBar(
+        title: const HorcruxAppBarTitle('New Vault'),
+        centerTitle: false,
+      ),
       body: Column(
         children: [
           Expanded(

--- a/lib/screens/vault_detail_screen.dart
+++ b/lib/screens/vault_detail_screen.dart
@@ -10,6 +10,7 @@ import '../widgets/steward_list.dart';
 import '../widgets/vault_detail_button_stack.dart';
 import '../widgets/vault_status_banner.dart';
 import '../widgets/vault_owner_display.dart';
+import '../widgets/horcrux_app_bar_title.dart';
 import '../widgets/horcrux_scaffold.dart';
 
 /// Detail/view screen for displaying a vault
@@ -51,11 +52,17 @@ class _VaultDetailScreenState extends ConsumerState<VaultDetailScreen> {
 
     return vaultAsync.when(
       loading: () => Scaffold(
-        appBar: AppBar(title: const Text('Loading...'), centerTitle: false),
+        appBar: AppBar(
+          title: const HorcruxAppBarTitle('Loading...'),
+          centerTitle: false,
+        ),
         body: const Center(child: CircularProgressIndicator()),
       ),
       error: (error, stack) => Scaffold(
-        appBar: AppBar(title: const Text('Error'), centerTitle: false),
+        appBar: AppBar(
+          title: const HorcruxAppBarTitle('Error'),
+          centerTitle: false,
+        ),
         body: Center(
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
@@ -76,7 +83,7 @@ class _VaultDetailScreenState extends ConsumerState<VaultDetailScreen> {
         if (vault == null) {
           return Scaffold(
             appBar: AppBar(
-              title: const Text('Vault Not Found'),
+              title: const HorcruxAppBarTitle('Vault Not Found'),
               centerTitle: false,
             ),
             body: const Center(child: Text('This vault no longer exists.')),
@@ -117,7 +124,7 @@ class _VaultDetailScreenState extends ConsumerState<VaultDetailScreen> {
     return HorcruxScaffold(
       showNotificationBanner: true,
       appBar: AppBar(
-        title: Text(vault.name),
+        title: HorcruxAppBarTitle(vault.name),
         centerTitle: false,
         actions: [
           currentPubkeyAsync.when(

--- a/lib/screens/vault_explainer_screen.dart
+++ b/lib/screens/vault_explainer_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../widgets/row_button.dart';
+import '../widgets/horcrux_app_bar_title.dart';
 import '../widgets/horcrux_scaffold.dart';
 import 'vault_create_screen.dart';
 
@@ -22,7 +23,10 @@ class VaultExplainerScreen extends StatelessWidget {
     final textTheme = theme.textTheme;
 
     return HorcruxScaffold(
-      appBar: AppBar(title: const Text('Create Vault'), centerTitle: false),
+      appBar: AppBar(
+        title: const HorcruxAppBarTitle('Create Vault'),
+        centerTitle: false,
+      ),
       body: Column(
         children: [
           Expanded(

--- a/lib/widgets/horcrux_app_bar_title.dart
+++ b/lib/widgets/horcrux_app_bar_title.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+/// AppBar title wrapper for bead horcrux_app-dyc / Option C.
+///
+/// Wraps the title text in a `FittedBox(fit: BoxFit.scaleDown)` so the title
+/// stays on a single line at any phone width. The text never grows past the
+/// theme's titleTextStyle size, but it is allowed to shrink uniformly until
+/// it fits the available width. This option intentionally has *no minimum
+/// font size* — it always fits.
+///
+/// Tradeoff: long titles can render very small (e.g. 20pt) and the header
+/// rhythm becomes unpredictable across screens. See bead notes for the full
+/// design tradeoff vs Options B / E / H.
+class HorcruxAppBarTitle extends StatelessWidget {
+  final String text;
+
+  const HorcruxAppBarTitle(this.text, {super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final base = Theme.of(context).appBarTheme.titleTextStyle ?? const TextStyle();
+    return FittedBox(
+      fit: BoxFit.scaleDown,
+      alignment: Alignment.centerLeft,
+      child: DefaultTextStyle(
+        style: base,
+        softWrap: false,
+        maxLines: 1,
+        overflow: TextOverflow.visible,
+        child: Text(text),
+      ),
+    );
+  }
+}

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -470,7 +470,9 @@ ThemeData horcrux3(Brightness brightness) {
       ),
     ),
 
-    // AppBar: stark, minimal
+    // AppBar: stark, minimal. Single-line at theme size (40pt); titles
+    // shrink to fit via HorcruxAppBarTitle's FittedBox (Option C for bead
+    // horcrux_app-dyc), so toolbarHeight stays at the original 100pt.
     appBarTheme: AppBarTheme(
       backgroundColor: scaffoldBg,
       foregroundColor: primaryText,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Bead

`horcrux_app-dyc` — Fix App Title Bar Overflow.

This is **2 of 4** parallel option PRs filed under that bead. See `[Option B]`, `[Option H]`, `[Option E]` for the other three. Pick the one that feels best in the actual app and we'll close the others.

## What

- New `lib/widgets/horcrux_app_bar_title.dart` wraps the title text in `FittedBox(fit: BoxFit.scaleDown, alignment: centerLeft)` so it never grows past the theme size (40pt) but shrinks uniformly to fit the available width.
- The toolbar stays at the original 100pt — every title is single-line.
- Migrated every screen-level `AppBar(title: ... Text(...))` site (21 occurrences across 20 screens) to use `HorcruxAppBarTitle`.

## Why

Single-line titles preserve the simple, ledger-like header rhythm. The text is always whole — no ellipses, no wrapping — at the cost of consistency: a long title like `Account Imported Successfully` ends up rendering at ~20pt while `Settings` stays at 40pt. The gradient is documented in `horcrux_app-dyc` design notes (Option C tradeoff).

## Testing

- `dart format .` — clean.
- `flutter analyze` — `No issues found!`
- `flutter test --exclude-tags=golden` — 383/383 pass.
- In-tree mockup at iPhone-SE width (375pt):

[Option C rendered in-tree at 375pt](https://cursor.com/agents/bc-09f0ca63-d9e6-4ead-9384-5534187df16d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fappbar_option_c_in_tree.png)

You can see the header size differ from row to row.

## Screenshots

See above. Existing screen golden tests are stale and need `flutter test --update-goldens` on macOS once an option is picked.

## Breaking changes

None.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09f0ca63-d9e6-4ead-9384-5534187df16d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09f0ca63-d9e6-4ead-9384-5534187df16d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

