### PR TITLE
fix: hydrate recovery requests in VaultDetailRepository (horcrux_app-2n0)

### DIFF
--- a/lib/database/recovery_request_hydration.dart
+++ b/lib/database/recovery_request_hydration.dart
@@ -1,0 +1,55 @@
+import 'dart:convert';
+
+import 'app_database.dart';
+import '../models/recovery_request.dart';
+import '../models/share.dart';
+
+/// Loads participant and response rows and builds a [RecoveryRequest].
+///
+/// Shared by vault repository and vault detail repository so recovery
+/// hydration stays consistent when the schema or mapping changes.
+Future<RecoveryRequest> recoveryRequestFromRow(AppDatabase db, RecoveryRequestRow r) async {
+  final participants = await db.recoveryDao.participantsFor(r.id);
+  final responses = await db.recoveryDao.responsesFor(r.id);
+  return RecoveryRequest.makeFromParticipants(
+    id: r.id,
+    vaultId: r.vaultId,
+    initiatorPubkey: r.initiatorPubkey,
+    requestedAt: DateTime.fromMillisecondsSinceEpoch(r.startedAt),
+    status: RecoveryRequestStatus.values.firstWhere(
+      (e) => e.name == r.status,
+      orElse: () => RecoveryRequestStatus.pending,
+    ),
+    threshold: r.thresholdAtStart,
+    nostrEventId: r.requestEventId,
+    eventCreationTime: r.eventCreationTimeMs != null
+        ? DateTime.fromMillisecondsSinceEpoch(r.eventCreationTimeMs!)
+        : null,
+    expiresAt: r.expiresAt == null ? null : DateTime.fromMillisecondsSinceEpoch(r.expiresAt!),
+    stewardPubkeys: participants.map((p) => p.pubkey),
+    responses: responses.map(recoveryResponseFromRow),
+    errorMessage: r.errorMessage,
+    isPractice: r.isPractice,
+  );
+}
+
+/// Maps a persisted recovery response row to the domain model.
+RecoveryResponse recoveryResponseFromRow(RecoveryResponseRow r) {
+  Share? share;
+  if (r.sharePayload.isNotEmpty) {
+    try {
+      share = shareFromJson(json.decode(r.sharePayload) as Map<String, dynamic>);
+    } catch (_) {
+      share = null;
+    }
+  }
+  return RecoveryResponse(
+    pubkey: r.responderPubkey,
+    approved: r.approved,
+    respondedAt:
+        r.respondedAtMs == null ? null : DateTime.fromMillisecondsSinceEpoch(r.respondedAtMs!),
+    share: share,
+    nostrEventId: r.nostrEventId,
+    errorMessage: r.errorMessage,
+  );
+}

--- a/lib/models/vault_detail.dart
+++ b/lib/models/vault_detail.dart
@@ -31,9 +31,7 @@ sealed class VaultDetail {
   /// Active stewards for this vault (left_at IS NULL in DB).
   List<Steward> get stewards;
 
-  /// In-flight recovery requests. Always empty until Phase 3 ships the
-  /// `recovery_requests` table; kept here so [hasActiveRecovery] and
-  /// [manageableRecoveryFor] work uniformly once Phase 3 lands.
+  /// In-flight recovery requests from the local `recovery_requests` table.
   List<RecoveryRequest> get recoveryRequests;
 
   bool get pushEnabled;

--- a/lib/providers/vault_detail_repository.dart
+++ b/lib/providers/vault_detail_repository.dart
@@ -1,10 +1,12 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
 
 import '../database/app_database.dart';
 import '../models/backup_config.dart';
+import '../models/recovery_request.dart';
 import '../models/share.dart';
 import '../models/steward.dart';
 import '../models/steward_status.dart';
@@ -20,9 +22,8 @@ import '../services/login_service.dart';
 /// row is ignored and [StewardedVaultDetail] is used so UI role gates stay
 /// consistent with [VaultDetail.isVaultOwner].
 ///
-/// **Phase 3 note**: [recoveryRequests] is always empty until the
-/// `recovery_requests` table lands. At that point this repository's hydration
-/// will include those rows.
+/// Recovery rows are read from `recovery_requests` (participants and
+/// responses included) when building each [VaultDetail].
 class VaultDetailRepository {
   final AppDatabase _db;
   final LoginService? _loginService;
@@ -72,10 +73,10 @@ class VaultDetailRepository {
   /// Reactive stream for a single vault. Emits null when the vault is not
   /// found or has been deleted.
   Stream<VaultDetail?> watchVaultDetail(String vaultId) {
-    // Re-hydrate when the vault row changes and when steward / held_share rows
-    // change — otherwise opening vault detail can stay stale until an unrelated
-    // `vaults` write (share ingest mostly bumps `last_synced_at`, but steward-
-    // only fixes must still repaint).
+    // Re-hydrate when the vault row changes, when steward / held_share rows
+    // change, and when recovery request rows change — otherwise the detail
+    // screen can show a stale "Initiate Recovery" vs "Manage Recovery" label
+    // until an unrelated write.
     return Stream<VaultDetail?>.multi((controller) {
       var closed = false;
 
@@ -94,6 +95,7 @@ class VaultDetailRepository {
         _db.vaultDao.watchById(vaultId).listen((_) => emit()),
         _db.stewardDao.watchActiveForVault(vaultId).listen((_) => emit()),
         _db.heldShareDao.watchForVault(vaultId).listen((_) => emit()),
+        _db.recoveryDao.watchForVault(vaultId).listen((_) => emit()),
       ];
 
       controller.onCancel = () {
@@ -157,6 +159,11 @@ class VaultDetailRepository {
       distributionVersion: row.currentDistributionVersion,
     );
     final inviteCodeByStewardId = await _inviteCodesByStewardId(row.id);
+    final recoveryRows = await _db.recoveryDao.forVault(row.id);
+    final recoveryRequests = <RecoveryRequest>[];
+    for (final rr in recoveryRows) {
+      recoveryRequests.add(await _recoveryRequestFromRow(rr));
+    }
 
     final stewards = stewardRows
         .map(
@@ -181,8 +188,10 @@ class VaultDetailRepository {
           )
         : null;
 
-    final deviceIsVaultOwner =
-        await _deviceTreatsOwnedRowAsVaultOwner(row: row, ownedRow: ownedRow);
+    final deviceIsVaultOwner = await _deviceTreatsOwnedRowAsVaultOwner(
+      row: row,
+      ownedRow: ownedRow,
+    );
 
     final createdAt = DateTime.fromMillisecondsSinceEpoch(row.createdAt);
     final archivedAt =
@@ -202,7 +211,7 @@ class VaultDetailRepository {
         threshold: row.threshold,
         totalShares: row.totalShares,
         stewards: stewards,
-        recoveryRequests: const [],
+        recoveryRequests: recoveryRequests,
         pushEnabled: row.pushEnabled,
         createdAt: createdAt,
         archivedAt: archivedAt,
@@ -223,7 +232,7 @@ class VaultDetailRepository {
       threshold: row.threshold,
       totalShares: row.totalShares,
       stewards: stewards,
-      recoveryRequests: const [],
+      recoveryRequests: recoveryRequests,
       pushEnabled: row.pushEnabled,
       createdAt: createdAt,
       archivedAt: archivedAt,
@@ -260,11 +269,15 @@ class VaultDetailRepository {
     }
 
     final distributionId = _distributionId(vaultId, distributionVersion);
-    final byId = await (_db.select(_db.distributions)..where((d) => d.id.equals(distributionId)))
+    final byId = await (_db.select(
+      _db.distributions,
+    )..where((d) => d.id.equals(distributionId)))
         .getSingleOrNull();
     final distribution = byId ??
         await (_db.select(_db.distributions)
-              ..where((d) => d.vaultId.equals(vaultId) & d.version.equals(distributionVersion)))
+              ..where(
+                (d) => d.vaultId.equals(vaultId) & d.version.equals(distributionVersion),
+              ))
             .getSingleOrNull();
     if (distribution == null) {
       return const {};
@@ -318,6 +331,53 @@ class VaultDetailRepository {
       acknowledgedAt: acknowledgedAt,
       acknowledgmentEventId: distributionShareRow?.acknowledgmentEventId,
       acknowledgedDistributionVersion: acknowledgedVersion,
+    );
+  }
+
+  Future<RecoveryRequest> _recoveryRequestFromRow(RecoveryRequestRow r) async {
+    final participants = await _db.recoveryDao.participantsFor(r.id);
+    final responses = await _db.recoveryDao.responsesFor(r.id);
+    return RecoveryRequest.makeFromParticipants(
+      id: r.id,
+      vaultId: r.vaultId,
+      initiatorPubkey: r.initiatorPubkey,
+      requestedAt: DateTime.fromMillisecondsSinceEpoch(r.startedAt),
+      status: RecoveryRequestStatus.values.firstWhere(
+        (e) => e.name == r.status,
+        orElse: () => RecoveryRequestStatus.pending,
+      ),
+      threshold: r.thresholdAtStart,
+      nostrEventId: r.requestEventId,
+      eventCreationTime: r.eventCreationTimeMs != null
+          ? DateTime.fromMillisecondsSinceEpoch(r.eventCreationTimeMs!)
+          : null,
+      expiresAt: r.expiresAt == null ? null : DateTime.fromMillisecondsSinceEpoch(r.expiresAt!),
+      stewardPubkeys: participants.map((p) => p.pubkey),
+      responses: responses.map(_recoveryResponseFromRow),
+      errorMessage: r.errorMessage,
+      isPractice: r.isPractice,
+    );
+  }
+
+  RecoveryResponse _recoveryResponseFromRow(RecoveryResponseRow r) {
+    Share? share;
+    if (r.sharePayload.isNotEmpty) {
+      try {
+        share = shareFromJson(
+          json.decode(r.sharePayload) as Map<String, dynamic>,
+        );
+      } catch (_) {
+        share = null;
+      }
+    }
+    return RecoveryResponse(
+      pubkey: r.responderPubkey,
+      approved: r.approved,
+      respondedAt:
+          r.respondedAtMs == null ? null : DateTime.fromMillisecondsSinceEpoch(r.respondedAtMs!),
+      share: share,
+      nostrEventId: r.nostrEventId,
+      errorMessage: r.errorMessage,
     );
   }
 

--- a/lib/providers/vault_detail_repository.dart
+++ b/lib/providers/vault_detail_repository.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
 
 import '../database/app_database.dart';
+import '../database/recovery_request_hydration.dart';
 import '../models/backup_config.dart';
 import '../models/recovery_request.dart';
 import '../models/share.dart';
@@ -162,7 +162,7 @@ class VaultDetailRepository {
     final recoveryRows = await _db.recoveryDao.forVault(row.id);
     final recoveryRequests = <RecoveryRequest>[];
     for (final rr in recoveryRows) {
-      recoveryRequests.add(await _recoveryRequestFromRow(rr));
+      recoveryRequests.add(await recoveryRequestFromRow(_db, rr));
     }
 
     final stewards = stewardRows
@@ -331,53 +331,6 @@ class VaultDetailRepository {
       acknowledgedAt: acknowledgedAt,
       acknowledgmentEventId: distributionShareRow?.acknowledgmentEventId,
       acknowledgedDistributionVersion: acknowledgedVersion,
-    );
-  }
-
-  Future<RecoveryRequest> _recoveryRequestFromRow(RecoveryRequestRow r) async {
-    final participants = await _db.recoveryDao.participantsFor(r.id);
-    final responses = await _db.recoveryDao.responsesFor(r.id);
-    return RecoveryRequest.makeFromParticipants(
-      id: r.id,
-      vaultId: r.vaultId,
-      initiatorPubkey: r.initiatorPubkey,
-      requestedAt: DateTime.fromMillisecondsSinceEpoch(r.startedAt),
-      status: RecoveryRequestStatus.values.firstWhere(
-        (e) => e.name == r.status,
-        orElse: () => RecoveryRequestStatus.pending,
-      ),
-      threshold: r.thresholdAtStart,
-      nostrEventId: r.requestEventId,
-      eventCreationTime: r.eventCreationTimeMs != null
-          ? DateTime.fromMillisecondsSinceEpoch(r.eventCreationTimeMs!)
-          : null,
-      expiresAt: r.expiresAt == null ? null : DateTime.fromMillisecondsSinceEpoch(r.expiresAt!),
-      stewardPubkeys: participants.map((p) => p.pubkey),
-      responses: responses.map(_recoveryResponseFromRow),
-      errorMessage: r.errorMessage,
-      isPractice: r.isPractice,
-    );
-  }
-
-  RecoveryResponse _recoveryResponseFromRow(RecoveryResponseRow r) {
-    Share? share;
-    if (r.sharePayload.isNotEmpty) {
-      try {
-        share = shareFromJson(
-          json.decode(r.sharePayload) as Map<String, dynamic>,
-        );
-      } catch (_) {
-        share = null;
-      }
-    }
-    return RecoveryResponse(
-      pubkey: r.responderPubkey,
-      approved: r.approved,
-      respondedAt:
-          r.respondedAtMs == null ? null : DateTime.fromMillisecondsSinceEpoch(r.respondedAtMs!),
-      share: share,
-      nostrEventId: r.nostrEventId,
-      errorMessage: r.errorMessage,
     );
   }
 

--- a/lib/providers/vault_provider.dart
+++ b/lib/providers/vault_provider.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../database/app_database.dart';
 import '../database/app_database_provider.dart';
+import '../database/recovery_request_hydration.dart';
 import '../models/backup_config.dart';
 import '../models/recovery_request.dart';
 import '../models/share.dart';
@@ -778,7 +779,7 @@ class VaultRepository {
     final recoveryRows = await _db.recoveryDao.forVault(row.id);
     final recoveryRequests = <RecoveryRequest>[];
     for (final rr in recoveryRows) {
-      recoveryRequests.add(await _recoveryRequestFromRow(rr));
+      recoveryRequests.add(await recoveryRequestFromRow(_db, rr));
     }
 
     return Vault(
@@ -967,51 +968,6 @@ class VaultRepository {
     final now = DateTime.now().millisecondsSinceEpoch;
     await (_db.update(_db.vaults)..where((v) => v.id.equals(vaultId))).write(
       VaultsCompanion(lastSyncedAt: Value(now)),
-    );
-  }
-
-  Future<RecoveryRequest> _recoveryRequestFromRow(RecoveryRequestRow r) async {
-    final participants = await _db.recoveryDao.participantsFor(r.id);
-    final responses = await _db.recoveryDao.responsesFor(r.id);
-    return RecoveryRequest.makeFromParticipants(
-      id: r.id,
-      vaultId: r.vaultId,
-      initiatorPubkey: r.initiatorPubkey,
-      requestedAt: DateTime.fromMillisecondsSinceEpoch(r.startedAt),
-      status: RecoveryRequestStatus.values.firstWhere(
-        (e) => e.name == r.status,
-        orElse: () => RecoveryRequestStatus.pending,
-      ),
-      threshold: r.thresholdAtStart,
-      nostrEventId: r.requestEventId,
-      eventCreationTime: r.eventCreationTimeMs != null
-          ? DateTime.fromMillisecondsSinceEpoch(r.eventCreationTimeMs!)
-          : null,
-      expiresAt: r.expiresAt == null ? null : DateTime.fromMillisecondsSinceEpoch(r.expiresAt!),
-      stewardPubkeys: participants.map((p) => p.pubkey),
-      responses: responses.map(_recoveryResponseFromRow),
-      errorMessage: r.errorMessage,
-      isPractice: r.isPractice,
-    );
-  }
-
-  RecoveryResponse _recoveryResponseFromRow(RecoveryResponseRow r) {
-    Share? share;
-    if (r.sharePayload.isNotEmpty) {
-      try {
-        share = shareFromJson(json.decode(r.sharePayload) as Map<String, dynamic>);
-      } catch (_) {
-        share = null;
-      }
-    }
-    return RecoveryResponse(
-      pubkey: r.responderPubkey,
-      approved: r.approved,
-      respondedAt:
-          r.respondedAtMs == null ? null : DateTime.fromMillisecondsSinceEpoch(r.respondedAtMs!),
-      share: share,
-      nostrEventId: r.nostrEventId,
-      errorMessage: r.errorMessage,
     );
   }
 

--- a/test/providers/vault_detail_repository_role_test.dart
+++ b/test/providers/vault_detail_repository_role_test.dart
@@ -1,9 +1,10 @@
 import 'dart:typed_data';
 
-import 'package:drift/drift.dart';
+import 'package:drift/drift.dart' hide isNotNull;
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:horcrux/database/app_database.dart';
+import 'package:horcrux/models/recovery_request.dart';
 import 'package:horcrux/models/vault_detail.dart';
 import 'package:horcrux/providers/vault_detail_repository.dart';
 import 'package:horcrux/services/login_service.dart';
@@ -70,42 +71,178 @@ void main() {
       },
     );
 
-    test('owned vault with LoginService matching owner yields OwnedVaultDetail', () async {
-      final fx = await VaultFixture.owned(
-        db,
-        ownerPubkey: TestHexPubkeys.alice,
-        threshold: 1,
-        totalShares: 1,
-      );
-      await fx.withSteward(
-        shareIndex: 1,
-        pubkey: TestHexPubkeys.alice,
-        isOwner: true,
-        name: 'Alice',
-      );
-      final login = _PubkeyLoginService(TestHexPubkeys.alice);
+    test(
+      'owned vault with LoginService matching owner yields OwnedVaultDetail',
+      () async {
+        final fx = await VaultFixture.owned(
+          db,
+          ownerPubkey: TestHexPubkeys.alice,
+          threshold: 1,
+          totalShares: 1,
+        );
+        await fx.withSteward(
+          shareIndex: 1,
+          pubkey: TestHexPubkeys.alice,
+          isOwner: true,
+          name: 'Alice',
+        );
+        final login = _PubkeyLoginService(TestHexPubkeys.alice);
 
-      final repo = VaultDetailRepository(db: db, loginService: login);
-      addTearDown(repo.dispose);
+        final repo = VaultDetailRepository(db: db, loginService: login);
+        addTearDown(repo.dispose);
 
-      final detail = await repo.getVaultDetail(fx.vaultId);
-      expect(detail, isA<OwnedVaultDetail>());
-      expect(detail!.ownerPubkey, TestHexPubkeys.alice);
-    });
+        final detail = await repo.getVaultDetail(fx.vaultId);
+        expect(detail, isA<OwnedVaultDetail>());
+        expect(detail!.ownerPubkey, TestHexPubkeys.alice);
+      },
+    );
 
-    test('without LoginService, owned_vaults alone yields OwnedVaultDetail (legacy)', () async {
-      final fx = await VaultFixture.owned(
-        db,
-        ownerPubkey: TestHexPubkeys.alice,
-        threshold: 1,
-        totalShares: 1,
-      );
+    test(
+      'without LoginService, owned_vaults alone yields OwnedVaultDetail (legacy)',
+      () async {
+        final fx = await VaultFixture.owned(
+          db,
+          ownerPubkey: TestHexPubkeys.alice,
+          threshold: 1,
+          totalShares: 1,
+        );
 
-      final repo = VaultDetailRepository(db: db);
-      addTearDown(repo.dispose);
+        final repo = VaultDetailRepository(db: db);
+        addTearDown(repo.dispose);
 
-      final detail = await repo.getVaultDetail(fx.vaultId);
-      expect(detail, isA<OwnedVaultDetail>());
-    });
+        final detail = await repo.getVaultDetail(fx.vaultId);
+        expect(detail, isA<OwnedVaultDetail>());
+      },
+    );
+
+    test(
+      'hydrates active recovery requests so manageableRecoveryFor returns them',
+      () async {
+        final fx = await VaultFixture.stewarded(
+          db,
+          ownerPubkey: TestHexPubkeys.alice,
+          threshold: 2,
+          totalShares: 3,
+        );
+        await fx.withSteward(
+          shareIndex: 1,
+          pubkey: TestHexPubkeys.bob,
+          name: 'Bob',
+        );
+        await HeldShareFixture.insert(
+          db,
+          vaultId: fx.vaultId,
+          shareIndex: 1,
+          payload: 'p',
+        );
+        final session = await RecoverySessionFixture.inProgress(
+          db,
+          vaultId: fx.vaultId,
+          ownerPubkey: TestHexPubkeys.alice,
+          initiatorPubkey: TestHexPubkeys.bob,
+          threshold: 2,
+        );
+
+        final repo = VaultDetailRepository(
+          db: db,
+          loginService: _PubkeyLoginService(TestHexPubkeys.bob),
+        );
+        addTearDown(repo.dispose);
+
+        final detail = await repo.getVaultDetail(fx.vaultId);
+        expect(detail!.recoveryRequests, hasLength(1));
+        expect(detail.recoveryRequests.single.id, session.requestId);
+        expect(detail.recoveryRequests.single.status.isActive, isTrue);
+        expect(
+          detail.manageableRecoveryFor(TestHexPubkeys.bob, isPractice: false),
+          isNotNull,
+        );
+      },
+    );
+
+    test(
+      'hydrates recovery for OwnedVaultDetail when owner initiated',
+      () async {
+        final fx = await VaultFixture.owned(
+          db,
+          ownerPubkey: TestHexPubkeys.alice,
+          threshold: 2,
+          totalShares: 3,
+        );
+        await fx.withSteward(
+          shareIndex: 1,
+          pubkey: TestHexPubkeys.alice,
+          isOwner: true,
+          name: 'Alice',
+        );
+        await RecoverySessionFixture.inProgress(
+          db,
+          vaultId: fx.vaultId,
+          ownerPubkey: TestHexPubkeys.alice,
+          initiatorPubkey: TestHexPubkeys.alice,
+          threshold: 2,
+        );
+
+        final repo = VaultDetailRepository(
+          db: db,
+          loginService: _PubkeyLoginService(TestHexPubkeys.alice),
+        );
+        addTearDown(repo.dispose);
+
+        final detail = await repo.getVaultDetail(fx.vaultId);
+        expect(detail, isA<OwnedVaultDetail>());
+        expect(detail!.recoveryRequests, hasLength(1));
+        expect(
+          detail.manageableRecoveryFor(TestHexPubkeys.alice, isPractice: false),
+          isNotNull,
+        );
+      },
+    );
+
+    test(
+      'watchVaultDetail re-emits when a recovery request row is inserted',
+      () async {
+        final fx = await VaultFixture.stewarded(
+          db,
+          ownerPubkey: TestHexPubkeys.alice,
+          threshold: 2,
+          totalShares: 3,
+        );
+        await fx.withSteward(
+          shareIndex: 1,
+          pubkey: TestHexPubkeys.bob,
+          name: 'Bob',
+        );
+        await HeldShareFixture.insert(
+          db,
+          vaultId: fx.vaultId,
+          shareIndex: 1,
+          payload: 'p',
+        );
+
+        final repo = VaultDetailRepository(
+          db: db,
+          loginService: _PubkeyLoginService(TestHexPubkeys.bob),
+        );
+        addTearDown(repo.dispose);
+
+        final stream = repo.watchVaultDetail(fx.vaultId);
+        final first = await stream.first;
+        expect(first, isNotNull);
+        expect(first!.recoveryRequests, isEmpty);
+
+        await RecoverySessionFixture.inProgress(
+          db,
+          vaultId: fx.vaultId,
+          ownerPubkey: TestHexPubkeys.alice,
+          initiatorPubkey: TestHexPubkeys.bob,
+          threshold: 2,
+        );
+
+        final second = await stream.skip(1).first;
+        expect(second, isNotNull);
+        expect(second!.recoveryRequests, hasLength(1));
+      },
+    );
   });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Bead

horcrux_app-2n0

## What

- Hydrate `recoveryRequests` in `VaultDetailRepository._hydrateDetail` from `recovery_requests`, including participants and responses, using the same mapping approach as `VaultRepository`.
- Subscribe `watchVaultDetail` to `recoveryDao.watchForVault` so the detail stream updates when recovery rows change (new session, status transitions).
- Refresh documentation on `VaultDetail.recoveryRequests` and add regression tests: steward initiator, owner initiator, and stream re-emission after inserting a recovery request.
- **Follow-up (Bugbot):** Move shared drift→domain mapping into `lib/database/recovery_request_hydration.dart` (`recoveryRequestFromRow`, `recoveryResponseFromRow`) so `VaultRepository` and `VaultDetailRepository` cannot diverge.

## Why

After a process restart, `VaultDetail` always had `recoveryRequests: []`, so `manageableRecoveryFor` was null and the vault detail screen showed "Initiate Recovery" instead of "Manage Recovery" even when an active recovery row existed in the database.

## Testing

- `flutter test test/providers/vault_detail_repository_role_test.dart`
- `flutter test --exclude-tags=golden`
- `flutter analyze`

## Screenshots

Not applicable (read-model / repository change; no pixel diffs). Manual Linux check from the issue notes was not run in this agent environment.

## Breaking changes

None.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-57dd2572-22c1-424f-b74f-24d8960dbe1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57dd2572-22c1-424f-b74f-24d8960dbe1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

