### PR TITLE
fix: skip golden assertions on non-macOS in custom golden helpers

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -181,10 +181,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   charcode:
     dependency: transitive
     description:
@@ -768,18 +768,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   mcp_dart:
     dependency: transitive
     description:
@@ -792,10 +792,10 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1205,10 +1205,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.10"
   timezone:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -181,10 +181,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   charcode:
     dependency: transitive
     description:
@@ -768,18 +768,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   mcp_dart:
     dependency: transitive
     description:
@@ -792,10 +792,10 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
@@ -1205,10 +1205,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.6"
   timezone:
     dependency: transitive
     description:

--- a/test/helpers/golden_test_helpers.dart
+++ b/test/helpers/golden_test_helpers.dart
@@ -138,9 +138,11 @@ Future<void> screenMatchesGoldenWithoutSettle<T extends Widget>(
   await tester.pump();
 
   // Manually capture the golden without pumpAndSettle
+  // Respect the global skipGoldenAssertion (skips on non-macOS platforms)
   await expectLater(
     find.byType(T),
     matchesGoldenFile('goldens/$goldenName.png'),
+    skip: GoldenToolkit.configuration.skipGoldenAssertion(),
   );
 }
 
@@ -168,7 +170,12 @@ Future<void> screenMatchesGoldenWithoutSettleWithFinder(
   await tester.pump();
 
   // Manually capture the golden without pumpAndSettle
-  await expectLater(finder, matchesGoldenFile('goldens/$goldenName.png'));
+  // Respect the global skipGoldenAssertion (skips on non-macOS platforms)
+  await expectLater(
+    finder,
+    matchesGoldenFile('goldens/$goldenName.png'),
+    skip: GoldenToolkit.configuration.skipGoldenAssertion(),
+  );
 }
 
 /// Creates a MaterialApp wrapper with horcrux3Dark theme for golden tests.


### PR DESCRIPTION
## Summary

The custom `screenMatchesGoldenWithoutSettle` and `screenMatchesGoldenWithoutSettleWithFinder` helpers in `test/helpers/golden_test_helpers.dart` were calling `matchesGoldenFile` directly without respecting the `skipGoldenAssertion` policy configured in `flutter_test_config.dart` (which skips golden assertions on non-macOS platforms to avoid font-rendering mismatches).

This caused 6 golden tests to fail on Linux despite passing on macOS.

## Changes

- Added `skip: GoldenToolkit.configuration.skipGoldenAssertion()` to both helper functions' `expectLater` calls
- This makes them behave identically to golden_toolkit's built-in `screenMatchesGolden`

## Testing

- ✅ `flutter analyze`: clean (only 4 pre-existing Nip44 warnings)
- ✅ `flutter test --tags=golden`: all 168 golden tests skip on Linux (0 failures)
- ✅ `flutter test --exclude-tags=golden`: 441 non-golden tests pass

Fixes horcrux_app-16e