### PR TITLE
Block vault edit paths while a recovery is in progress

### DIFF
--- a/lib/widgets/vault_detail_button_stack.dart
+++ b/lib/widgets/vault_detail_button_stack.dart
@@ -71,6 +71,12 @@ class VaultDetailButtonStack extends ConsumerWidget {
                 // instead. The service would reject the call anyway.
                 final showInitiateRealRecovery = !hasMyInFlightRecovery;
 
+                // Any in-flight recovery on the vault (any initiator, practice or real)
+                // blocks owner edits that redistribute shards. Stewards must not be asked
+                // to release old shards while simultaneously receiving new ones.
+                // (bug horcrux_app-3u7).
+                final vaultHasActiveRecovery = vault.hasActiveRecovery;
+
                 // View Instructions Button (only show for stewards)
                 if (isSteward) {
                   final instructions = _getInstructions(vault);
@@ -95,6 +101,10 @@ class VaultDetailButtonStack extends ConsumerWidget {
                   buttons.add(
                     RowButtonConfig(
                       onPressed: () {
+                        if (vaultHasActiveRecovery) {
+                          _showRecoveryInProgressDialog(context);
+                          return;
+                        }
                         if (hasContent) {
                           // Edit existing content
                           Navigator.push(
@@ -127,21 +137,27 @@ class VaultDetailButtonStack extends ConsumerWidget {
                   );
 
                   // Recovery Plan Section - only allow if vault has content
+                  // and no recovery is in progress (an in-flight recovery would race
+                  // with key redistribution; horcrux_app-3u7).
                   buttons.add(
                     RowButtonConfig(
-                      onPressed: hasContent
-                          ? () {
-                              Navigator.push(
-                                context,
-                                MaterialPageRoute(
-                                  builder: (context) => BackupConfigScreen(vaultId: vaultId),
-                                ),
-                              );
-                            }
-                          : () {
-                              // Show dialog offering to create content first
-                              _showNoContentDialog(context, ref, vaultId);
-                            },
+                      onPressed: () {
+                        if (vaultHasActiveRecovery) {
+                          _showRecoveryInProgressDialog(context);
+                          return;
+                        }
+                        if (hasContent) {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) => BackupConfigScreen(vaultId: vaultId),
+                            ),
+                          );
+                        } else {
+                          // Show dialog offering to create content first
+                          _showNoContentDialog(context, ref, vaultId);
+                        }
+                      },
                       icon: Icons.settings,
                       text: 'Change Recovery Plan',
                     ),
@@ -456,6 +472,39 @@ class VaultDetailButtonStack extends ConsumerWidget {
         }
       }
     }
+  }
+
+  /// Show dialog when the owner taps an edit action while a recovery (practice
+  /// or real, any initiator) is in progress on the vault. Both "Change Vault
+  /// Contents" and "Change Recovery Plan" trigger key redistribution, which
+  /// races with the in-flight recovery -- stewards would be asked to release
+  /// old shards while simultaneously receiving new ones (horcrux_app-3u7).
+  Future<void> _showRecoveryInProgressDialog(BuildContext context) async {
+    await showDialog<void>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Recovery in progress'),
+        content: const Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'A recovery is currently in progress for this vault.',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            SizedBox(height: 12),
+            Text(
+              'You can\'t change the vault contents or the recovery plan until the recovery finishes or is cancelled, because doing so would distribute new keys to stewards while they\'re still processing the existing recovery request.',
+            ),
+            SizedBox(height: 12),
+            Text('Use "Manage Recovery" to finish or cancel the recovery first.'),
+          ],
+        ),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(context), child: const Text('OK')),
+        ],
+      ),
+    );
   }
 
   /// Show dialog when trying to change recovery plan without content

--- a/test/screens/vault_detail_screen_test.dart
+++ b/test/screens/vault_detail_screen_test.dart
@@ -422,4 +422,258 @@ void main() {
       },
     );
   });
+
+  // horcrux_app-3u7: while ANY recovery (practice or real, any initiator) is
+  // active on a vault, the owner must not be able to "Change Vault Contents"
+  // or "Change Recovery Plan" -- both trigger key redistribution, which races
+  // with the in-flight recovery (stewards getting new shards while old shards
+  // are being requested of them).
+  group('Owner edit actions blocked while recovery is in progress', () {
+    OwnedVaultDetail buildOwnerVaultWithActiveRecovery({required RecoveryRequest request}) {
+      return OwnedVaultDetail(
+        id: 'test-vault',
+        name: 'Test Vault',
+        ownerPubkey: testPubkey,
+        ownerName: null,
+        threshold: 2,
+        totalShares: 2,
+        stewards: const [],
+        recoveryRequests: [request],
+        pushEnabled: false,
+        createdAt: DateTime(2024, 1, 1),
+        archivedAt: null,
+        archivedReason: null,
+        backupConfig: createBackupConfig(
+          vaultId: 'test-vault',
+          threshold: 1,
+          totalKeys: 1,
+          stewards: [
+            createSteward(pubkey: otherPubkey, name: 'Alice'),
+          ],
+          relays: ['wss://relay.example.com'],
+        ).copyWith(distributionVersion: 1),
+        content: 'ciphertext',
+        selfHeldShare: null,
+      );
+    }
+
+    testWidgets(
+      'tapping Change Vault Contents during a real recovery shows the in-progress dialog',
+      (tester) async {
+        final request = RecoveryRequest(
+          id: 'real-request',
+          vaultId: 'test-vault',
+          initiatorPubkey: otherPubkey,
+          requestedAt: DateTime(2024, 1, 1, 10),
+          status: RecoveryRequestStatus.inProgress,
+          threshold: 1,
+        );
+        final vaultDetail = buildOwnerVaultWithActiveRecovery(request: request);
+
+        final container = ProviderContainer(
+          overrides: [
+            vaultDetailProvider('test-vault').overrideWith((ref) => Stream.value(vaultDetail)),
+            currentPublicKeyProvider.overrideWith((ref) async => testPubkey),
+            recoveryStatusProvider.overrideWith((ref, vaultId) {
+              return AsyncValue.data(
+                RecoveryStatus(
+                  hasActiveRecovery: true,
+                  canRecover: false,
+                  activeRecoveryRequest: request,
+                  isInitiator: false,
+                ),
+              );
+            }),
+          ],
+        );
+
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: const MaterialApp(home: VaultDetailScreen(vaultId: 'test-vault')),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Change Vault Contents'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Recovery in progress'), findsOneWidget);
+        expect(find.text('Edit Vault'), findsNothing);
+
+        container.dispose();
+      },
+    );
+
+    testWidgets(
+      'tapping Change Recovery Plan during a practice recovery shows the in-progress dialog',
+      (tester) async {
+        final request = RecoveryRequest(
+          id: 'practice-request',
+          vaultId: 'test-vault',
+          initiatorPubkey: otherPubkey,
+          requestedAt: DateTime(2024, 1, 1, 10),
+          status: RecoveryRequestStatus.inProgress,
+          threshold: 1,
+          isPractice: true,
+        );
+        final vaultDetail = buildOwnerVaultWithActiveRecovery(request: request);
+
+        final container = ProviderContainer(
+          overrides: [
+            vaultDetailProvider('test-vault').overrideWith((ref) => Stream.value(vaultDetail)),
+            currentPublicKeyProvider.overrideWith((ref) async => testPubkey),
+            recoveryStatusProvider.overrideWith((ref, vaultId) {
+              return AsyncValue.data(
+                RecoveryStatus(
+                  hasActiveRecovery: true,
+                  canRecover: false,
+                  activeRecoveryRequest: request,
+                  isInitiator: false,
+                ),
+              );
+            }),
+          ],
+        );
+
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: const MaterialApp(home: VaultDetailScreen(vaultId: 'test-vault')),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Change Recovery Plan'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Recovery in progress'), findsOneWidget);
+
+        container.dispose();
+      },
+    );
+
+    testWidgets(
+      'edits stay blocked even when the active recovery belongs to another initiator',
+      (tester) async {
+        final request = RecoveryRequest(
+          id: 'other-request',
+          vaultId: 'test-vault',
+          initiatorPubkey: otherPubkey,
+          requestedAt: DateTime(2024, 1, 1, 10),
+          status: RecoveryRequestStatus.inProgress,
+          threshold: 1,
+        );
+        final vaultDetail = buildOwnerVaultWithActiveRecovery(request: request);
+
+        final container = ProviderContainer(
+          overrides: [
+            vaultDetailProvider('test-vault').overrideWith((ref) => Stream.value(vaultDetail)),
+            currentPublicKeyProvider.overrideWith((ref) async => testPubkey),
+            recoveryStatusProvider.overrideWith((ref, vaultId) {
+              return AsyncValue.data(
+                RecoveryStatus(
+                  hasActiveRecovery: true,
+                  canRecover: false,
+                  activeRecoveryRequest: request,
+                  isInitiator: false,
+                ),
+              );
+            }),
+          ],
+        );
+
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: const MaterialApp(home: VaultDetailScreen(vaultId: 'test-vault')),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Change Recovery Plan'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Recovery in progress'), findsOneWidget);
+
+        container.dispose();
+      },
+    );
+
+    testWidgets(
+      'edits are allowed once the recovery has reached a terminal status',
+      (tester) async {
+        final cancelledRequest = RecoveryRequest(
+          id: 'cancelled-request',
+          vaultId: 'test-vault',
+          initiatorPubkey: otherPubkey,
+          requestedAt: DateTime(2024, 1, 1, 10),
+          status: RecoveryRequestStatus.cancelled,
+          threshold: 1,
+        );
+        final vaultDetail = OwnedVaultDetail(
+          id: 'test-vault',
+          name: 'Test Vault',
+          ownerPubkey: testPubkey,
+          ownerName: null,
+          threshold: 2,
+          totalShares: 2,
+          stewards: const [],
+          recoveryRequests: [cancelledRequest],
+          pushEnabled: false,
+          createdAt: DateTime(2024, 1, 1),
+          archivedAt: null,
+          archivedReason: null,
+          backupConfig: createBackupConfig(
+            vaultId: 'test-vault',
+            threshold: 1,
+            totalKeys: 1,
+            stewards: [
+              createSteward(pubkey: otherPubkey, name: 'Alice'),
+            ],
+            relays: ['wss://relay.example.com'],
+          ).copyWith(distributionVersion: 1),
+          content: 'ciphertext',
+          selfHeldShare: null,
+        );
+
+        final container = ProviderContainer(
+          overrides: [
+            vaultDetailProvider('test-vault').overrideWith((ref) => Stream.value(vaultDetail)),
+            currentPublicKeyProvider.overrideWith((ref) async => testPubkey),
+            recoveryStatusProvider.overrideWith((ref, vaultId) {
+              return const AsyncValue.data(
+                RecoveryStatus(
+                  hasActiveRecovery: false,
+                  canRecover: false,
+                  activeRecoveryRequest: null,
+                  isInitiator: false,
+                ),
+              );
+            }),
+          ],
+        );
+
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: const MaterialApp(home: VaultDetailScreen(vaultId: 'test-vault')),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Change Recovery Plan'));
+        // Use pump() rather than pumpAndSettle(): the destination screen
+        // (BackupConfigScreen) has its own ongoing async work (relay
+        // subscriptions etc.) that never quiesces in widget tests. We only
+        // care that the recovery-in-progress dialog does NOT appear.
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(find.text('Recovery in progress'), findsNothing);
+
+        container.dispose();
+      },
+    );
+  });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Bead

`horcrux_app-3u7`

## What

Block the owner's "Change Vault Contents" and "Change Recovery Plan" actions whenever any recovery (practice or real, any initiator) is in flight on the vault. When tapped while blocked, both buttons now surface a "Recovery in progress" dialog explaining the conflict and pointing the user at "Manage Recovery" to finish or cancel the existing recovery first. The buttons remain visible (and tappable again as soon as the recovery is no longer active) so users see the actions they have available.

## Why

Follow-up to the bug fixed in `horcrux_app-e0h` / #138. While playing with that fix, the owner could still trigger key redistribution mid-recovery via either edit path:

- "Change Vault Contents" → `EditVaultScreen` → save triggers redistribution.
- "Change Recovery Plan" → `BackupConfigScreen` → distribute triggers redistribution.

Both race against the in-flight recovery: stewards end up receiving fresh shards from the redistribution while their existing app state still has old-shard requests pending from the recovery. That puts the system into a confusing, hard-to-reason-about state.

`vault.hasActiveRecovery` already covers exactly the right window: any `RecoveryRequest` whose status is in `{pending, sent, inProgress}` (see `RecoveryRequestStatusExtension.isActive`). It does not filter by initiator or by `isPractice`, which matches the user's intent — practice recoveries put stewards through the same processing flow, so the same race exists. Once the recovery transitions to a terminal status (`completed`, `failed`, `cancelled`, `archived`) the gate releases.

The "Manage Recovery" button (added in #138) stays visible alongside the blocked buttons, giving users a one-tap path to cancel or finalize the recovery so they can edit again.

## Testing

- ✅ `flutter analyze` — No issues found (4 pre-existing Nip44 warnings only).
- ✅ `flutter test test/screens/vault_detail_screen_test.dart --exclude-tags=golden` — 10/10 (4 new tests added under `Owner edit actions blocked while recovery is in progress`):
  - `tapping Change Vault Contents during a real recovery shows the in-progress dialog`
  - `tapping Change Recovery Plan during a practice recovery shows the in-progress dialog`
  - `edits stay blocked even when the active recovery belongs to another initiator`
  - `edits are allowed once the recovery has reached a terminal status`
- ✅ `dart format` — Clean.

## Breaking changes

None.
<!-- CURSOR_AGENT_PR_BODY_END -->