### PR TITLE
[Option E] AppBar overflow: slim AppBar, title in body

### DIFF
--- a/lib/screens/account_choice_screen.dart
+++ b/lib/screens/account_choice_screen.dart
@@ -19,7 +19,7 @@ class _AccountChoiceScreenState extends ConsumerState<AccountChoiceScreen> {
   @override
   Widget build(BuildContext context) {
     return HorcruxScaffold(
-      appBar: AppBar(title: const Text('Setup'), centerTitle: false),
+      screenTitle: 'Setup',
       body: SafeArea(
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(16),

--- a/lib/screens/account_created_screen.dart
+++ b/lib/screens/account_created_screen.dart
@@ -93,11 +93,8 @@ class _AccountCreatedScreenState extends ConsumerState<AccountCreatedScreen> {
     final textTheme = theme.textTheme;
 
     return HorcruxScaffold(
-      appBar: AppBar(
-        automaticallyImplyLeading: false, // No back button
-        title: const Text('Account Created'),
-        centerTitle: false,
-      ),
+      screenTitle: 'Account Created',
+      appBar: AppBar(automaticallyImplyLeading: false),
       body: SafeArea(
         child: Column(
           children: [

--- a/lib/screens/account_management_screen.dart
+++ b/lib/screens/account_management_screen.dart
@@ -194,10 +194,7 @@ class _AccountManagementScreenState extends ConsumerState<AccountManagementScree
     });
 
     return HorcruxScaffold(
-      appBar: AppBar(
-        title: const Text('Account Management'),
-        centerTitle: false,
-      ),
+      screenTitle: 'Account Management',
       body: SafeArea(
         child: Column(
           children: [

--- a/lib/screens/backup_config_screen.dart
+++ b/lib/screens/backup_config_screen.dart
@@ -262,9 +262,9 @@ class _BackupConfigScreenState extends ConsumerState<BackupConfigScreen> {
   @override
   Widget build(BuildContext context) {
     if (_isLoading) {
-      return HorcruxScaffold(
-        appBar: AppBar(title: const Text('Recovery Plan'), centerTitle: false),
-        body: const Center(child: CircularProgressIndicator()),
+      return const HorcruxScaffold(
+        screenTitle: 'Recovery Plan',
+        body: Center(child: CircularProgressIndicator()),
       );
     }
 
@@ -309,7 +309,7 @@ class _BackupConfigScreenState extends ConsumerState<BackupConfigScreen> {
         }
       },
       child: HorcruxScaffold(
-        appBar: AppBar(title: const Text('Recovery Plan'), centerTitle: false),
+        screenTitle: 'Recovery Plan',
         body: Column(
           children: [
             Expanded(

--- a/lib/screens/edit_vault_screen.dart
+++ b/lib/screens/edit_vault_screen.dart
@@ -53,15 +53,15 @@ class _EditVaultScreenState extends ConsumerState<EditVaultScreen> with VaultCon
   @override
   Widget build(BuildContext context) {
     if (_vault == null) {
-      return HorcruxScaffold(
-        appBar: AppBar(title: const Text('Vault Not Found')),
-        body: const Center(child: Text('This vault no longer exists.')),
+      return const HorcruxScaffold(
+        screenTitle: 'Vault Not Found',
+        body: Center(child: Text('This vault no longer exists.')),
       );
     }
 
     return HorcruxScaffold(
+      screenTitle: 'Edit Vault',
       appBar: AppBar(
-        title: const Text('Edit Vault'),
         centerTitle: false,
         actions: [
           TextButton(

--- a/lib/screens/horcrux_gallery_screen.dart
+++ b/lib/screens/horcrux_gallery_screen.dart
@@ -19,8 +19,8 @@ class _HorcruxGalleryState extends State<HorcruxGallery> {
       builder: (context) {
         final cs = Theme.of(context).colorScheme;
         return HorcruxScaffold(
+          screenTitle: 'UI Component Gallery',
           appBar: AppBar(
-            title: const Text('UI Component Gallery'),
             actions: [
               PopupMenuButton(
                 itemBuilder: (_) => const [

--- a/lib/screens/import_success_screen.dart
+++ b/lib/screens/import_success_screen.dart
@@ -16,15 +16,8 @@ class ImportSuccessScreen extends StatelessWidget {
     final textTheme = theme.textTheme;
 
     return HorcruxScaffold(
-      appBar: AppBar(
-        automaticallyImplyLeading: false, // No back button
-        title: const Text(
-          'Account Imported Successfully',
-          maxLines: 2,
-          overflow: TextOverflow.visible,
-        ),
-        centerTitle: false,
-      ),
+      screenTitle: 'Account Imported Successfully',
+      appBar: AppBar(automaticallyImplyLeading: false),
       body: SafeArea(
         child: Column(
           children: [

--- a/lib/screens/invitation_acceptance_screen.dart
+++ b/lib/screens/invitation_acceptance_screen.dart
@@ -36,7 +36,7 @@ class _InvitationAcceptanceScreenState extends ConsumerState<InvitationAcceptanc
     final currentPubkeyAsync = ref.watch(currentPublicKeyProvider);
 
     return HorcruxScaffold(
-      appBar: AppBar(title: const Text('Invitation'), centerTitle: false),
+      screenTitle: 'Invitation',
       body: invitationAsync.when(
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (error, stack) => Padding(

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -117,10 +117,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
     final textTheme = theme.textTheme;
 
     return HorcruxScaffold(
-      appBar: AppBar(
-        title: const Text('Login with Nostr Key'),
-        centerTitle: false,
-      ),
+      screenTitle: 'Login with Nostr Key',
       body: SafeArea(
         child: Column(
           children: [

--- a/lib/screens/practice_recovery_info_screen.dart
+++ b/lib/screens/practice_recovery_info_screen.dart
@@ -24,8 +24,8 @@ class PracticeRecoveryInfoScreen extends ConsumerWidget {
     final currentPubkeyAsync = ref.watch(currentPublicKeyProvider);
 
     return HorcruxScaffold(
+      screenTitle: 'Practice Recovery',
       appBar: AppBar(
-        title: const Text('Practice Recovery'),
         leading: IconButton(
           icon: const Icon(Icons.close),
           onPressed: () => Navigator.pop(context),

--- a/lib/screens/push_notification_settings_screen.dart
+++ b/lib/screens/push_notification_settings_screen.dart
@@ -89,10 +89,7 @@ class _PushNotificationSettingsScreenState extends ConsumerState<PushNotificatio
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return HorcruxScaffold(
-      appBar: AppBar(
-        title: const Text('Push Notifications'),
-        centerTitle: false,
-      ),
+      screenTitle: 'Push Notifications',
       body: _loading
           ? const Center(child: CircularProgressIndicator())
           : ListView(

--- a/lib/screens/recovered_content_screen.dart
+++ b/lib/screens/recovered_content_screen.dart
@@ -25,9 +25,9 @@ class RecoveredContentScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return HorcruxScaffold(
       showNotificationBanner: false,
+      screenTitle: 'Vault Contents',
       appBar: AppBar(
         centerTitle: false,
-        title: const Text('Vault Contents'),
         actions: [
           Padding(
             padding: const EdgeInsets.only(right: 6),

--- a/lib/screens/recovery_request_detail_screen.dart
+++ b/lib/screens/recovery_request_detail_screen.dart
@@ -197,14 +197,7 @@ class _RecoveryRequestDetailScreenState extends ConsumerState<RecoveryRequestDet
     final vaultAsync = ref.watch(vaultProvider(request.vaultId));
 
     return HorcruxScaffold(
-      appBar: AppBar(
-        title: const Text(
-          'Recovery Request',
-          overflow: TextOverflow.visible,
-          maxLines: 2,
-        ),
-        centerTitle: false,
-      ),
+      screenTitle: 'Recovery Request',
       body: _isLoading
           ? const Center(child: CircularProgressIndicator())
           : vaultAsync.when(

--- a/lib/screens/recovery_request_screen.dart
+++ b/lib/screens/recovery_request_screen.dart
@@ -20,8 +20,8 @@ class _RecoveryRequestScreenState extends State<RecoveryRequestScreen> {
   @override
   Widget build(BuildContext context) {
     return HorcruxScaffold(
+      screenTitle: 'Initiate Recovery',
       appBar: AppBar(
-        title: const Text('Initiate Recovery'),
         backgroundColor: Theme.of(context).primaryColor,
         foregroundColor: Colors.white,
       ),

--- a/lib/screens/recovery_status_screen.dart
+++ b/lib/screens/recovery_status_screen.dart
@@ -82,14 +82,7 @@ class _RecoveryStatusScreenState extends ConsumerState<RecoveryStatusScreen> {
     requestAsync.whenData(_scheduleAlreadyEndedAlertIfNeeded);
 
     return HorcruxScaffold(
-      appBar: AppBar(
-        title: const Text(
-          'Recovering Vault',
-          maxLines: 2,
-          overflow: TextOverflow.visible,
-        ),
-        centerTitle: false,
-      ),
+      screenTitle: 'Recovering Vault',
       body: requestAsync.when(
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (error, stack) => Center(child: Text('Error: $error')),

--- a/lib/screens/relay_management_screen.dart
+++ b/lib/screens/relay_management_screen.dart
@@ -187,8 +187,8 @@ class _RelayManagementScreenState extends ConsumerState<RelayManagementScreen> {
   @override
   Widget build(BuildContext context) {
     return HorcruxScaffold(
+      screenTitle: 'Relay Management',
       appBar: AppBar(
-        title: const Text('Relay Management'),
         backgroundColor: Theme.of(context).primaryColor,
         foregroundColor: Colors.white,
         actions: [

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -24,7 +24,7 @@ class SettingsScreen extends ConsumerWidget {
     final theme = Theme.of(context);
 
     return HorcruxScaffold(
-      appBar: AppBar(title: const Text('Settings'), centerTitle: false),
+      screenTitle: 'Settings',
       body: ListView(
         children: [
           ListTile(

--- a/lib/screens/vault_create_screen.dart
+++ b/lib/screens/vault_create_screen.dart
@@ -53,7 +53,7 @@ class _VaultCreateScreenState extends ConsumerState<VaultCreateScreen> with Vaul
   @override
   Widget build(BuildContext context) {
     return HorcruxScaffold(
-      appBar: AppBar(title: const Text('New Vault'), centerTitle: false),
+      screenTitle: 'New Vault',
       body: Column(
         children: [
           Expanded(

--- a/lib/screens/vault_detail_screen.dart
+++ b/lib/screens/vault_detail_screen.dart
@@ -50,12 +50,12 @@ class _VaultDetailScreenState extends ConsumerState<VaultDetailScreen> {
     final vaultAsync = ref.watch(vaultProvider(vaultId));
 
     return vaultAsync.when(
-      loading: () => Scaffold(
-        appBar: AppBar(title: const Text('Loading...'), centerTitle: false),
-        body: const Center(child: CircularProgressIndicator()),
+      loading: () => const HorcruxScaffold(
+        screenTitle: 'Loading...',
+        body: Center(child: CircularProgressIndicator()),
       ),
-      error: (error, stack) => Scaffold(
-        appBar: AppBar(title: const Text('Error'), centerTitle: false),
+      error: (error, stack) => HorcruxScaffold(
+        screenTitle: 'Error',
         body: Center(
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
@@ -74,12 +74,9 @@ class _VaultDetailScreenState extends ConsumerState<VaultDetailScreen> {
       ),
       data: (vault) {
         if (vault == null) {
-          return Scaffold(
-            appBar: AppBar(
-              title: const Text('Vault Not Found'),
-              centerTitle: false,
-            ),
-            body: const Center(child: Text('This vault no longer exists.')),
+          return const HorcruxScaffold(
+            screenTitle: 'Vault Not Found',
+            body: Center(child: Text('This vault no longer exists.')),
           );
         }
 
@@ -116,8 +113,8 @@ class _VaultDetailScreenState extends ConsumerState<VaultDetailScreen> {
   ) {
     return HorcruxScaffold(
       showNotificationBanner: true,
+      screenTitle: vault.name,
       appBar: AppBar(
-        title: Text(vault.name),
         centerTitle: false,
         actions: [
           currentPubkeyAsync.when(

--- a/lib/screens/vault_explainer_screen.dart
+++ b/lib/screens/vault_explainer_screen.dart
@@ -22,7 +22,7 @@ class VaultExplainerScreen extends StatelessWidget {
     final textTheme = theme.textTheme;
 
     return HorcruxScaffold(
-      appBar: AppBar(title: const Text('Create Vault'), centerTitle: false),
+      screenTitle: 'Create Vault',
       body: Column(
         children: [
           Expanded(

--- a/lib/screens/vault_list_screen.dart
+++ b/lib/screens/vault_list_screen.dart
@@ -19,19 +19,16 @@ class VaultListScreen extends ConsumerWidget {
 
     return HorcruxScaffold(
       showNotificationBanner: true,
+      screenTitle: 'Horcrux',
       appBar: AppBar(
-        title: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Image.asset(
-              'assets/icon/app_icon.png',
-              height: 40,
-              width: 40,
-              fit: BoxFit.contain,
-            ),
-            const SizedBox(width: 8),
-            const Text('Horcrux'),
-          ],
+        leading: Padding(
+          padding: const EdgeInsets.only(left: 12),
+          child: Image.asset(
+            'assets/icon/app_icon.png',
+            height: 24,
+            width: 24,
+            fit: BoxFit.contain,
+          ),
         ),
         centerTitle: false,
         actions: [

--- a/lib/widgets/horcrux_scaffold.dart
+++ b/lib/widgets/horcrux_scaffold.dart
@@ -1,11 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'horcrux_screen_title.dart';
 import 'recovery_request_banner.dart';
 
 /// Scaffold wrapper that automatically includes the recovery request banner
-/// below the AppBar when there are pending recovery requests
+/// below the AppBar when there are pending recovery requests.
+///
+/// For bead horcrux_app-dyc Option E, also supports a [screenTitle] field:
+/// when set, HorcruxScaffold renders a `HorcruxScreenTitle` at the top of
+/// the body (so the page title can wrap freely) and the AppBar becomes a
+/// slim nav strip carrying only the back button and any actions. If no
+/// [appBar] is provided alongside [screenTitle], a default `AppBar()` is
+/// used.
 class HorcruxScaffold extends ConsumerWidget {
   final PreferredSizeWidget? appBar;
+  final String? screenTitle;
   final Widget? body;
   final Widget? floatingActionButton;
   final FloatingActionButtonLocation? floatingActionButtonLocation;
@@ -30,6 +39,7 @@ class HorcruxScaffold extends ConsumerWidget {
   const HorcruxScaffold({
     super.key,
     this.appBar,
+    this.screenTitle,
     this.body,
     this.floatingActionButton,
     this.floatingActionButtonLocation,
@@ -54,9 +64,10 @@ class HorcruxScaffold extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final effectiveAppBar = appBar ?? (screenTitle != null ? AppBar() : null);
     return Scaffold(
-      appBar: appBar,
-      body: _buildBody(context, ref),
+      appBar: effectiveAppBar,
+      body: _buildBody(context, ref, effectiveAppBar),
       floatingActionButton: floatingActionButton,
       floatingActionButtonLocation: floatingActionButtonLocation,
       floatingActionButtonAnimator: floatingActionButtonAnimator,
@@ -78,16 +89,32 @@ class HorcruxScaffold extends ConsumerWidget {
     );
   }
 
-  Widget _buildBody(BuildContext context, WidgetRef ref) {
-    if (!showNotificationBanner || appBar == null) {
-      return body ?? const SizedBox.shrink();
+  Widget _buildBody(
+    BuildContext context,
+    WidgetRef ref,
+    PreferredSizeWidget? effectiveAppBar,
+  ) {
+    Widget content = body ?? const SizedBox.shrink();
+
+    if (screenTitle != null) {
+      content = Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          HorcruxScreenTitle(screenTitle!),
+          Expanded(child: content),
+        ],
+      );
     }
 
-    return Column(
-      children: [
-        const RecoveryRequestBanner(),
-        Expanded(child: body ?? const SizedBox.shrink()),
-      ],
-    );
+    if (showNotificationBanner && effectiveAppBar != null) {
+      content = Column(
+        children: [
+          const RecoveryRequestBanner(),
+          Expanded(child: content),
+        ],
+      );
+    }
+
+    return content;
   }
 }

--- a/lib/widgets/horcrux_screen_title.dart
+++ b/lib/widgets/horcrux_screen_title.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+/// Body-level page title used with the slim AppBar pattern.
+///
+/// Option E for bead horcrux_app-dyc: the AppBar becomes a slim nav strip
+/// (back button + actions) and the large page title moves into the body as
+/// the first item, where it can wrap freely without eating toolbar chrome.
+///
+/// Renders the title at displaySmall scale (28pt Archivo w700 from the
+/// theme) on as many lines as it needs, with horizontal padding that
+/// matches the screen content padding. Place it as the first child of your
+/// scrollable body, above any other content.
+class HorcruxScreenTitle extends StatelessWidget {
+  final String text;
+
+  const HorcruxScreenTitle(this.text, {super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final style = Theme.of(context).textTheme.displaySmall;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+      child: Text(text, style: style),
+    );
+  }
+}

--- a/lib/widgets/theme.dart
+++ b/lib/widgets/theme.dart
@@ -470,17 +470,19 @@ ThemeData horcrux3(Brightness brightness) {
       ),
     ),
 
-    // AppBar: stark, minimal
+    // AppBar: stark, minimal nav strip. The page title now lives in the
+    // body (rendered via HorcruxScreenTitle), so the bar only carries the
+    // back arrow and any actions. Option E for bead horcrux_app-dyc.
     appBarTheme: AppBarTheme(
       backgroundColor: scaffoldBg,
       foregroundColor: primaryText,
       elevation: 0,
       surfaceTintColor: Colors.transparent, // Prevent bluish tint when scrolling
-      toolbarHeight: 100.0,
-      titleSpacing: 32.0,
+      toolbarHeight: 52.0,
+      titleSpacing: 16.0,
       leadingWidth: 32.0,
       titleTextStyle: TextStyle(
-        fontSize: 40,
+        fontSize: 18,
         fontWeight: FontWeight.w500,
         fontFamily: 'Archivo',
         color: primaryText,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Bead

`horcrux_app-dyc` — Fix App Title Bar Overflow.

This is **4 of 4** parallel option PRs filed under that bead. See `[Option B]`, `[Option C]`, `[Option H]` for the other three. Pick whichever feels best in the actual app and we'll close the others.

## What

The large 40pt page title moves out of the AppBar entirely. The AppBar becomes a slim 52pt nav strip carrying only the back button and any actions. The title is rendered as the first item of the body at `displaySmall` (28pt Archivo w700) where it can wrap freely on as many lines as it needs without eating any toolbar chrome.

- New `lib/widgets/horcrux_screen_title.dart` renders the body header.
- `lib/widgets/horcrux_scaffold.dart` learns a `screenTitle` parameter that:
  - builds a default slim `AppBar()` when no appBar is provided, and
  - wraps the body in a `Column([HorcruxScreenTitle(...), Expanded(body)])`.
- `lib/widgets/theme.dart`:
  - `appBarTheme.toolbarHeight`: 100 → 52
  - `titleSpacing`: 32 → 16
  - `titleTextStyle`: 40pt → 18pt (only used by leftover non-screenTitle AppBars)
- Migrated every screen-level AppBar (21 sites across 20 screens) to pass `screenTitle:` instead of an in-AppBar `Text` title. Removed the ad-hoc `maxLines/overflow` band-aids on `import_success`, `recovery_request_detail`, `recovery_status`. Replaced four bare `Scaffold` usages on `vault_detail_screen.dart` with `HorcruxScaffold` for consistency.
- `vault_list_screen.dart`: the home brand mark (40pt icon + "Horcrux" Row) is broken up — the icon shrinks to 24pt and moves to the AppBar leading slot; "Horcrux" becomes the body title. Open to feedback on this one specifically; the home screen is the one place where the existing 40pt icon block worked fine.

## Why

This option fully solves the problem class (no more overflow, ever — title can wrap to N lines), and it's the most modern-feeling pattern (large iOS-style title in scroll content). It's also the largest refactor.

Tradeoffs:
- The 40pt brand moment in the AppBar is gone. The page header goes from 40pt → 28pt.
- Existing screens that already had prominent body H1s now have a redundant header above them — those will want a small content cleanup pass.
- The slim 52pt bar can feel empty on screens with no actions.

## Testing

- `dart format .` — clean.
- `flutter analyze` — `No issues found!`
- `flutter test --exclude-tags=golden` — 383/383 pass.
- In-tree mockup at iPhone-SE width (375pt):

[Option E rendered in-tree at 375pt](https://cursor.com/agents/bc-09f0ca63-d9e6-4ead-9384-5534187df16d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fappbar_option_e_in_tree.png)

All four titles render in full; "Account Imported Successfully" wraps to two lines naturally.

## Screenshots

See above. **Existing screen golden tests will diff dramatically** — every screen's header has changed shape. Reviewer will need `flutter test --update-goldens` on macOS.

## Breaking changes

`HorcruxScaffold` API gained a `screenTitle: String?` parameter. Existing callers continue to work as before; new callers can pass `screenTitle` for the slim-bar pattern.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09f0ca63-d9e6-4ead-9384-5534187df16d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09f0ca63-d9e6-4ead-9384-5534187df16d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

