### PR TITLE
fix(ui): RowButton bottom inset — avoid double SafeArea (horcrux_app-83p)

### DIFF
--- a/lib/screens/account_created_screen.dart
+++ b/lib/screens/account_created_screen.dart
@@ -99,6 +99,7 @@ class _AccountCreatedScreenState extends ConsumerState<AccountCreatedScreen> {
         centerTitle: false,
       ),
       body: SafeArea(
+        bottom: false, // RowButtonStack applies bottom inset via addBottomSafeArea
         child: Column(
           children: [
             Expanded(

--- a/lib/screens/account_management_screen.dart
+++ b/lib/screens/account_management_screen.dart
@@ -199,6 +199,7 @@ class _AccountManagementScreenState extends ConsumerState<AccountManagementScree
         centerTitle: false,
       ),
       body: SafeArea(
+        bottom: false, // RowButton applies bottom inset via addBottomSafeArea
         child: Column(
           children: [
             Expanded(

--- a/lib/screens/horcrux_gallery_screen.dart
+++ b/lib/screens/horcrux_gallery_screen.dart
@@ -174,6 +174,8 @@ class _HorcruxGalleryState extends State<HorcruxGallery> {
             ],
           ),
           bottomNavigationBar: SafeArea(
+            top: false,
+            bottom: false, // RowButtonStack applies bottom inset via addBottomSafeArea
             child: RowButtonStack(
               buttons: [
                 RowButtonConfig(

--- a/lib/screens/import_success_screen.dart
+++ b/lib/screens/import_success_screen.dart
@@ -26,6 +26,7 @@ class ImportSuccessScreen extends StatelessWidget {
         centerTitle: false,
       ),
       body: SafeArea(
+        bottom: false, // RowButtonStack applies bottom inset via addBottomSafeArea
         child: Column(
           children: [
             Expanded(

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -122,6 +122,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
         centerTitle: false,
       ),
       body: SafeArea(
+        bottom: false, // RowButton applies bottom inset via addBottomSafeArea
         child: Column(
           children: [
             Expanded(

--- a/lib/widgets/row_button.dart
+++ b/lib/widgets/row_button.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'dart:io' show Platform;
 
 /// A full-width button with an icon and text in a row layout
 class RowButton extends StatelessWidget {
@@ -57,12 +56,8 @@ class RowButton extends StatelessWidget {
 
     // Pad past the system inset at the bottom of the screen (iOS home indicator
     // or Android gesture/navigation bar) so the button isn't covered by it.
-    final systemBottomInset = MediaQuery.of(context).padding.bottom;
-    final bottomSafeArea = switch ((Platform.operatingSystem, addBottomSafeArea)) {
-      ('ios', true) => 8.0,
-      ('android', true) => systemBottomInset,
-      _ => 0.0,
-    };
+    final systemBottomInset = MediaQuery.paddingOf(context).bottom;
+    final bottomSafeArea = addBottomSafeArea ? systemBottomInset : 0.0;
 
     final effectivePadding = padding != null
         ? padding!.copyWith(bottom: padding!.bottom + bottomSafeArea)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Bead

horcrux_app-83p

## What

- Screens that wrapped the whole body (or gallery bottom bar) in `SafeArea` while also using `RowButton` / `RowButtonStack` with `addBottomSafeArea: true` applied the **bottom inset twice**, so buttons sat too high on iOS (and similarly on Android with gesture nav).
- Align those layouts with `OnboardingScreen`: **`SafeArea(bottom: false)`** on body columns that end in a bottom `RowButton`/`RowButtonStack`; **`HorcruxGallery`**: `SafeArea(top: false, bottom: false)` around the bottom bar so left/right notches stay padded without doubling bottom inset.
- **`RowButton`**: use **`MediaQuery.padding.bottom`** whenever `addBottomSafeArea` is true (same path as Android), instead of iOS-only `8.0`pt.

Also fixed the same pattern on **Login** and **Import success** (same bug class).

## Why

Single source of truth for bottom safe area on primary actions: either the scaffold/safe-area wrapper or `RowButton`, not both.

## Testing

- `dart format .`
- `flutter analyze` — No issues found
- `flutter test --exclude-tags=golden` — all passed (Linux VM; golden screenshots macOS-only)

## Screenshots

None (layout/inset logic only).

## Breaking changes

None.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2606cc7-2b4b-45f7-b95e-e9a054a177a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2606cc7-2b4b-45f7-b95e-e9a054a177a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

