### PR TITLE
Migrate recovery shard cache from SharedPreferences to recovery_responses (horcrux_app-2em)

### DIFF
--- a/lib/database/daos/recovery_dao.dart
+++ b/lib/database/daos/recovery_dao.dart
@@ -53,6 +53,12 @@ class RecoveryDao extends DatabaseAccessor<AppDatabase> with _$RecoveryDaoMixin 
   Future<int> deleteResponsesForRequest(String requestId) =>
       (delete(recoveryResponses)..where((r) => r.requestId.equals(requestId))).go();
 
+  /// Clears stored Shamir payloads while keeping response rows (audit trail).
+  Future<int> clearSharePayloadsForRequest(String requestId) =>
+      (update(recoveryResponses)..where((r) => r.requestId.equals(requestId))).write(
+        const RecoveryResponsesCompanion(sharePayload: Value('')),
+      );
+
   Future<int> deleteRequestCascade(String requestId) async {
     await deleteResponsesForRequest(requestId);
     await (delete(recoveryRequestParticipants)..where((p) => p.requestId.equals(requestId))).go();

--- a/lib/providers/vault_provider.dart
+++ b/lib/providers/vault_provider.dart
@@ -86,12 +86,10 @@ final vaultDetailListProvider = StreamProvider.autoDispose<List<VaultDetail>>((r
 /// - Inserting a `held_shares` row also updates `vaults.last_synced_at` so
 ///   the reactive vault stream re-emits and callers see the updated shares.
 ///
-/// **Still Phase 1 / stub behavior**:
-///
-/// - `Vault.recoveryRequests` always hydrates to `[]`. The
-///   `recovery_requests` / `recovery_responses` tables land in Phase 3; until
-///   then [addRecoveryRequestToVault] and [updateRecoveryRequestInVault]
-///   throw [UnimplementedError].
+/// - `Vault.recoveryRequests` hydrates from `recovery_requests`,
+///   `recovery_request_participants`, and `recovery_responses` via
+///   [recovery_request_hydration.dart]. [addRecoveryRequestToVault] and
+///   [updateRecoveryRequestInVault] persist to those tables.
 /// - `BackupConfig` is hydrated from `vaults` + `owned_vaults` + active
 ///   `stewards` (`StewardDao.activeForVault`). [updateBackupConfig] writes
 ///   the same triple back atomically.
@@ -658,6 +656,26 @@ class VaultRepository {
             );
       }
     });
+    await _bumpVaultSync(vaultId);
+  }
+
+  /// Clears [recovery_responses.sharePayload] for [requestId] (e.g. cancelled recovery).
+  ///
+  /// Keeps rows so approve/deny metadata remains for audit.
+  Future<void> deleteRecoveryResponseSharesForRequest({
+    required String vaultId,
+    required String requestId,
+  }) async {
+    await _db.recoveryDao.clearSharePayloadsForRequest(requestId);
+    await _bumpVaultSync(vaultId);
+  }
+
+  /// Deletes all [recovery_responses] rows for [requestId] (e.g. after successful recovery).
+  Future<void> deleteRecoveryResponsesForRequest({
+    required String vaultId,
+    required String requestId,
+  }) async {
+    await _db.recoveryDao.deleteResponsesForRequest(requestId);
     await _bumpVaultSync(vaultId);
   }
 

--- a/lib/services/logout_service.dart
+++ b/lib/services/logout_service.dart
@@ -11,7 +11,6 @@ import 'processed_nostr_event_store.dart';
 import 'recovery_service.dart';
 import 'relay_scan_service.dart';
 import 'secure_storage_corruption.dart';
-import 'vault_share_service.dart';
 
 /// Service responsible for performing logout cleanup across data stores.
 ///
@@ -22,7 +21,6 @@ import 'vault_share_service.dart';
 final logoutServiceProvider = Provider<LogoutService>((ref) {
   return LogoutService(
     vaultRepository: ref.watch(vaultRepositoryProvider),
-    vaultShareService: ref.watch(vaultShareServiceProvider),
     recoveryService: ref.watch(recoveryServiceProvider),
     relayScanService: ref.watch(relayScanServiceProvider),
     loginService: ref.watch(loginServiceProvider),
@@ -33,7 +31,6 @@ final logoutServiceProvider = Provider<LogoutService>((ref) {
 
 class LogoutService {
   final VaultRepository _vaultRepository;
-  final VaultShareService _vaultShareService;
   final RecoveryService _recoveryService;
   final RelayScanService _relayScanService;
   final LoginService _loginService;
@@ -45,7 +42,6 @@ class LogoutService {
 
   LogoutService({
     required VaultRepository vaultRepository,
-    required VaultShareService vaultShareService,
     required RecoveryService recoveryService,
     required RelayScanService relayScanService,
     required LoginService loginService,
@@ -55,7 +51,6 @@ class LogoutService {
     Future<void> Function()? clearSharedPreferences,
     Future<void> Function()? clearSecureStorage,
   })  : _vaultRepository = vaultRepository,
-        _vaultShareService = vaultShareService,
         _recoveryService = recoveryService,
         _relayScanService = relayScanService,
         _loginService = loginService,
@@ -65,7 +60,7 @@ class LogoutService {
         _clearSharedPreferences = clearSharedPreferences ?? _clearAllSharedPreferences,
         _clearSecureStorage = clearSecureStorage ?? clearSecureStorageForWipe;
 
-  // TODO(hvc-2em): Remove once VaultShareService recovery_shard_data is migrated to drift.
+  // TODO(horcrux_app-u86): Remove once remaining SharedPreferences users migrate off prefs.
   static Future<void> _clearAllSharedPreferences() async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.clear();
@@ -87,7 +82,6 @@ class LogoutService {
     // Clear all service data (clear the on-disk processed Nostr event store
     // after relay scanning has stopped so nothing is racing to write the WAL).
     await _vaultRepository.clearAll();
-    await _vaultShareService.clearAll();
     await _recoveryService.clearAll();
     await _relayScanService.clearAll();
     try {

--- a/lib/services/ndk_service.dart
+++ b/lib/services/ndk_service.dart
@@ -644,11 +644,9 @@ class NdkService {
       final shardDataJson = shardPayload as Map<String, dynamic>;
       shardData = shareFromJson(shardDataJson);
 
-      final vaultShareService = _ref.read(vaultShareServiceProvider);
-      await vaultShareService.addRecoveryShard(recoveryRequestId, shardData);
-
       Log.info(
-        'Stored recovery shard from $senderPubkey for recovery request $recoveryRequestId',
+        'Decoded recovery shard from $senderPubkey for recovery request $recoveryRequestId '
+        '(persists via RecoveryService)',
       );
     }
 

--- a/lib/services/recovery_service.dart
+++ b/lib/services/recovery_service.dart
@@ -17,7 +17,6 @@ import 'local_notification_service.dart';
 import 'ndk_service.dart';
 import 'notification_recency.dart';
 import 'processed_nostr_event_store.dart';
-import 'vault_share_service.dart';
 import 'logger.dart';
 
 /// Provider for RecoveryService
@@ -32,7 +31,6 @@ final Provider<RecoveryService> recoveryServiceProvider = Provider<RecoveryServi
   final backupService = ref.watch(backupServiceProvider);
   // Use ref.read() to break circular dependency with NdkService
   final NdkService ndkService = ref.read(ndkServiceProvider);
-  final vaultShareService = ref.watch(vaultShareServiceProvider);
   final processedStore = ref.watch(processedNostrEventStoreProvider);
   final localNotifications = ref.watch(localNotificationServiceProvider);
   final notificationService = ref.watch(horcruxNotificationServiceProvider);
@@ -41,7 +39,6 @@ final Provider<RecoveryService> recoveryServiceProvider = Provider<RecoveryServi
     repository,
     backupService,
     ndkService,
-    vaultShareService,
     processedStore,
     localNotifications,
     notificationService,
@@ -62,7 +59,6 @@ class RecoveryService {
   final VaultRepository repository;
   final BackupService backupService;
   final NdkService _ndkService;
-  final VaultShareService _vaultShareService;
   final ProcessedNostrEventStore _processedStore;
   final LocalNotificationService _localNotifications;
   final HorcruxNotificationService _notificationService;
@@ -97,7 +93,6 @@ class RecoveryService {
     this.repository,
     this.backupService,
     this._ndkService,
-    this._vaultShareService,
     this._processedStore,
     this._localNotifications,
     this._notificationService,
@@ -785,18 +780,22 @@ class RecoveryService {
 
   /// Cancel a recovery request
   Future<void> cancelRecoveryRequest(String recoveryRequestId) async {
+    final request = await getRecoveryRequest(recoveryRequestId);
+    if (request == null) {
+      throw ArgumentError('Recovery request not found: $recoveryRequestId');
+    }
+
     await _updateRecoveryRequestStatus(
       recoveryRequestId,
       RecoveryRequestStatus.cancelled,
     );
 
-    // Delete all recovery shards for this recovery request
-    // Note: User's own shard is stored separately in _cachedShare (keyed by vaultId)
-    // and won't be affected by removeRecoveryShards() which only deletes recovery shards
-    // (keyed by recoveryRequestId)
-    await _vaultShareService.removeRecoveryShards(recoveryRequestId);
+    await repository.deleteRecoveryResponseSharesForRequest(
+      vaultId: request.vaultId,
+      requestId: recoveryRequestId,
+    );
     Log.info(
-      'Deleted recovery shards for cancelled recovery request $recoveryRequestId',
+      'Cleared recovery share payloads for cancelled recovery request $recoveryRequestId',
     );
   }
 
@@ -825,12 +824,11 @@ class RecoveryService {
       Log.info('Deleted recovered content from vault ${request.vaultId}');
     }
 
-    // Delete all recovery shards for this recovery request
-    // Note: User's own shard is stored separately in _cachedShare (keyed by vaultId)
-    // and won't be affected by removeRecoveryShards() which only deletes recovery shards
-    // (keyed by recoveryRequestId)
-    await _vaultShareService.removeRecoveryShards(recoveryRequestId);
-    Log.info('Deleted recovery shards for recovery request $recoveryRequestId');
+    await repository.deleteRecoveryResponsesForRequest(
+      vaultId: request.vaultId,
+      requestId: recoveryRequestId,
+    );
+    Log.info('Deleted recovery response rows for recovery request $recoveryRequestId');
 
     Log.info('Exited recovery mode for recovery request $recoveryRequestId');
   }

--- a/lib/services/secure_storage_corruption.dart
+++ b/lib/services/secure_storage_corruption.dart
@@ -50,7 +50,7 @@ Future<void> wipeLocalDataForCorruptedSecureStorage({
     Log.error('Failed to clear processed Nostr event store during corruption wipe', e, st);
   }
 
-  // TODO(hvc-2em): Remove once VaultShareService recovery_shard_data is migrated to drift.
+  // TODO(horcrux_app-u86): Remove prefs.clear once remaining SharedPreferences users migrate.
   try {
     final prefs = await SharedPreferences.getInstance();
     await prefs.clear();

--- a/lib/services/vault_share_service.dart
+++ b/lib/services/vault_share_service.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ndk/ndk.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import '../models/invitation_link.dart';
 import '../models/share.dart';
 import '../models/steward_status.dart';
@@ -61,16 +60,11 @@ final vaultShareServiceProvider = Provider<VaultShareService>((ref) {
   );
 });
 
-/// Service for managing vault shares and recovery operations.
+/// Service for managing vault shares (steward-side) and related Nostr flows.
 ///
-/// **Phase 2a**: steward-side held shares are stored in the `held_shares`
-/// drift table via [VaultRepository]. The prefs-based steward-share cache
-/// has been removed; [addShareToVault] and [processVaultShare] now go through
-/// the DB.
-///
-/// Recovery shards (collected by the initiator during recovery) remain in
-/// SharedPreferences for now; they move to the `recovery_responses` table in
-/// Phase 3.
+/// Steward-side held shares live in the `held_shares` drift table via
+/// [VaultRepository]. Collected recovery shards are stored in
+/// `recovery_responses` through [RecoveryService] / [VaultRepository], not here.
 class VaultShareService {
   final VaultRepository repository;
   final NdkService Function() _getNdkService;
@@ -83,53 +77,6 @@ class VaultShareService {
     this._getNotificationService,
     this._getPushReceiver,
   );
-
-  // ── Recovery shards (Phase 3 will move these to `recovery_responses`) ──
-
-  static const String _recoveryShareKey = 'recovery_shard_data';
-  static Map<String, List<Share>>? _cachedRecoveryShards;
-  static bool _recoveryInitialized = false;
-
-  Future<void> _ensureRecoveryInitialized() async {
-    if (_recoveryInitialized) return;
-    await _loadRecoveryShares();
-    _recoveryInitialized = true;
-  }
-
-  Future<void> _loadRecoveryShares() async {
-    final prefs = await SharedPreferences.getInstance();
-    final jsonData = prefs.getString(_recoveryShareKey);
-    if (jsonData == null || jsonData.isEmpty) {
-      _cachedRecoveryShards = {};
-      return;
-    }
-    try {
-      final Map<String, dynamic> jsonMap = json.decode(jsonData);
-      _cachedRecoveryShards = jsonMap.map((id, shardListJson) {
-        final shardList = (shardListJson as List<dynamic>)
-            .map((e) => shareFromJson(e as Map<String, dynamic>))
-            .toList();
-        return MapEntry(id, shardList);
-      });
-    } catch (e) {
-      Log.error('Error loading recovery shard data', e);
-      _cachedRecoveryShards = {};
-    }
-  }
-
-  Future<void> _saveRecoveryShards() async {
-    if (_cachedRecoveryShards == null) return;
-    try {
-      final jsonMap = _cachedRecoveryShards!.map((id, shards) {
-        return MapEntry(id, shards.map(shareToJson).toList());
-      });
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.setString(_recoveryShareKey, json.encode(jsonMap));
-    } catch (e) {
-      Log.error('Error saving recovery shard data', e);
-      rethrow;
-    }
-  }
 
   // ── Steward-side share management (backed by `held_shares` table) ──
 
@@ -363,80 +310,6 @@ class VaultShareService {
       Log.error('processKeyHolderRemoval: error processing event ${event.id}', e);
       rethrow;
     }
-  }
-
-  // ── Recovery shard methods (Phase 3 will move these to `recovery_responses`) ──
-
-  /// Add a recovery shard (initiator collecting shards from stewards).
-  Future<void> addRecoveryShard(
-    String recoveryRequestId,
-    Share shardData,
-  ) async {
-    await _ensureRecoveryInitialized();
-    if (!shardData.isValid) throw ArgumentError('Invalid shard data');
-
-    final existing = _cachedRecoveryShards![recoveryRequestId] ?? [];
-    final idx = existing.indexWhere(
-      (s) => s.nostrEventId != null && s.nostrEventId == shardData.nostrEventId,
-    );
-    if (idx != -1) {
-      existing[idx] = shardData;
-    } else {
-      existing.add(shardData);
-      Log.info(
-        'addRecoveryShard: added shard for request $recoveryRequestId '
-        '(event: ${shardData.nostrEventId}, total: ${existing.length})',
-      );
-    }
-    _cachedRecoveryShards![recoveryRequestId] = existing;
-    await _saveRecoveryShards();
-  }
-
-  /// Get all recovery shards for a recovery request.
-  Future<List<Share>> getRecoveryShards(String recoveryRequestId) async {
-    await _ensureRecoveryInitialized();
-    return List.unmodifiable(_cachedRecoveryShards![recoveryRequestId] ?? []);
-  }
-
-  /// Get recovery shard count for a recovery request.
-  Future<int> getRecoveryShardCount(String recoveryRequestId) async {
-    await _ensureRecoveryInitialized();
-    return _cachedRecoveryShards![recoveryRequestId]?.length ?? 0;
-  }
-
-  /// True when sufficient recovery shards have been collected.
-  Future<bool> hasSufficientRecoveryShards(
-    String recoveryRequestId,
-    int threshold,
-  ) async {
-    await _ensureRecoveryInitialized();
-    return (_cachedRecoveryShards![recoveryRequestId]?.length ?? 0) >= threshold;
-  }
-
-  /// Remove all recovery shards for a recovery request.
-  Future<void> removeRecoveryShards(String recoveryRequestId) async {
-    await _ensureRecoveryInitialized();
-    if (_cachedRecoveryShards!.containsKey(recoveryRequestId)) {
-      final count = _cachedRecoveryShards![recoveryRequestId]!.length;
-      _cachedRecoveryShards!.remove(recoveryRequestId);
-      await _saveRecoveryShards();
-      Log.info(
-        'removeRecoveryShards: removed $count shards for request $recoveryRequestId',
-      );
-    }
-  }
-
-  /// Clear all local state (called on logout / wipe).
-  ///
-  /// Held shares (steward-side) live in the drift DB and are cleared when the
-  /// DB is wiped. This method clears the recovery-shard prefs cache so the
-  /// in-process cache does not serve stale data after a re-login.
-  Future<void> clearAll() async {
-    _cachedRecoveryShards = {};
-    _recoveryInitialized = false;
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.remove(_recoveryShareKey);
-    Log.info('VaultShareService.clearAll: cleared recovery shard cache');
   }
 
   // ── Private helpers ──

--- a/test/services/backup_service_test.mocks.dart
+++ b/test/services/backup_service_test.mocks.dart
@@ -429,6 +429,42 @@ class MockVaultRepository extends _i1.Mock implements _i5.VaultRepository {
       ) as _i6.Future<void>);
 
   @override
+  _i6.Future<void> deleteRecoveryResponseSharesForRequest({
+    required String? vaultId,
+    required String? requestId,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #deleteRecoveryResponseSharesForRequest,
+          [],
+          {
+            #vaultId: vaultId,
+            #requestId: requestId,
+          },
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> deleteRecoveryResponsesForRequest({
+    required String? vaultId,
+    required String? requestId,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #deleteRecoveryResponsesForRequest,
+          [],
+          {
+            #vaultId: vaultId,
+            #requestId: requestId,
+          },
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
+
+  @override
   _i6.Future<void> cleanupExpiredRecoverySessions() => (super.noSuchMethod(
         Invocation.method(
           #cleanupExpiredRecoverySessions,

--- a/test/services/horcrux_notification_service_test.mocks.dart
+++ b/test/services/horcrux_notification_service_test.mocks.dart
@@ -618,6 +618,42 @@ class MockVaultRepository extends _i1.Mock implements _i6.VaultRepository {
       ) as _i4.Future<void>);
 
   @override
+  _i4.Future<void> deleteRecoveryResponseSharesForRequest({
+    required String? vaultId,
+    required String? requestId,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #deleteRecoveryResponseSharesForRequest,
+          [],
+          {
+            #vaultId: vaultId,
+            #requestId: requestId,
+          },
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+
+  @override
+  _i4.Future<void> deleteRecoveryResponsesForRequest({
+    required String? vaultId,
+    required String? requestId,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #deleteRecoveryResponsesForRequest,
+          [],
+          {
+            #vaultId: vaultId,
+            #requestId: requestId,
+          },
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+
+  @override
   _i4.Future<void> cleanupExpiredRecoverySessions() => (super.noSuchMethod(
         Invocation.method(
           #cleanupExpiredRecoverySessions,

--- a/test/services/invitation_acceptance_format_test.mocks.dart
+++ b/test/services/invitation_acceptance_format_test.mocks.dart
@@ -925,6 +925,42 @@ class MockVaultRepository extends _i1.Mock implements _i12.VaultRepository {
       ) as _i7.Future<void>);
 
   @override
+  _i7.Future<void> deleteRecoveryResponseSharesForRequest({
+    required String? vaultId,
+    required String? requestId,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #deleteRecoveryResponseSharesForRequest,
+          [],
+          {
+            #vaultId: vaultId,
+            #requestId: requestId,
+          },
+        ),
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
+
+  @override
+  _i7.Future<void> deleteRecoveryResponsesForRequest({
+    required String? vaultId,
+    required String? requestId,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #deleteRecoveryResponsesForRequest,
+          [],
+          {
+            #vaultId: vaultId,
+            #requestId: requestId,
+          },
+        ),
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
+
+  @override
   _i7.Future<void> cleanupExpiredRecoverySessions() => (super.noSuchMethod(
         Invocation.method(
           #cleanupExpiredRecoverySessions,

--- a/test/services/invitation_service_test.mocks.dart
+++ b/test/services/invitation_service_test.mocks.dart
@@ -925,6 +925,42 @@ class MockVaultRepository extends _i1.Mock implements _i12.VaultRepository {
       ) as _i7.Future<void>);
 
   @override
+  _i7.Future<void> deleteRecoveryResponseSharesForRequest({
+    required String? vaultId,
+    required String? requestId,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #deleteRecoveryResponseSharesForRequest,
+          [],
+          {
+            #vaultId: vaultId,
+            #requestId: requestId,
+          },
+        ),
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
+
+  @override
+  _i7.Future<void> deleteRecoveryResponsesForRequest({
+    required String? vaultId,
+    required String? requestId,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #deleteRecoveryResponsesForRequest,
+          [],
+          {
+            #vaultId: vaultId,
+            #requestId: requestId,
+          },
+        ),
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
+
+  @override
   _i7.Future<void> cleanupExpiredRecoverySessions() => (super.noSuchMethod(
         Invocation.method(
           #cleanupExpiredRecoverySessions,

--- a/test/services/local_notification_service_navigation_test.mocks.dart
+++ b/test/services/local_notification_service_navigation_test.mocks.dart
@@ -390,6 +390,42 @@ class MockVaultRepository extends _i1.Mock implements _i2.VaultRepository {
       ) as _i3.Future<void>);
 
   @override
+  _i3.Future<void> deleteRecoveryResponseSharesForRequest({
+    required String? vaultId,
+    required String? requestId,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #deleteRecoveryResponseSharesForRequest,
+          [],
+          {
+            #vaultId: vaultId,
+            #requestId: requestId,
+          },
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
+
+  @override
+  _i3.Future<void> deleteRecoveryResponsesForRequest({
+    required String? vaultId,
+    required String? requestId,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #deleteRecoveryResponsesForRequest,
+          [],
+          {
+            #vaultId: vaultId,
+            #requestId: requestId,
+          },
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
+
+  @override
   _i3.Future<void> cleanupExpiredRecoverySessions() => (super.noSuchMethod(
         Invocation.method(
           #cleanupExpiredRecoverySessions,

--- a/test/services/logout_service_test.dart
+++ b/test/services/logout_service_test.dart
@@ -6,7 +6,6 @@ import 'package:horcrux/services/logout_service.dart';
 import 'package:horcrux/services/processed_nostr_event_store.dart';
 import 'package:horcrux/services/recovery_service.dart';
 import 'package:horcrux/services/relay_scan_service.dart';
-import 'package:horcrux/services/vault_share_service.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 
@@ -15,7 +14,6 @@ import 'logout_service_test.mocks.dart';
 
 @GenerateNiceMocks([
   MockSpec<VaultRepository>(),
-  MockSpec<VaultShareService>(),
   MockSpec<RecoveryService>(),
   MockSpec<RelayScanService>(),
   MockSpec<LoginService>(),
@@ -24,7 +22,6 @@ import 'logout_service_test.mocks.dart';
 void main() {
   group('LogoutService', () {
     late MockVaultRepository vaultRepository;
-    late MockVaultShareService vaultShareService;
     late MockRecoveryService recoveryService;
     late MockRelayScanService relayScanService;
     late MockLoginService loginService;
@@ -33,7 +30,6 @@ void main() {
 
     setUp(() {
       vaultRepository = MockVaultRepository();
-      vaultShareService = MockVaultShareService();
       recoveryService = MockRecoveryService();
       relayScanService = MockRelayScanService();
       loginService = MockLoginService();
@@ -42,7 +38,6 @@ void main() {
 
       when(relayScanService.stopRelayScanning()).thenAnswer((_) async {});
       when(vaultRepository.clearAll()).thenAnswer((_) async {});
-      when(vaultShareService.clearAll()).thenAnswer((_) async {});
       when(recoveryService.clearAll()).thenAnswer((_) async {});
       when(relayScanService.clearAll()).thenAnswer((_) async {});
       when(processedStore.clearAll()).thenAnswer((_) async {});
@@ -59,7 +54,6 @@ void main() {
       var clearedSecureStorage = false;
       final service = LogoutService(
         vaultRepository: vaultRepository,
-        vaultShareService: vaultShareService,
         recoveryService: recoveryService,
         relayScanService: relayScanService,
         loginService: loginService,
@@ -80,7 +74,6 @@ void main() {
 
       verify(relayScanService.stopRelayScanning()).called(1);
       verify(vaultRepository.clearAll()).called(1);
-      verify(vaultShareService.clearAll()).called(1);
       verify(recoveryService.clearAll()).called(1);
       verify(relayScanService.clearAll()).called(1);
       verify(processedStore.clearAll()).called(1);
@@ -97,7 +90,6 @@ void main() {
       var clearedSecureStorage = false;
       final service = LogoutService(
         vaultRepository: vaultRepository,
-        vaultShareService: vaultShareService,
         recoveryService: recoveryService,
         relayScanService: relayScanService,
         loginService: loginService,

--- a/test/services/logout_service_test.mocks.dart
+++ b/test/services/logout_service_test.mocks.dart
@@ -7,22 +7,20 @@ import 'dart:async' as _i8;
 
 import 'package:horcrux/models/backup_config.dart' as _i10;
 import 'package:horcrux/models/recovery_request.dart' as _i4;
-import 'package:horcrux/models/recovery_status.dart' as _i16;
-import 'package:horcrux/models/relay_configuration.dart' as _i18;
+import 'package:horcrux/models/recovery_status.dart' as _i14;
+import 'package:horcrux/models/relay_configuration.dart' as _i16;
 import 'package:horcrux/models/share.dart' as _i12;
 import 'package:horcrux/models/steward_status.dart' as _i11;
 import 'package:horcrux/models/vault.dart' as _i9;
 import 'package:horcrux/providers/vault_provider.dart' as _i2;
 import 'package:horcrux/services/backup_service.dart' as _i3;
-import 'package:horcrux/services/login_service.dart' as _i19;
+import 'package:horcrux/services/login_service.dart' as _i17;
 import 'package:horcrux/services/ndk_service.dart' as _i5;
-import 'package:horcrux/services/processed_nostr_event_store.dart' as _i20;
-import 'package:horcrux/services/recovery_service.dart' as _i15;
+import 'package:horcrux/services/processed_nostr_event_store.dart' as _i18;
+import 'package:horcrux/services/recovery_service.dart' as _i13;
 import 'package:horcrux/services/relay_scan_service.dart' as _i6;
-import 'package:horcrux/services/vault_share_service.dart' as _i13;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i17;
-import 'package:ndk/ndk.dart' as _i14;
+import 'package:mockito/src/dummies.dart' as _i15;
 import 'package:ndk/shared/nips/nip01/key_pair.dart' as _i7;
 
 // ignore_for_file: type=lint
@@ -467,6 +465,42 @@ class MockVaultRepository extends _i1.Mock implements _i2.VaultRepository {
       ) as _i8.Future<void>);
 
   @override
+  _i8.Future<void> deleteRecoveryResponseSharesForRequest({
+    required String? vaultId,
+    required String? requestId,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #deleteRecoveryResponseSharesForRequest,
+          [],
+          {
+            #vaultId: vaultId,
+            #requestId: requestId,
+          },
+        ),
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
+
+  @override
+  _i8.Future<void> deleteRecoveryResponsesForRequest({
+    required String? vaultId,
+    required String? requestId,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #deleteRecoveryResponsesForRequest,
+          [],
+          {
+            #vaultId: vaultId,
+            #requestId: requestId,
+          },
+        ),
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
+
+  @override
   _i8.Future<void> cleanupExpiredRecoverySessions() => (super.noSuchMethod(
         Invocation.method(
           #cleanupExpiredRecoverySessions,
@@ -519,222 +553,10 @@ class MockVaultRepository extends _i1.Mock implements _i2.VaultRepository {
       );
 }
 
-/// A class which mocks [VaultShareService].
-///
-/// See the documentation for Mockito's code generation for more information.
-class MockVaultShareService extends _i1.Mock implements _i13.VaultShareService {
-  @override
-  _i2.VaultRepository get repository => (super.noSuchMethod(
-        Invocation.getter(#repository),
-        returnValue: _FakeVaultRepository_0(
-          this,
-          Invocation.getter(#repository),
-        ),
-        returnValueForMissingStub: _FakeVaultRepository_0(
-          this,
-          Invocation.getter(#repository),
-        ),
-      ) as _i2.VaultRepository);
-
-  @override
-  _i8.Future<List<_i12.Share>> getVaultShares(String? vaultId) => (super.noSuchMethod(
-        Invocation.method(
-          #getVaultShares,
-          [vaultId],
-        ),
-        returnValue: _i8.Future<List<_i12.Share>>.value(<_i12.Share>[]),
-        returnValueForMissingStub: _i8.Future<List<_i12.Share>>.value(<_i12.Share>[]),
-      ) as _i8.Future<List<_i12.Share>>);
-
-  @override
-  _i8.Future<_i12.Share?> getVaultShare(String? vaultId) => (super.noSuchMethod(
-        Invocation.method(
-          #getVaultShare,
-          [vaultId],
-        ),
-        returnValue: _i8.Future<_i12.Share?>.value(),
-        returnValueForMissingStub: _i8.Future<_i12.Share?>.value(),
-      ) as _i8.Future<_i12.Share?>);
-
-  @override
-  _i8.Future<void> addVaultShare(
-    String? vaultId,
-    _i12.Share? share,
-  ) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #addVaultShare,
-          [
-            vaultId,
-            share,
-          ],
-        ),
-        returnValue: _i8.Future<void>.value(),
-        returnValueForMissingStub: _i8.Future<void>.value(),
-      ) as _i8.Future<void>);
-
-  @override
-  _i8.Future<void> processVaultShare(
-    String? vaultId,
-    _i12.Share? shardData,
-  ) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #processVaultShare,
-          [
-            vaultId,
-            shardData,
-          ],
-        ),
-        returnValue: _i8.Future<void>.value(),
-        returnValueForMissingStub: _i8.Future<void>.value(),
-      ) as _i8.Future<void>);
-
-  @override
-  _i8.Future<String?> sendShareConfirmationEvent({
-    required String? vaultId,
-    required int? shareIndex,
-    required String? ownerPubkey,
-    required List<String>? relayUrls,
-    int? distributionVersion,
-  }) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #sendShareConfirmationEvent,
-          [],
-          {
-            #vaultId: vaultId,
-            #shareIndex: shareIndex,
-            #ownerPubkey: ownerPubkey,
-            #relayUrls: relayUrls,
-            #distributionVersion: distributionVersion,
-          },
-        ),
-        returnValue: _i8.Future<String?>.value(),
-        returnValueForMissingStub: _i8.Future<String?>.value(),
-      ) as _i8.Future<String?>);
-
-  @override
-  _i8.Future<bool> isKeyHolderForVault(String? vaultId) => (super.noSuchMethod(
-        Invocation.method(
-          #isKeyHolderForVault,
-          [vaultId],
-        ),
-        returnValue: _i8.Future<bool>.value(false),
-        returnValueForMissingStub: _i8.Future<bool>.value(false),
-      ) as _i8.Future<bool>);
-
-  @override
-  _i8.Future<int> getShardCount(String? vaultId) => (super.noSuchMethod(
-        Invocation.method(
-          #getShardCount,
-          [vaultId],
-        ),
-        returnValue: _i8.Future<int>.value(0),
-        returnValueForMissingStub: _i8.Future<int>.value(0),
-      ) as _i8.Future<int>);
-
-  @override
-  _i8.Future<void> removeVaultShare(String? vaultId) => (super.noSuchMethod(
-        Invocation.method(
-          #removeVaultShare,
-          [vaultId],
-        ),
-        returnValue: _i8.Future<void>.value(),
-        returnValueForMissingStub: _i8.Future<void>.value(),
-      ) as _i8.Future<void>);
-
-  @override
-  _i8.Future<void> processKeyHolderRemoval({required _i14.Nip01Event? event}) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #processKeyHolderRemoval,
-          [],
-          {#event: event},
-        ),
-        returnValue: _i8.Future<void>.value(),
-        returnValueForMissingStub: _i8.Future<void>.value(),
-      ) as _i8.Future<void>);
-
-  @override
-  _i8.Future<void> addRecoveryShard(
-    String? recoveryRequestId,
-    _i12.Share? shardData,
-  ) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #addRecoveryShard,
-          [
-            recoveryRequestId,
-            shardData,
-          ],
-        ),
-        returnValue: _i8.Future<void>.value(),
-        returnValueForMissingStub: _i8.Future<void>.value(),
-      ) as _i8.Future<void>);
-
-  @override
-  _i8.Future<List<_i12.Share>> getRecoveryShards(String? recoveryRequestId) => (super.noSuchMethod(
-        Invocation.method(
-          #getRecoveryShards,
-          [recoveryRequestId],
-        ),
-        returnValue: _i8.Future<List<_i12.Share>>.value(<_i12.Share>[]),
-        returnValueForMissingStub: _i8.Future<List<_i12.Share>>.value(<_i12.Share>[]),
-      ) as _i8.Future<List<_i12.Share>>);
-
-  @override
-  _i8.Future<int> getRecoveryShardCount(String? recoveryRequestId) => (super.noSuchMethod(
-        Invocation.method(
-          #getRecoveryShardCount,
-          [recoveryRequestId],
-        ),
-        returnValue: _i8.Future<int>.value(0),
-        returnValueForMissingStub: _i8.Future<int>.value(0),
-      ) as _i8.Future<int>);
-
-  @override
-  _i8.Future<bool> hasSufficientRecoveryShards(
-    String? recoveryRequestId,
-    int? threshold,
-  ) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #hasSufficientRecoveryShards,
-          [
-            recoveryRequestId,
-            threshold,
-          ],
-        ),
-        returnValue: _i8.Future<bool>.value(false),
-        returnValueForMissingStub: _i8.Future<bool>.value(false),
-      ) as _i8.Future<bool>);
-
-  @override
-  _i8.Future<void> removeRecoveryShards(String? recoveryRequestId) => (super.noSuchMethod(
-        Invocation.method(
-          #removeRecoveryShards,
-          [recoveryRequestId],
-        ),
-        returnValue: _i8.Future<void>.value(),
-        returnValueForMissingStub: _i8.Future<void>.value(),
-      ) as _i8.Future<void>);
-
-  @override
-  _i8.Future<void> clearAll() => (super.noSuchMethod(
-        Invocation.method(
-          #clearAll,
-          [],
-        ),
-        returnValue: _i8.Future<void>.value(),
-        returnValueForMissingStub: _i8.Future<void>.value(),
-      ) as _i8.Future<void>);
-}
-
 /// A class which mocks [RecoveryService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockRecoveryService extends _i1.Mock implements _i15.RecoveryService {
+class MockRecoveryService extends _i1.Mock implements _i13.RecoveryService {
   @override
   _i2.VaultRepository get repository => (super.noSuchMethod(
         Invocation.getter(#repository),
@@ -916,15 +738,15 @@ class MockRecoveryService extends _i1.Mock implements _i15.RecoveryService {
       ) as _i8.Future<_i4.RecoveryRequest?>);
 
   @override
-  _i8.Future<_i16.RecoveryStatus?> getRecoveryStatus(String? recoveryRequestId) =>
+  _i8.Future<_i14.RecoveryStatus?> getRecoveryStatus(String? recoveryRequestId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRecoveryStatus,
           [recoveryRequestId],
         ),
-        returnValue: _i8.Future<_i16.RecoveryStatus?>.value(),
-        returnValueForMissingStub: _i8.Future<_i16.RecoveryStatus?>.value(),
-      ) as _i8.Future<_i16.RecoveryStatus?>);
+        returnValue: _i8.Future<_i14.RecoveryStatus?>.value(),
+        returnValueForMissingStub: _i8.Future<_i14.RecoveryStatus?>.value(),
+      ) as _i8.Future<_i14.RecoveryStatus?>);
 
   @override
   _i8.Future<void> processRecoveryResponse(
@@ -1010,14 +832,14 @@ class MockRecoveryService extends _i1.Mock implements _i15.RecoveryService {
           #performRecovery,
           [recoveryRequestId],
         ),
-        returnValue: _i8.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i8.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #performRecovery,
             [recoveryRequestId],
           ),
         )),
-        returnValueForMissingStub: _i8.Future<String>.value(_i17.dummyValue<String>(
+        returnValueForMissingStub: _i8.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #performRecovery,
@@ -1089,7 +911,7 @@ class MockRecoveryService extends _i1.Mock implements _i15.RecoveryService {
           ],
           {#relays: relays},
         ),
-        returnValue: _i8.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i8.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendRecoveryResponseViaNostr,
@@ -1101,7 +923,7 @@ class MockRecoveryService extends _i1.Mock implements _i15.RecoveryService {
             {#relays: relays},
           ),
         )),
-        returnValueForMissingStub: _i8.Future<String>.value(_i17.dummyValue<String>(
+        returnValueForMissingStub: _i8.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendRecoveryResponseViaNostr,
@@ -1246,31 +1068,31 @@ class MockRelayScanService extends _i1.Mock implements _i6.RelayScanService {
       ) as _i8.Future<void>);
 
   @override
-  _i8.Future<List<_i18.RelayConfiguration>> getRelayConfigurations({bool? enabledOnly}) =>
+  _i8.Future<List<_i16.RelayConfiguration>> getRelayConfigurations({bool? enabledOnly}) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRelayConfigurations,
           [],
           {#enabledOnly: enabledOnly},
         ),
-        returnValue: _i8.Future<List<_i18.RelayConfiguration>>.value(<_i18.RelayConfiguration>[]),
+        returnValue: _i8.Future<List<_i16.RelayConfiguration>>.value(<_i16.RelayConfiguration>[]),
         returnValueForMissingStub:
-            _i8.Future<List<_i18.RelayConfiguration>>.value(<_i18.RelayConfiguration>[]),
-      ) as _i8.Future<List<_i18.RelayConfiguration>>);
+            _i8.Future<List<_i16.RelayConfiguration>>.value(<_i16.RelayConfiguration>[]),
+      ) as _i8.Future<List<_i16.RelayConfiguration>>);
 
   @override
-  _i8.Future<_i18.RelayConfiguration?> getRelayConfiguration(String? relayId) =>
+  _i8.Future<_i16.RelayConfiguration?> getRelayConfiguration(String? relayId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRelayConfiguration,
           [relayId],
         ),
-        returnValue: _i8.Future<_i18.RelayConfiguration?>.value(),
-        returnValueForMissingStub: _i8.Future<_i18.RelayConfiguration?>.value(),
-      ) as _i8.Future<_i18.RelayConfiguration?>);
+        returnValue: _i8.Future<_i16.RelayConfiguration?>.value(),
+        returnValueForMissingStub: _i8.Future<_i16.RelayConfiguration?>.value(),
+      ) as _i8.Future<_i16.RelayConfiguration?>);
 
   @override
-  _i8.Future<void> addRelayConfiguration(_i18.RelayConfiguration? relay) => (super.noSuchMethod(
+  _i8.Future<void> addRelayConfiguration(_i16.RelayConfiguration? relay) => (super.noSuchMethod(
         Invocation.method(
           #addRelayConfiguration,
           [relay],
@@ -1280,7 +1102,7 @@ class MockRelayScanService extends _i1.Mock implements _i6.RelayScanService {
       ) as _i8.Future<void>);
 
   @override
-  _i8.Future<void> updateRelayConfiguration(_i18.RelayConfiguration? relay) => (super.noSuchMethod(
+  _i8.Future<void> updateRelayConfiguration(_i16.RelayConfiguration? relay) => (super.noSuchMethod(
         Invocation.method(
           #updateRelayConfiguration,
           [relay],
@@ -1406,7 +1228,7 @@ class MockRelayScanService extends _i1.Mock implements _i6.RelayScanService {
 /// A class which mocks [LoginService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockLoginService extends _i1.Mock implements _i19.LoginService {
+class MockLoginService extends _i1.Mock implements _i17.LoginService {
   @override
   set onSecureStorageReadFailure(_i8.Future<void> Function()? _onSecureStorageReadFailure) =>
       super.noSuchMethod(
@@ -1541,14 +1363,14 @@ class MockLoginService extends _i1.Mock implements _i19.LoginService {
           #encryptText,
           [plaintext],
         ),
-        returnValue: _i8.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i8.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #encryptText,
             [plaintext],
           ),
         )),
-        returnValueForMissingStub: _i8.Future<String>.value(_i17.dummyValue<String>(
+        returnValueForMissingStub: _i8.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #encryptText,
@@ -1563,14 +1385,14 @@ class MockLoginService extends _i1.Mock implements _i19.LoginService {
           #decryptText,
           [encryptedText],
         ),
-        returnValue: _i8.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i8.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #decryptText,
             [encryptedText],
           ),
         )),
-        returnValueForMissingStub: _i8.Future<String>.value(_i17.dummyValue<String>(
+        returnValueForMissingStub: _i8.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #decryptText,
@@ -1621,7 +1443,7 @@ class MockLoginService extends _i1.Mock implements _i19.LoginService {
             #recipientPubkey: recipientPubkey,
           },
         ),
-        returnValue: _i8.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i8.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #encryptForRecipient,
@@ -1632,7 +1454,7 @@ class MockLoginService extends _i1.Mock implements _i19.LoginService {
             },
           ),
         )),
-        returnValueForMissingStub: _i8.Future<String>.value(_i17.dummyValue<String>(
+        returnValueForMissingStub: _i8.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #encryptForRecipient,
@@ -1659,7 +1481,7 @@ class MockLoginService extends _i1.Mock implements _i19.LoginService {
             #senderPubkey: senderPubkey,
           },
         ),
-        returnValue: _i8.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i8.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #decryptFromSender,
@@ -1670,7 +1492,7 @@ class MockLoginService extends _i1.Mock implements _i19.LoginService {
             },
           ),
         )),
-        returnValueForMissingStub: _i8.Future<String>.value(_i17.dummyValue<String>(
+        returnValueForMissingStub: _i8.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #decryptFromSender,
@@ -1687,7 +1509,7 @@ class MockLoginService extends _i1.Mock implements _i19.LoginService {
 /// A class which mocks [ProcessedNostrEventStore].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockProcessedNostrEventStore extends _i1.Mock implements _i20.ProcessedNostrEventStore {
+class MockProcessedNostrEventStore extends _i1.Mock implements _i18.ProcessedNostrEventStore {
   @override
   int get maxIds => (super.noSuchMethod(
         Invocation.getter(#maxIds),

--- a/test/services/recovery_service_test.dart
+++ b/test/services/recovery_service_test.dart
@@ -18,21 +18,17 @@ import 'package:horcrux/services/recovery_service.dart';
 import 'package:horcrux/services/backup_service.dart';
 import 'package:horcrux/services/share_distribution_service.dart';
 import 'package:horcrux/services/ndk_service.dart';
-import 'package:horcrux/services/vault_share_service.dart';
 import 'package:horcrux/services/local_notification_service.dart';
 import 'package:horcrux/services/processed_nostr_event_store.dart';
-import 'package:shared_preferences/shared_preferences.dart';
-
-import 'recovery_service_test.mocks.dart';
 import '../helpers/secure_storage_mock.dart';
 import '../helpers/test_database.dart';
+import 'recovery_service_test.mocks.dart';
 
 @GenerateMocks([
   BackupService,
   LocalNotificationService,
   ShareDistributionService,
   NdkService,
-  VaultShareService,
   HorcruxNotificationService,
   Nip01Event,
 ])
@@ -55,7 +51,6 @@ void main() {
     late VaultRepository repository;
     late BackupService backupService;
     late NdkService ndkService;
-    late VaultShareService vaultShareService;
     late MockLocalNotificationService mockLocalNotificationService;
     late RecoveryService recoveryService;
     late AppDatabase testDb;
@@ -65,8 +60,6 @@ void main() {
 
     setUp(() async {
       secureStorageMock.clear();
-      SharedPreferences.setMockInitialValues({});
-
       loginService = LoginService();
       await loginService.clearStoredKeys();
       loginService.resetCacheForTest();
@@ -81,7 +74,6 @@ void main() {
       // Create mocks for circular dependency
       final mockBackupService = MockBackupService();
       final mockNdkService = MockNdkService();
-      final mockVaultShareService = MockVaultShareService();
       mockLocalNotificationService = MockLocalNotificationService();
       when(
         mockLocalNotificationService.notifyRecoveryRequestProcessed(any),
@@ -96,7 +88,6 @@ void main() {
 
       backupService = mockBackupService;
       ndkService = mockNdkService;
-      vaultShareService = mockVaultShareService;
       final mockHorcruxNotificationService = MockHorcruxNotificationService();
       when(
         mockHorcruxNotificationService.tryPushForEvent(
@@ -111,7 +102,6 @@ void main() {
         repository,
         backupService,
         ndkService,
-        vaultShareService,
         ProcessedNostrEventStore(),
         mockLocalNotificationService,
         mockHorcruxNotificationService,
@@ -538,6 +528,10 @@ void main() {
         updatedRequest.responseForPubkey(testKeyHolder1)?.share?.payload,
         'recovered_shard_AAA=',
       );
+
+      final daoRows = await testDb.recoveryDao.responsesFor(recoveryRequest.id);
+      expect(daoRows, hasLength(1));
+      expect(daoRows.single.sharePayload, contains('recovered_shard_AAA'));
     });
 
     test('recovery response denial does not include shard data', () async {
@@ -569,6 +563,74 @@ void main() {
         updatedRequest.responseForPubkey(testKeyHolder1)?.share,
         isNull,
       );
+    });
+
+    test('cancelRecoveryRequest clears share_payload in recovery_responses', () async {
+      final recoveryRequest = await recoveryService.initiateRecovery(
+        testVaultId,
+        initiatorPubkey: testCreatorPubkey,
+        stewardPubkeys: [testKeyHolder1],
+        threshold: 1,
+      );
+
+      final shardData = createShare(
+        payload: 'cancel_test_payload=',
+        threshold: 1,
+        shareIndex: 0,
+        totalShares: 1,
+        primeMod: 'test_prime=',
+        creatorPubkey: testCreatorPubkey,
+        vaultId: testVaultId,
+      );
+
+      await recoveryService.processRecoveryResponse(
+        recoveryRequest.id,
+        testKeyHolder1,
+        true,
+        share: shardData,
+      );
+
+      var rows = await testDb.recoveryDao.responsesFor(recoveryRequest.id);
+      expect(rows, isNotEmpty);
+      expect(rows.every((r) => r.sharePayload.isNotEmpty), isTrue);
+
+      await recoveryService.cancelRecoveryRequest(recoveryRequest.id);
+
+      rows = await testDb.recoveryDao.responsesFor(recoveryRequest.id);
+      expect(rows, isNotEmpty);
+      expect(rows.every((r) => r.sharePayload.isEmpty), isTrue);
+    });
+
+    test('exitRecoveryMode deletes recovery_responses rows for the request', () async {
+      final recoveryRequest = await recoveryService.initiateRecovery(
+        testVaultId,
+        initiatorPubkey: testCreatorPubkey,
+        stewardPubkeys: [testKeyHolder1],
+        threshold: 1,
+      );
+
+      final shardData = createShare(
+        payload: 'exit_mode_payload=',
+        threshold: 1,
+        shareIndex: 0,
+        totalShares: 1,
+        primeMod: 'test_prime=',
+        creatorPubkey: testCreatorPubkey,
+        vaultId: testVaultId,
+      );
+
+      await recoveryService.processRecoveryResponse(
+        recoveryRequest.id,
+        testKeyHolder1,
+        true,
+        share: shardData,
+      );
+
+      expect(await testDb.recoveryDao.responsesFor(recoveryRequest.id), isNotEmpty);
+
+      await recoveryService.exitRecoveryMode(recoveryRequest.id);
+
+      expect(await testDb.recoveryDao.responsesFor(recoveryRequest.id), isEmpty);
     });
 
     test('multiple recovery responses accumulate correctly', () async {

--- a/test/services/recovery_service_test.mocks.dart
+++ b/test/services/recovery_service_test.mocks.dart
@@ -3,26 +3,24 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i6;
+import 'dart:async' as _i5;
 
 import 'package:horcrux/models/backup_config.dart' as _i2;
-import 'package:horcrux/models/backup_status.dart' as _i10;
-import 'package:horcrux/models/event_status.dart' as _i17;
-import 'package:horcrux/models/nostr_kinds.dart' as _i15;
-import 'package:horcrux/models/recovery_request.dart' as _i13;
-import 'package:horcrux/models/share.dart' as _i8;
-import 'package:horcrux/models/steward.dart' as _i7;
-import 'package:horcrux/models/steward_status.dart' as _i11;
-import 'package:horcrux/models/vault.dart' as _i20;
-import 'package:horcrux/providers/vault_provider.dart' as _i4;
-import 'package:horcrux/services/backup_service.dart' as _i5;
-import 'package:horcrux/services/horcrux_notification_service.dart' as _i19;
-import 'package:horcrux/services/local_notification_service.dart' as _i12;
-import 'package:horcrux/services/ndk_service.dart' as _i14;
-import 'package:horcrux/services/share_distribution_service.dart' as _i16;
-import 'package:horcrux/services/vault_share_service.dart' as _i18;
+import 'package:horcrux/models/backup_status.dart' as _i9;
+import 'package:horcrux/models/event_status.dart' as _i16;
+import 'package:horcrux/models/nostr_kinds.dart' as _i14;
+import 'package:horcrux/models/recovery_request.dart' as _i12;
+import 'package:horcrux/models/share.dart' as _i7;
+import 'package:horcrux/models/steward.dart' as _i6;
+import 'package:horcrux/models/steward_status.dart' as _i10;
+import 'package:horcrux/models/vault.dart' as _i18;
+import 'package:horcrux/services/backup_service.dart' as _i4;
+import 'package:horcrux/services/horcrux_notification_service.dart' as _i17;
+import 'package:horcrux/services/local_notification_service.dart' as _i11;
+import 'package:horcrux/services/ndk_service.dart' as _i13;
+import 'package:horcrux/services/share_distribution_service.dart' as _i15;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i9;
+import 'package:mockito/src/dummies.dart' as _i8;
 import 'package:ndk/ndk.dart' as _i3;
 
 // ignore_for_file: type=lint
@@ -59,18 +57,8 @@ class _FakeNdk_1 extends _i1.SmartFake implements _i3.Ndk {
         );
 }
 
-class _FakeVaultRepository_2 extends _i1.SmartFake implements _i4.VaultRepository {
-  _FakeVaultRepository_2(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
-}
-
-class _FakeNip01Event_3 extends _i1.SmartFake implements _i3.Nip01Event {
-  _FakeNip01Event_3(
+class _FakeNip01Event_2 extends _i1.SmartFake implements _i3.Nip01Event {
+  _FakeNip01Event_2(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -82,17 +70,17 @@ class _FakeNip01Event_3 extends _i1.SmartFake implements _i3.Nip01Event {
 /// A class which mocks [BackupService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockBackupService extends _i1.Mock implements _i5.BackupService {
+class MockBackupService extends _i1.Mock implements _i4.BackupService {
   MockBackupService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i6.Future<_i2.BackupConfig> createBackupConfiguration({
+  _i5.Future<_i2.BackupConfig> createBackupConfiguration({
     required String? vaultId,
     required int? threshold,
     required int? totalKeys,
-    required List<_i7.Steward>? stewards,
+    required List<_i6.Steward>? stewards,
     required List<String>? relays,
     String? instructions,
   }) =>
@@ -109,7 +97,7 @@ class MockBackupService extends _i1.Mock implements _i5.BackupService {
             #instructions: instructions,
           },
         ),
-        returnValue: _i6.Future<_i2.BackupConfig>.value(_FakeBackupConfig_0(
+        returnValue: _i5.Future<_i2.BackupConfig>.value(_FakeBackupConfig_0(
           this,
           Invocation.method(
             #createBackupConfiguration,
@@ -124,48 +112,48 @@ class MockBackupService extends _i1.Mock implements _i5.BackupService {
             },
           ),
         )),
-      ) as _i6.Future<_i2.BackupConfig>);
+      ) as _i5.Future<_i2.BackupConfig>);
 
   @override
-  _i6.Future<_i2.BackupConfig?> getBackupConfig(String? vaultId) => (super.noSuchMethod(
+  _i5.Future<_i2.BackupConfig?> getBackupConfig(String? vaultId) => (super.noSuchMethod(
         Invocation.method(
           #getBackupConfig,
           [vaultId],
         ),
-        returnValue: _i6.Future<_i2.BackupConfig?>.value(),
-      ) as _i6.Future<_i2.BackupConfig?>);
+        returnValue: _i5.Future<_i2.BackupConfig?>.value(),
+      ) as _i5.Future<_i2.BackupConfig?>);
 
   @override
-  _i6.Future<List<_i2.BackupConfig>> getAllBackupConfigs() => (super.noSuchMethod(
+  _i5.Future<List<_i2.BackupConfig>> getAllBackupConfigs() => (super.noSuchMethod(
         Invocation.method(
           #getAllBackupConfigs,
           [],
         ),
-        returnValue: _i6.Future<List<_i2.BackupConfig>>.value(<_i2.BackupConfig>[]),
-      ) as _i6.Future<List<_i2.BackupConfig>>);
+        returnValue: _i5.Future<List<_i2.BackupConfig>>.value(<_i2.BackupConfig>[]),
+      ) as _i5.Future<List<_i2.BackupConfig>>);
 
   @override
-  _i6.Future<void> updateBackupConfig(_i2.BackupConfig? config) => (super.noSuchMethod(
+  _i5.Future<void> updateBackupConfig(_i2.BackupConfig? config) => (super.noSuchMethod(
         Invocation.method(
           #updateBackupConfig,
           [config],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i6.Future<void> deleteBackupConfig(String? vaultId) => (super.noSuchMethod(
+  _i5.Future<void> deleteBackupConfig(String? vaultId) => (super.noSuchMethod(
         Invocation.method(
           #deleteBackupConfig,
           [vaultId],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i6.Future<List<_i8.Share>> generateShamirShares({
+  _i5.Future<List<_i7.Share>> generateShamirShares({
     required String? content,
     required int? threshold,
     required int? totalShards,
@@ -194,18 +182,18 @@ class MockBackupService extends _i1.Mock implements _i5.BackupService {
             #pushEnabled: pushEnabled,
           },
         ),
-        returnValue: _i6.Future<List<_i8.Share>>.value(<_i8.Share>[]),
-      ) as _i6.Future<List<_i8.Share>>);
+        returnValue: _i5.Future<List<_i7.Share>>.value(<_i7.Share>[]),
+      ) as _i5.Future<List<_i7.Share>>);
 
   @override
-  _i6.Future<String> reconstructFromShares({required List<_i8.Share>? shares}) =>
+  _i5.Future<String> reconstructFromShares({required List<_i7.Share>? shares}) =>
       (super.noSuchMethod(
         Invocation.method(
           #reconstructFromShares,
           [],
           {#shares: shares},
         ),
-        returnValue: _i6.Future<String>.value(_i9.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #reconstructFromShares,
@@ -213,12 +201,12 @@ class MockBackupService extends _i1.Mock implements _i5.BackupService {
             {#shares: shares},
           ),
         )),
-      ) as _i6.Future<String>);
+      ) as _i5.Future<String>);
 
   @override
-  _i6.Future<void> updateBackupStatus(
+  _i5.Future<void> updateBackupStatus(
     String? vaultId,
-    _i10.BackupStatus? status,
+    _i9.BackupStatus? status,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -228,15 +216,15 @@ class MockBackupService extends _i1.Mock implements _i5.BackupService {
             status,
           ],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i6.Future<void> updateStewardStatus({
+  _i5.Future<void> updateStewardStatus({
     required String? vaultId,
     required String? pubkey,
-    required _i11.StewardStatus? status,
+    required _i10.StewardStatus? status,
     DateTime? acknowledgedAt,
     String? acknowledgmentEventId,
     String? giftWrapEventId,
@@ -254,24 +242,24 @@ class MockBackupService extends _i1.Mock implements _i5.BackupService {
             #giftWrapEventId: giftWrapEventId,
           },
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i6.Future<bool> isBackupReady(String? vaultId) => (super.noSuchMethod(
+  _i5.Future<bool> isBackupReady(String? vaultId) => (super.noSuchMethod(
         Invocation.method(
           #isBackupReady,
           [vaultId],
         ),
-        returnValue: _i6.Future<bool>.value(false),
-      ) as _i6.Future<bool>);
+        returnValue: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
 
   @override
-  _i6.Future<_i2.BackupConfig> mergeBackupConfig({
+  _i5.Future<_i2.BackupConfig> mergeBackupConfig({
     required String? vaultId,
     int? threshold,
-    List<_i7.Steward>? stewards,
+    List<_i6.Steward>? stewards,
     List<String>? relays,
     String? instructions,
   }) =>
@@ -287,7 +275,7 @@ class MockBackupService extends _i1.Mock implements _i5.BackupService {
             #instructions: instructions,
           },
         ),
-        returnValue: _i6.Future<_i2.BackupConfig>.value(_FakeBackupConfig_0(
+        returnValue: _i5.Future<_i2.BackupConfig>.value(_FakeBackupConfig_0(
           this,
           Invocation.method(
             #mergeBackupConfig,
@@ -301,46 +289,46 @@ class MockBackupService extends _i1.Mock implements _i5.BackupService {
             },
           ),
         )),
-      ) as _i6.Future<_i2.BackupConfig>);
+      ) as _i5.Future<_i2.BackupConfig>);
 
   @override
-  _i6.Future<void> handleContentChange(String? vaultId) => (super.noSuchMethod(
+  _i5.Future<void> handleContentChange(String? vaultId) => (super.noSuchMethod(
         Invocation.method(
           #handleContentChange,
           [vaultId],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i6.Future<void> redistributeForPushPreferenceChange({required String? vaultId}) =>
+  _i5.Future<void> redistributeForPushPreferenceChange({required String? vaultId}) =>
       (super.noSuchMethod(
         Invocation.method(
           #redistributeForPushPreferenceChange,
           [],
           {#vaultId: vaultId},
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i6.Future<void> distributeKeysIfNecessary(String? vaultId) => (super.noSuchMethod(
+  _i5.Future<void> distributeKeysIfNecessary(String? vaultId) => (super.noSuchMethod(
         Invocation.method(
           #distributeKeysIfNecessary,
           [vaultId],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i6.Future<_i2.BackupConfig> saveBackupConfig({
+  _i5.Future<_i2.BackupConfig> saveBackupConfig({
     required String? vaultId,
     required int? threshold,
     required int? totalKeys,
-    required List<_i7.Steward>? stewards,
+    required List<_i6.Steward>? stewards,
     required List<String>? relays,
     String? instructions,
   }) =>
@@ -357,7 +345,7 @@ class MockBackupService extends _i1.Mock implements _i5.BackupService {
             #instructions: instructions,
           },
         ),
-        returnValue: _i6.Future<_i2.BackupConfig>.value(_FakeBackupConfig_0(
+        returnValue: _i5.Future<_i2.BackupConfig>.value(_FakeBackupConfig_0(
           this,
           Invocation.method(
             #saveBackupConfig,
@@ -372,17 +360,17 @@ class MockBackupService extends _i1.Mock implements _i5.BackupService {
             },
           ),
         )),
-      ) as _i6.Future<_i2.BackupConfig>);
+      ) as _i5.Future<_i2.BackupConfig>);
 
   @override
-  _i6.Future<_i2.BackupConfig> createAndDistributeBackup({required String? vaultId}) =>
+  _i5.Future<_i2.BackupConfig> createAndDistributeBackup({required String? vaultId}) =>
       (super.noSuchMethod(
         Invocation.method(
           #createAndDistributeBackup,
           [],
           {#vaultId: vaultId},
         ),
-        returnValue: _i6.Future<_i2.BackupConfig>.value(_FakeBackupConfig_0(
+        returnValue: _i5.Future<_i2.BackupConfig>.value(_FakeBackupConfig_0(
           this,
           Invocation.method(
             #createAndDistributeBackup,
@@ -390,53 +378,53 @@ class MockBackupService extends _i1.Mock implements _i5.BackupService {
             {#vaultId: vaultId},
           ),
         )),
-      ) as _i6.Future<_i2.BackupConfig>);
+      ) as _i5.Future<_i2.BackupConfig>);
 }
 
 /// A class which mocks [LocalNotificationService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockLocalNotificationService extends _i1.Mock implements _i12.LocalNotificationService {
+class MockLocalNotificationService extends _i1.Mock implements _i11.LocalNotificationService {
   MockLocalNotificationService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i6.Future<void> initialize() => (super.noSuchMethod(
+  _i5.Future<void> initialize() => (super.noSuchMethod(
         Invocation.method(
           #initialize,
           [],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i6.Future<void> notifyRecoveryRequestProcessed(_i13.RecoveryRequest? request) =>
+  _i5.Future<void> notifyRecoveryRequestProcessed(_i12.RecoveryRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #notifyRecoveryRequestProcessed,
           [request],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i6.Future<void> notifyRecoveryResponseProcessed(_i14.RecoveryResponseEvent? response) =>
+  _i5.Future<void> notifyRecoveryResponseProcessed(_i13.RecoveryResponseEvent? response) =>
       (super.noSuchMethod(
         Invocation.method(
           #notifyRecoveryResponseProcessed,
           [response],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i6.Future<void> notifyShareDataProcessed({
+  _i5.Future<void> notifyShareDataProcessed({
     required _i3.Nip01Event? event,
-    required _i8.Share? share,
+    required _i7.Share? share,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -447,12 +435,12 @@ class MockLocalNotificationService extends _i1.Mock implements _i12.LocalNotific
             #share: share,
           },
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i6.Future<void> notifyShareConfirmationProcessed({
+  _i5.Future<void> notifyShareConfirmationProcessed({
     required _i3.Nip01Event? event,
     required String? vaultId,
   }) =>
@@ -465,30 +453,30 @@ class MockLocalNotificationService extends _i1.Mock implements _i12.LocalNotific
             #vaultId: vaultId,
           },
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i6.Future<bool> requestPlatformNotificationPermissions() => (super.noSuchMethod(
+  _i5.Future<bool> requestPlatformNotificationPermissions() => (super.noSuchMethod(
         Invocation.method(
           #requestPlatformNotificationPermissions,
           [],
         ),
-        returnValue: _i6.Future<bool>.value(false),
-      ) as _i6.Future<bool>);
+        returnValue: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
 
   @override
-  _i6.Future<bool> areOsNotificationsEnabled() => (super.noSuchMethod(
+  _i5.Future<bool> areOsNotificationsEnabled() => (super.noSuchMethod(
         Invocation.method(
           #areOsNotificationsEnabled,
           [],
         ),
-        returnValue: _i6.Future<bool>.value(false),
-      ) as _i6.Future<bool>);
+        returnValue: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
 
   @override
-  _i6.Future<void> showNotification({
+  _i5.Future<void> showNotification({
     required String? title,
     required String? body,
     String? payload,
@@ -503,13 +491,13 @@ class MockLocalNotificationService extends _i1.Mock implements _i12.LocalNotific
             #payload: payload,
           },
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i6.Future<bool> navigateForKind(
-    _i15.NostrKind? kind,
+  _i5.Future<bool> navigateForKind(
+    _i14.NostrKind? kind,
     String? id, {
     String? vaultId,
   }) =>
@@ -522,18 +510,18 @@ class MockLocalNotificationService extends _i1.Mock implements _i12.LocalNotific
           ],
           {#vaultId: vaultId},
         ),
-        returnValue: _i6.Future<bool>.value(false),
-      ) as _i6.Future<bool>);
+        returnValue: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
 
   @override
-  _i6.Future<void> navigateToVault(String? vaultId) => (super.noSuchMethod(
+  _i5.Future<void> navigateToVault(String? vaultId) => (super.noSuchMethod(
         Invocation.method(
           #navigateToVault,
           [vaultId],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
   void dispose() => super.noSuchMethod(
@@ -548,13 +536,13 @@ class MockLocalNotificationService extends _i1.Mock implements _i12.LocalNotific
 /// A class which mocks [ShareDistributionService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockShareDistributionService extends _i1.Mock implements _i16.ShareDistributionService {
+class MockShareDistributionService extends _i1.Mock implements _i15.ShareDistributionService {
   MockShareDistributionService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i6.Future<
+  _i5.Future<
       List<
           ({
             String backupConfigId,
@@ -564,11 +552,11 @@ class MockShareDistributionService extends _i1.Mock implements _i16.ShareDistrib
             DateTime? publishedAt,
             String recipientPubkey,
             int shareIndex,
-            _i17.EventStatus status
+            _i16.EventStatus status
           })>> distributeShares({
     required String? ownerPubkey,
     required _i2.BackupConfig? config,
-    required List<_i8.Share>? shares,
+    required List<_i7.Share>? shares,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -580,7 +568,7 @@ class MockShareDistributionService extends _i1.Mock implements _i16.ShareDistrib
             #shares: shares,
           },
         ),
-        returnValue: _i6.Future<
+        returnValue: _i5.Future<
             List<
                 ({
                   String backupConfigId,
@@ -590,7 +578,7 @@ class MockShareDistributionService extends _i1.Mock implements _i16.ShareDistrib
                   DateTime? publishedAt,
                   String recipientPubkey,
                   int shareIndex,
-                  _i17.EventStatus status
+                  _i16.EventStatus status
                 })>>.value(<({
           String backupConfigId,
           DateTime createdAt,
@@ -599,9 +587,9 @@ class MockShareDistributionService extends _i1.Mock implements _i16.ShareDistrib
           DateTime? publishedAt,
           String recipientPubkey,
           int shareIndex,
-          _i17.EventStatus status
+          _i16.EventStatus status
         })>[]),
-      ) as _i6.Future<
+      ) as _i5.Future<
           List<
               ({
                 String backupConfigId,
@@ -611,11 +599,11 @@ class MockShareDistributionService extends _i1.Mock implements _i16.ShareDistrib
                 DateTime? publishedAt,
                 String recipientPubkey,
                 int shareIndex,
-                _i17.EventStatus status
+                _i16.EventStatus status
               })>>);
 
   @override
-  _i6.Future<void> updateDistributionStatus({
+  _i5.Future<void> updateDistributionStatus({
     required String? vaultId,
     required List<
             ({
@@ -626,7 +614,7 @@ class MockShareDistributionService extends _i1.Mock implements _i16.ShareDistrib
               DateTime? publishedAt,
               String recipientPubkey,
               int shareIndex,
-              _i17.EventStatus status
+              _i16.EventStatus status
             })>?
         shareEvents,
   }) =>
@@ -639,38 +627,38 @@ class MockShareDistributionService extends _i1.Mock implements _i16.ShareDistrib
             #shareEvents: shareEvents,
           },
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i6.Future<void> processShareConfirmationEvent({required _i3.Nip01Event? event}) =>
+  _i5.Future<void> processShareConfirmationEvent({required _i3.Nip01Event? event}) =>
       (super.noSuchMethod(
         Invocation.method(
           #processShareConfirmationEvent,
           [],
           {#event: event},
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i6.Future<void> processShareErrorEvent({required _i3.Nip01Event? event}) => (super.noSuchMethod(
+  _i5.Future<void> processShareErrorEvent({required _i3.Nip01Event? event}) => (super.noSuchMethod(
         Invocation.method(
           #processShareErrorEvent,
           [],
           {#event: event},
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 }
 
 /// A class which mocks [NdkService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockNdkService extends _i1.Mock implements _i14.NdkService {
+class MockNdkService extends _i1.Mock implements _i13.NdkService {
   MockNdkService() {
     _i1.throwOnMissingStub(this);
   }
@@ -682,37 +670,37 @@ class MockNdkService extends _i1.Mock implements _i14.NdkService {
       ) as bool);
 
   @override
-  _i6.Future<void> initialize() => (super.noSuchMethod(
+  _i5.Future<void> initialize() => (super.noSuchMethod(
         Invocation.method(
           #initialize,
           [],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i6.Future<void> addRelay(String? relayUrl) => (super.noSuchMethod(
+  _i5.Future<void> addRelay(String? relayUrl) => (super.noSuchMethod(
         Invocation.method(
           #addRelay,
           [relayUrl],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i6.Future<void> removeRelay(String? relayUrl) => (super.noSuchMethod(
+  _i5.Future<void> removeRelay(String? relayUrl) => (super.noSuchMethod(
         Invocation.method(
           #removeRelay,
           [relayUrl],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i6.Future<void> processGiftWrapFromForegroundPush(
+  _i5.Future<void> processGiftWrapFromForegroundPush(
     _i3.Nip01Event? event, {
     bool? allowLocalNotification = true,
   }) =>
@@ -722,12 +710,12 @@ class MockNdkService extends _i1.Mock implements _i14.NdkService {
           [event],
           {#allowLocalNotification: allowLocalNotification},
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i6.Future<_i3.Nip01Event?> fetchGiftWrapByIdForPush({
+  _i5.Future<_i3.Nip01Event?> fetchGiftWrapByIdForPush({
     required String? eventIdHex,
     List<String>? relayHints,
   }) =>
@@ -740,11 +728,11 @@ class MockNdkService extends _i1.Mock implements _i14.NdkService {
             #relayHints: relayHints,
           },
         ),
-        returnValue: _i6.Future<_i3.Nip01Event?>.value(),
-      ) as _i6.Future<_i3.Nip01Event?>);
+        returnValue: _i5.Future<_i3.Nip01Event?>.value(),
+      ) as _i5.Future<_i3.Nip01Event?>);
 
   @override
-  _i6.Future<_i8.Share?> loadShareDataFromPublishedDistributionGiftWrap({
+  _i5.Future<_i7.Share?> loadShareDataFromPublishedDistributionGiftWrap({
     required String? giftWrapEventId,
     required List<String>? relayHints,
   }) =>
@@ -757,30 +745,30 @@ class MockNdkService extends _i1.Mock implements _i14.NdkService {
             #relayHints: relayHints,
           },
         ),
-        returnValue: _i6.Future<_i8.Share?>.value(),
-      ) as _i6.Future<_i8.Share?>);
+        returnValue: _i5.Future<_i7.Share?>.value(),
+      ) as _i5.Future<_i7.Share?>);
 
   @override
-  _i6.Future<String?> resolveVaultIdForGiftWrap(_i3.Nip01Event? giftWrap) => (super.noSuchMethod(
+  _i5.Future<String?> resolveVaultIdForGiftWrap(_i3.Nip01Event? giftWrap) => (super.noSuchMethod(
         Invocation.method(
           #resolveVaultIdForGiftWrap,
           [giftWrap],
         ),
-        returnValue: _i6.Future<String?>.value(),
-      ) as _i6.Future<String?>);
+        returnValue: _i5.Future<String?>.value(),
+      ) as _i5.Future<String?>);
 
   @override
-  _i6.Future<({_i15.NostrKind kind, String recoveryRequestId})?>
+  _i5.Future<({_i14.NostrKind kind, String recoveryRequestId})?>
       resolveRecoveryRequestIdForGiftWrap(_i3.Nip01Event? giftWrap) => (super.noSuchMethod(
             Invocation.method(
               #resolveRecoveryRequestIdForGiftWrap,
               [giftWrap],
             ),
-            returnValue: _i6.Future<({_i15.NostrKind kind, String recoveryRequestId})?>.value(),
-          ) as _i6.Future<({_i15.NostrKind kind, String recoveryRequestId})?>);
+            returnValue: _i5.Future<({_i14.NostrKind kind, String recoveryRequestId})?>.value(),
+          ) as _i5.Future<({_i14.NostrKind kind, String recoveryRequestId})?>);
 
   @override
-  _i6.Future<String?> publishRecoveryRequest({
+  _i5.Future<String?> publishRecoveryRequest({
     required String? vaultId,
     required List<String>? stewardPubkeys,
     DateTime? expiresAt,
@@ -795,18 +783,18 @@ class MockNdkService extends _i1.Mock implements _i14.NdkService {
             #expiresAt: expiresAt,
           },
         ),
-        returnValue: _i6.Future<String?>.value(),
-      ) as _i6.Future<String?>);
+        returnValue: _i5.Future<String?>.value(),
+      ) as _i5.Future<String?>);
 
   @override
-  _i6.Future<void> closeSubscriptions() => (super.noSuchMethod(
+  _i5.Future<void> closeSubscriptions() => (super.noSuchMethod(
         Invocation.method(
           #closeSubscriptions,
           [],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
   List<String> getActiveRelays() => (super.noSuchMethod(
@@ -818,16 +806,16 @@ class MockNdkService extends _i1.Mock implements _i14.NdkService {
       ) as List<String>);
 
   @override
-  _i6.Future<String?> getCurrentPubkey() => (super.noSuchMethod(
+  _i5.Future<String?> getCurrentPubkey() => (super.noSuchMethod(
         Invocation.method(
           #getCurrentPubkey,
           [],
         ),
-        returnValue: _i6.Future<String?>.value(),
-      ) as _i6.Future<String?>);
+        returnValue: _i5.Future<String?>.value(),
+      ) as _i5.Future<String?>);
 
   @override
-  _i6.Future<_i3.Nip01Event?> publishEncryptedEvent({
+  _i5.Future<_i3.Nip01Event?> publishEncryptedEvent({
     required String? content,
     required int? kind,
     required String? recipientPubkey,
@@ -850,11 +838,11 @@ class MockNdkService extends _i1.Mock implements _i14.NdkService {
             #vaultId: vaultId,
           },
         ),
-        returnValue: _i6.Future<_i3.Nip01Event?>.value(),
-      ) as _i6.Future<_i3.Nip01Event?>);
+        returnValue: _i5.Future<_i3.Nip01Event?>.value(),
+      ) as _i5.Future<_i3.Nip01Event?>);
 
   @override
-  _i6.Future<List<_i3.Nip01Event?>> publishEncryptedEventToMultiple({
+  _i5.Future<List<_i3.Nip01Event?>> publishEncryptedEventToMultiple({
     required String? content,
     required int? kind,
     required List<String>? recipientPubkeys,
@@ -877,23 +865,23 @@ class MockNdkService extends _i1.Mock implements _i14.NdkService {
             #vaultId: vaultId,
           },
         ),
-        returnValue: _i6.Future<List<_i3.Nip01Event?>>.value(<_i3.Nip01Event?>[]),
-      ) as _i6.Future<List<_i3.Nip01Event?>>);
+        returnValue: _i5.Future<List<_i3.Nip01Event?>>.value(<_i3.Nip01Event?>[]),
+      ) as _i5.Future<List<_i3.Nip01Event?>>);
 
   @override
-  _i6.Future<_i3.Ndk> getNdk() => (super.noSuchMethod(
+  _i5.Future<_i3.Ndk> getNdk() => (super.noSuchMethod(
         Invocation.method(
           #getNdk,
           [],
         ),
-        returnValue: _i6.Future<_i3.Ndk>.value(_FakeNdk_1(
+        returnValue: _i5.Future<_i3.Ndk>.value(_FakeNdk_1(
           this,
           Invocation.method(
             #getNdk,
             [],
           ),
         )),
-      ) as _i6.Future<_i3.Ndk>);
+      ) as _i5.Future<_i3.Ndk>);
 
   @override
   void setNdkForTesting(_i3.Ndk? ndk) => super.noSuchMethod(
@@ -914,256 +902,53 @@ class MockNdkService extends _i1.Mock implements _i14.NdkService {
       );
 
   @override
-  _i6.Future<void> dispose() => (super.noSuchMethod(
+  _i5.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
-}
-
-/// A class which mocks [VaultShareService].
-///
-/// See the documentation for Mockito's code generation for more information.
-class MockVaultShareService extends _i1.Mock implements _i18.VaultShareService {
-  MockVaultShareService() {
-    _i1.throwOnMissingStub(this);
-  }
-
-  @override
-  _i4.VaultRepository get repository => (super.noSuchMethod(
-        Invocation.getter(#repository),
-        returnValue: _FakeVaultRepository_2(
-          this,
-          Invocation.getter(#repository),
-        ),
-      ) as _i4.VaultRepository);
-
-  @override
-  _i6.Future<List<_i8.Share>> getVaultShares(String? vaultId) => (super.noSuchMethod(
-        Invocation.method(
-          #getVaultShares,
-          [vaultId],
-        ),
-        returnValue: _i6.Future<List<_i8.Share>>.value(<_i8.Share>[]),
-      ) as _i6.Future<List<_i8.Share>>);
-
-  @override
-  _i6.Future<_i8.Share?> getVaultShare(String? vaultId) => (super.noSuchMethod(
-        Invocation.method(
-          #getVaultShare,
-          [vaultId],
-        ),
-        returnValue: _i6.Future<_i8.Share?>.value(),
-      ) as _i6.Future<_i8.Share?>);
-
-  @override
-  _i6.Future<void> addVaultShare(
-    String? vaultId,
-    _i8.Share? share,
-  ) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #addVaultShare,
-          [
-            vaultId,
-            share,
-          ],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
-
-  @override
-  _i6.Future<void> processVaultShare(
-    String? vaultId,
-    _i8.Share? shardData,
-  ) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #processVaultShare,
-          [
-            vaultId,
-            shardData,
-          ],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
-
-  @override
-  _i6.Future<String?> sendShareConfirmationEvent({
-    required String? vaultId,
-    required int? shareIndex,
-    required String? ownerPubkey,
-    required List<String>? relayUrls,
-    int? distributionVersion,
-  }) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #sendShareConfirmationEvent,
-          [],
-          {
-            #vaultId: vaultId,
-            #shareIndex: shareIndex,
-            #ownerPubkey: ownerPubkey,
-            #relayUrls: relayUrls,
-            #distributionVersion: distributionVersion,
-          },
-        ),
-        returnValue: _i6.Future<String?>.value(),
-      ) as _i6.Future<String?>);
-
-  @override
-  _i6.Future<bool> isKeyHolderForVault(String? vaultId) => (super.noSuchMethod(
-        Invocation.method(
-          #isKeyHolderForVault,
-          [vaultId],
-        ),
-        returnValue: _i6.Future<bool>.value(false),
-      ) as _i6.Future<bool>);
-
-  @override
-  _i6.Future<int> getShardCount(String? vaultId) => (super.noSuchMethod(
-        Invocation.method(
-          #getShardCount,
-          [vaultId],
-        ),
-        returnValue: _i6.Future<int>.value(0),
-      ) as _i6.Future<int>);
-
-  @override
-  _i6.Future<void> removeVaultShare(String? vaultId) => (super.noSuchMethod(
-        Invocation.method(
-          #removeVaultShare,
-          [vaultId],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
-
-  @override
-  _i6.Future<void> processKeyHolderRemoval({required _i3.Nip01Event? event}) => (super.noSuchMethod(
-        Invocation.method(
-          #processKeyHolderRemoval,
-          [],
-          {#event: event},
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
-
-  @override
-  _i6.Future<void> addRecoveryShard(
-    String? recoveryRequestId,
-    _i8.Share? shardData,
-  ) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #addRecoveryShard,
-          [
-            recoveryRequestId,
-            shardData,
-          ],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
-
-  @override
-  _i6.Future<List<_i8.Share>> getRecoveryShards(String? recoveryRequestId) => (super.noSuchMethod(
-        Invocation.method(
-          #getRecoveryShards,
-          [recoveryRequestId],
-        ),
-        returnValue: _i6.Future<List<_i8.Share>>.value(<_i8.Share>[]),
-      ) as _i6.Future<List<_i8.Share>>);
-
-  @override
-  _i6.Future<int> getRecoveryShardCount(String? recoveryRequestId) => (super.noSuchMethod(
-        Invocation.method(
-          #getRecoveryShardCount,
-          [recoveryRequestId],
-        ),
-        returnValue: _i6.Future<int>.value(0),
-      ) as _i6.Future<int>);
-
-  @override
-  _i6.Future<bool> hasSufficientRecoveryShards(
-    String? recoveryRequestId,
-    int? threshold,
-  ) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #hasSufficientRecoveryShards,
-          [
-            recoveryRequestId,
-            threshold,
-          ],
-        ),
-        returnValue: _i6.Future<bool>.value(false),
-      ) as _i6.Future<bool>);
-
-  @override
-  _i6.Future<void> removeRecoveryShards(String? recoveryRequestId) => (super.noSuchMethod(
-        Invocation.method(
-          #removeRecoveryShards,
-          [recoveryRequestId],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
-
-  @override
-  _i6.Future<void> clearAll() => (super.noSuchMethod(
-        Invocation.method(
-          #clearAll,
-          [],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 }
 
 /// A class which mocks [HorcruxNotificationService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockHorcruxNotificationService extends _i1.Mock implements _i19.HorcruxNotificationService {
+class MockHorcruxNotificationService extends _i1.Mock implements _i17.HorcruxNotificationService {
   MockHorcruxNotificationService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i6.Future<String> getBaseUrl() => (super.noSuchMethod(
+  _i5.Future<String> getBaseUrl() => (super.noSuchMethod(
         Invocation.method(
           #getBaseUrl,
           [],
         ),
-        returnValue: _i6.Future<String>.value(_i9.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #getBaseUrl,
             [],
           ),
         )),
-      ) as _i6.Future<String>);
+      ) as _i5.Future<String>);
 
   @override
-  _i6.Future<void> setBaseUrl(String? override) => (super.noSuchMethod(
+  _i5.Future<void> setBaseUrl(String? override) => (super.noSuchMethod(
         Invocation.method(
           #setBaseUrl,
           [override],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i6.Future<void> register({
+  _i5.Future<void> register({
     required String? fcmToken,
-    required _i19.NotifierPlatform? platform,
+    required _i17.NotifierPlatform? platform,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1174,24 +959,24 @@ class MockHorcruxNotificationService extends _i1.Mock implements _i19.HorcruxNot
             #platform: platform,
           },
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i6.Future<void> deregister() => (super.noSuchMethod(
+  _i5.Future<void> deregister() => (super.noSuchMethod(
         Invocation.method(
           #deregister,
           [],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i6.Future<void> updateToken({
+  _i5.Future<void> updateToken({
     required String? newToken,
-    required _i19.NotifierPlatform? platform,
+    required _i17.NotifierPlatform? platform,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1202,24 +987,24 @@ class MockHorcruxNotificationService extends _i1.Mock implements _i19.HorcruxNot
             #platform: platform,
           },
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i6.Future<void> replaceConsents(List<String>? authorizedSenders) => (super.noSuchMethod(
+  _i5.Future<void> replaceConsents(List<String>? authorizedSenders) => (super.noSuchMethod(
         Invocation.method(
           #replaceConsents,
           [authorizedSenders],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
   List<String> computeConsentList({
     required String? currentUserPubkey,
-    required List<_i20.Vault>? vaults,
+    required List<_i18.Vault>? vaults,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1234,30 +1019,30 @@ class MockHorcruxNotificationService extends _i1.Mock implements _i19.HorcruxNot
       ) as List<String>);
 
   @override
-  _i6.Future<void> syncConsentList() => (super.noSuchMethod(
+  _i5.Future<void> syncConsentList() => (super.noSuchMethod(
         Invocation.method(
           #syncConsentList,
           [],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i6.Future<void> deleteConsent(String? senderPubkey) => (super.noSuchMethod(
+  _i5.Future<void> deleteConsent(String? senderPubkey) => (super.noSuchMethod(
         Invocation.method(
           #deleteConsent,
           [senderPubkey],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i6.Future<void> tryPushForEvent({
+  _i5.Future<void> tryPushForEvent({
     required _i3.Nip01Event? event,
-    required _i15.NostrKind? kind,
-    required _i20.Vault? vault,
+    required _i14.NostrKind? kind,
+    required _i18.Vault? vault,
     List<String>? relayHints,
     bool? recoveryApproved,
   }) =>
@@ -1273,12 +1058,12 @@ class MockHorcruxNotificationService extends _i1.Mock implements _i19.HorcruxNot
             #recoveryApproved: recoveryApproved,
           },
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i6.Future<void> push({
+  _i5.Future<void> push({
     required String? recipientPubkey,
     required String? title,
     required String? body,
@@ -1299,9 +1084,9 @@ class MockHorcruxNotificationService extends _i1.Mock implements _i19.HorcruxNot
             #relayHints: relayHints,
           },
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
   void dispose() => super.noSuchMethod(
@@ -1324,7 +1109,7 @@ class MockNip01Event extends _i1.Mock implements _i3.Nip01Event {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i9.dummyValue<String>(
+        returnValue: _i8.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -1333,7 +1118,7 @@ class MockNip01Event extends _i1.Mock implements _i3.Nip01Event {
   @override
   String get pubKey => (super.noSuchMethod(
         Invocation.getter(#pubKey),
-        returnValue: _i9.dummyValue<String>(
+        returnValue: _i8.dummyValue<String>(
           this,
           Invocation.getter(#pubKey),
         ),
@@ -1360,7 +1145,7 @@ class MockNip01Event extends _i1.Mock implements _i3.Nip01Event {
   @override
   String get content => (super.noSuchMethod(
         Invocation.getter(#content),
-        returnValue: _i9.dummyValue<String>(
+        returnValue: _i8.dummyValue<String>(
           this,
           Invocation.getter(#content),
         ),
@@ -1369,7 +1154,7 @@ class MockNip01Event extends _i1.Mock implements _i3.Nip01Event {
   @override
   String get sig => (super.noSuchMethod(
         Invocation.getter(#sig),
-        returnValue: _i9.dummyValue<String>(
+        returnValue: _i8.dummyValue<String>(
           this,
           Invocation.getter(#sig),
         ),
@@ -1483,7 +1268,7 @@ class MockNip01Event extends _i1.Mock implements _i3.Nip01Event {
           #toBase64,
           [],
         ),
-        returnValue: _i9.dummyValue<String>(
+        returnValue: _i8.dummyValue<String>(
           this,
           Invocation.method(
             #toBase64,
@@ -1540,7 +1325,7 @@ class MockNip01Event extends _i1.Mock implements _i3.Nip01Event {
             #sources: sources,
           },
         ),
-        returnValue: _FakeNip01Event_3(
+        returnValue: _FakeNip01Event_2(
           this,
           Invocation.method(
             #copyWith,

--- a/test/services/share_distribution_service_test.mocks.dart
+++ b/test/services/share_distribution_service_test.mocks.dart
@@ -1014,6 +1014,42 @@ class MockVaultRepository extends _i1.Mock implements _i7.VaultRepository {
       ) as _i4.Future<void>);
 
   @override
+  _i4.Future<void> deleteRecoveryResponseSharesForRequest({
+    required String? vaultId,
+    required String? requestId,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #deleteRecoveryResponseSharesForRequest,
+          [],
+          {
+            #vaultId: vaultId,
+            #requestId: requestId,
+          },
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+
+  @override
+  _i4.Future<void> deleteRecoveryResponsesForRequest({
+    required String? vaultId,
+    required String? requestId,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #deleteRecoveryResponsesForRequest,
+          [],
+          {
+            #vaultId: vaultId,
+            #requestId: requestId,
+          },
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+
+  @override
   _i4.Future<void> cleanupExpiredRecoverySessions() => (super.noSuchMethod(
         Invocation.method(
           #cleanupExpiredRecoverySessions,

--- a/test/services/vault_share_service_test.dart
+++ b/test/services/vault_share_service_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:mockito/annotations.dart';
 import 'package:ndk/ndk.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:drift/drift.dart' hide isNotNull, isNull;
 import 'dart:typed_data';
 
@@ -42,11 +41,6 @@ void main() {
     late VaultShareService service;
 
     setUp(() {
-      // Reset SharedPreferences' internal singleton so each test starts with
-      // an empty store (the method-channel mock alone is not enough - the
-      // plugin caches values in-process across getInstance() calls).
-      SharedPreferences.setMockInitialValues({});
-
       mockLoginService = MockLoginService();
       when(mockLoginService.encryptText(any))
           .thenAnswer((invocation) async => invocation.positionalArguments[0] as String);
@@ -253,7 +247,6 @@ void main() {
     late VaultShareService service;
 
     setUp(() {
-      SharedPreferences.setMockInitialValues({});
       db = newTestDatabase();
       mockLoginService = MockLoginService();
       when(mockLoginService.encryptText(any))
@@ -599,7 +592,6 @@ void main() {
     late VaultShareService service;
 
     setUp(() {
-      SharedPreferences.setMockInitialValues({});
       db = newTestDatabase();
       mockLoginService = MockLoginService();
       when(mockLoginService.encryptText(any))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Bead

horcrux_app-2em

## What

- Removed the `recovery_shard_data` SharedPreferences path from `VaultShareService` (recovery shard APIs and `clearAll`).
- `NdkService` no longer calls `addRecoveryShard`; persistence stays in `RecoveryService.processRecoveryResponse` → `VaultRepository.updateRecoveryRequestInVault` → `recovery_responses.share_payload`.
- Added `RecoveryDao.clearSharePayloadsForRequest` and `VaultRepository.deleteRecoveryResponseSharesForRequest` / `deleteRecoveryResponsesForRequest` so `cancelRecoveryRequest` clears payloads (audit rows kept) and `exitRecoveryMode` deletes response rows.
- Dropped `VaultShareService` from `RecoveryService` and removed the redundant `VaultShareService.clearAll` step from `LogoutService`.
- Tests: removed prefs mock scaffolding from `vault_share_service_test`, extended `recovery_service_test` with drift assertions and cancel/exit regressions; regenerated mocks.

## Why

`recovery_responses` was already the durable store for collected shards; the prefs cache duplicated writes and risked divergence. This unifies on drift per the bead plan.

## Testing

- `dart analyze` — no issues found.
- `flutter test --exclude-tags=golden` — all tests passed (Linux).
- Targeted: `flutter test test/services/recovery_service_test.dart test/services/logout_service_test.dart test/services/vault_share_service_test.dart`.

## Screenshots

N/A (no UI changes).

## Breaking changes

None for app consumers. `VaultShareService` no longer exposes recovery-shard or `clearAll` APIs; internal/logout wiring updated accordingly.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e88c7ac-6883-4875-b62c-18e1c5bc06e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e88c7ac-6883-4875-b62c-18e1c5bc06e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

