### PR TITLE
fix(login): clear cached DB error after logout by invalidating appDatabaseProvider

### DIFF
--- a/lib/utils/app_initialization.dart
+++ b/lib/utils/app_initialization.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../app_navigator.dart';
+import '../database/app_database_provider.dart';
 import '../providers/key_provider.dart';
 import '../services/deep_link_service.dart';
 import '../services/local_notification_service.dart';
@@ -70,6 +71,10 @@ Future<void> initializeAppServices(
 /// This is a convenience function that combines service initialization with
 /// provider invalidation, commonly used after account creation or login.
 ///
+/// Also invalidates [appDatabaseProvider] so a post-logout failed open (no key
+/// in secure storage while SQLCipher was touched) cannot leave a cached error
+/// on the provider after the user imports a key.
+///
 /// Parameters:
 /// - [ref] - WidgetRef to access providers
 Future<void> initializeAppAndRefreshKeys(WidgetRef ref) async {
@@ -79,4 +84,5 @@ Future<void> initializeAppAndRefreshKeys(WidgetRef ref) async {
   ref.invalidate(currentPublicKeyProvider);
   ref.invalidate(currentPublicKeyBech32Provider);
   ref.invalidate(isLoggedInProvider);
+  ref.invalidate(appDatabaseProvider);
 }

--- a/test/providers/app_database_provider_invalidation_test.dart
+++ b/test/providers/app_database_provider_invalidation_test.dart
@@ -98,5 +98,38 @@ void main() {
         expect(vaults, isEmpty);
       },
     );
+
+    test(
+      'invalidating appDatabaseProvider after key appears clears a cached '
+      'open failure (logout then login)',
+      () {
+        var keyPresent = false;
+
+        final container = ProviderContainer(
+          overrides: [
+            appDatabaseProvider.overrideWith((ref) {
+              if (!keyPresent) {
+                throw StateError(
+                  'Cannot open AppDatabase: no Nostr private key in secure '
+                  'storage. The user must complete login first.',
+                );
+              }
+              return trackDb(AppDatabase(NativeDatabase.memory()));
+            }),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        expect(() => container.read(appDatabaseProvider), throwsStateError);
+
+        keyPresent = true;
+        expect(() => container.read(appDatabaseProvider), throwsStateError);
+
+        container.invalidate(appDatabaseProvider);
+
+        final db = container.read(appDatabaseProvider);
+        expect(db, isA<AppDatabase>());
+      },
+    );
   });
 }


### PR DESCRIPTION
**Bead:** horcrux_app-4l5

**What:** After logout, something can touch `appDatabaseProvider` while the Nostr key is already cleared from secure storage, so SQLCipher key derivation fails and Riverpod keeps serving that failure across login. `initializeAppAndRefreshKeys` now invalidates `appDatabaseProvider` (same as logout) so the first read after importing an nsec builds a fresh `AppDatabase`.

**Why:** Matches the root cause in the 4l5 plan: login refreshed key providers but not the database provider.

**Testing:** `flutter test --exclude-tags=golden` (all passed). New unit test documents the logout→login invalidation contract.

**Scope:** Does not address wire-side `BackupConfig` reconstruction (horcrux_app-6sy / horcrux_app-8yw).

Made with [Cursor](https://cursor.com)