### PR TITLE
docs: agents need not run bd dolt push (remote Dolt server)

### DIFF
--- a/.beads/README.md
+++ b/.beads/README.md
@@ -28,8 +28,7 @@ bd show <issue-id> --json
 bd update <issue-id> --claim
 bd update <issue-id> --status done
 
-# Sync with Dolt remote
-bd dolt push
+# This project uses server-mode bd against a remote Dolt database — routine bd commands persist there; agents do not need bd dolt push
 ```
 
 ### Working with Issues

--- a/.cursor/rules/beads-workflow.mdc
+++ b/.cursor/rules/beads-workflow.mdc
@@ -59,4 +59,4 @@ If a change affects visible copy or form validators (especially `lib/widgets/*_f
 
 ## Closing protocol
 
-Follow project/session rules in AGENTS.md and `bd prime` for `git push`, `bd dolt push`, and bead closure.
+Follow project/session rules in AGENTS.md and `bd prime` for `git push` and bead closure.

--- a/.cursor/rules/beads.mdc
+++ b/.cursor/rules/beads.mdc
@@ -13,7 +13,7 @@ This project uses [Beads (bd)](https://github.com/steveyegge/beads) for issue tr
 - When opening a GitHub PR for bd-tracked work, include that **bead issue ID** in the PR description (`bd show <id>`)
 - Use `bd ready` to find available work
 - Use `bd create` to track new issues/tasks/bugs
-- Use `bd dolt push` at end of session to sync with git remote
+- With this repo’s remote Dolt server, routine `bd` commands persist issues directly; agents should **not** run `bd dolt push` unless a maintainer explicitly requests it
 - Git hooks auto-sync on commit/merge
 
 ## Quick Reference
@@ -25,7 +25,6 @@ bd create --title="..." --type=task  # Create new issue
 bd update <id> --claim               # Claim work atomically
 bd close <id>                         # Mark complete
 bd dep add <issue> <depends-on>       # Add dependency (issue depends on depends-on)
-bd dolt push                               # Sync with git remote
 ```
 
 ## Workflow
@@ -33,7 +32,7 @@ bd dolt push                               # Sync with git remote
 2. Claim an issue atomically: `bd update <id> --claim`
 3. Do the work
 4. Mark complete: `bd close <id>`
-5. Sync: `bd dolt push` (or let git hooks handle it)
+5. Issue updates are stored on the remote Dolt server when you run `bd`; no separate sync step is required for agents
 
 ## Context Loading
 Run `bd prime` to get complete workflow documentation in AI-optimized format (~1-2k tokens).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,6 +351,7 @@ The Dart VM Service URI appears in the output (e.g. `http://127.0.0.1:8181/<toke
 
 - The `BEADS_DOLT_PASSWORD` secret must be set (Cursor secret for user `cursor_cloud`)
 - After `bd init` in server mode, `bd` connects to the remote Dolt server directly
+- **Agents:** Routine commands (`bd create`, `bd update`, `bd close`, notes, etc.) write to that server. Do **not** treat `bd dolt push` as a required end-of-session step here unless a maintainer asks for it (for example local or offline Dolt workflows).
 - Run `bd prime` at session start to load workflow context
 - Init command (run once per fresh VM): `BEADS_DOLT_PASSWORD="$BEADS_DOLT_PASSWORD" bd init --non-interactive --server --server-host=dolt.lorentz.is --server-port=3307 --server-user=cursor_cloud --external --database=horcrux_app --prefix=horcrux_app --skip-agents --skip-hooks`
 
@@ -403,10 +404,11 @@ bd close <id>         # Complete work
 4. **PUSH TO REMOTE** - This is MANDATORY:
    ```bash
    git pull --rebase
-   bd dolt push
    git push
    git status  # MUST show "up to date with origin"
    ```
+
+   Beads: With the configured remote Dolt server, updating issues via normal `bd` commands is sufficient; agents do not need to run `bd dolt push`.
 5. **Clean up** - Clear stashes, prune remote branches
 6. **Verify** - All changes committed AND pushed
 7. **Hand off** - Provide context for next session

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,10 +35,11 @@ bd close <id>         # Complete work
 4. **PUSH TO REMOTE** - This is MANDATORY:
    ```bash
    git pull --rebase
-   bd dolt push
    git push
    git status  # MUST show "up to date with origin"
    ```
+
+   Beads: With the configured remote Dolt server, updating issues via normal `bd` commands is sufficient; agents do not need to run `bd dolt push`.
 5. **Clean up** - Clear stashes, prune remote branches
 6. **Verify** - All changes committed AND pushed
 7. **Hand off** - Provide context for next session


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Bead:** horcrux_app-my6

**What:** Align agent-facing docs and Cursor beads rules with how this repo uses beads: `bd` is configured against a remote Dolt server, so normal commands persist issue updates without a separate `bd dolt push`.

**Why:** Session-completion text in AGENTS.md / CLAUDE.md incorrectly implied agents must run `bd dolt push`; that is unnecessary (and often denied) for cursor_cloud against the remote server.

**Changes:**
- `AGENTS.md` — beads section + session completion `git pull`/`git push` block (removed `bd dolt push`)
- `CLAUDE.md` — same session completion adjustment
- `.cursor/rules/beads.mdc` — core rules and workflow step 5
- `.cursor/rules/beads-workflow.mdc` — closing protocol line
- `.beads/README.md` — replace sync command with Horcrux-specific note

**Testing:** Documentation only; no code paths changed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-048f262d-7ec6-4dfe-8709-73c59497b00a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-048f262d-7ec6-4dfe-8709-73c59497b00a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

