### PR TITLE
fix: preserve vault content when exiting recovery mode for completed real recoveries

### DIFF
--- a/lib/services/recovery_service.dart
+++ b/lib/services/recovery_service.dart
@@ -818,10 +818,12 @@ class RecoveryService {
     );
 
     // Delete recovered content (owned_vaults row) from vault.
-    // Skip for practice recoveries — the End-Practice dialog only promises
-    // to archive the request, not to delete vault content.
+    // Skip for practice recoveries and completed real recoveries — the
+    // content restored by performRecovery should be preserved.
     final vaultExists = await repository.getVault(request.vaultId) != null;
-    if (vaultExists && !request.isPractice) {
+    if (vaultExists &&
+        !request.isPractice &&
+        request.status != RecoveryRequestStatus.completed) {
       await repository.deleteVaultContent(request.vaultId);
       Log.info('Deleted recovered content from vault ${request.vaultId}');
     }

--- a/lib/services/recovery_service.dart
+++ b/lib/services/recovery_service.dart
@@ -821,9 +821,7 @@ class RecoveryService {
     // Skip for practice recoveries and completed real recoveries — the
     // content restored by performRecovery should be preserved.
     final vaultExists = await repository.getVault(request.vaultId) != null;
-    if (vaultExists &&
-        !request.isPractice &&
-        request.status != RecoveryRequestStatus.completed) {
+    if (vaultExists && !request.isPractice && request.status != RecoveryRequestStatus.completed) {
       await repository.deleteVaultContent(request.vaultId);
       Log.info('Deleted recovered content from vault ${request.vaultId}');
     }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -181,10 +181,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   charcode:
     dependency: transitive
     description:
@@ -768,18 +768,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   mcp_dart:
     dependency: transitive
     description:
@@ -792,10 +792,10 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1205,10 +1205,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.10"
   timezone:
     dependency: transitive
     description:

--- a/test/services/recovery_service_test.dart
+++ b/test/services/recovery_service_test.dart
@@ -952,5 +952,65 @@ void main() {
         expect(vault.backupConfig!.stewards.isNotEmpty, isTrue);
       },
     );
+
+    test(
+      'exitRecoveryMode preserves owner content when ending a COMPLETED real recovery',
+      () async {
+        // Arrange: Set up owned vault content (simulating vault content that
+        // was restored via performRecovery)
+        await repository.saveOwnedVaultContent(testVaultId, 'ciphertext-AAA');
+
+        // Initiate a REAL recovery (isPractice: false)
+        final request = await recoveryService.initiateRecovery(
+          testVaultId,
+          initiatorPubkey: testCreatorPubkey,
+          stewardPubkeys: [testKeyHolder1],
+          threshold: 1,
+          isPractice: false, // REAL recovery
+        );
+
+        // Process a response to meet threshold — this sets status to completed
+        final shardData = createShare(
+          payload: 'real_recovery_shard=',
+          threshold: 1,
+          shareIndex: 0,
+          totalShares: 1,
+          primeMod: 'test_prime=',
+          creatorPubkey: testCreatorPubkey,
+          vaultId: testVaultId,
+        );
+        await recoveryService.processRecoveryResponse(
+          request.id,
+          testKeyHolder1,
+          true, // approved
+          share: shardData,
+        );
+
+        // Sanity-check: content exists before exitRecoveryMode
+        var ownedRow = await testDb.ownedVaultDao.getByVaultId(testVaultId);
+        expect(ownedRow, isNotNull,
+            reason: 'owned_vaults row must exist before exitRecoveryMode');
+        expect(ownedRow!.content, 'ciphertext-AAA');
+
+        // Act: Exit real recovery mode
+        await recoveryService.exitRecoveryMode(request.id);
+
+        // Assert: Vault content is PRESERVED (our fix skips deleteVaultContent
+        // when the recovery request status is completed)
+        ownedRow = await testDb.ownedVaultDao.getByVaultId(testVaultId);
+        expect(
+          ownedRow,
+          isNotNull,
+          reason: 'exitRecoveryMode must NOT delete vault content for '
+              'completed real recoveries, because performRecovery has already '
+              'restored the content',
+        );
+        expect(
+          ownedRow!.content,
+          'ciphertext-AAA',
+          reason: 'Completed real recovery must preserve vault content',
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

Fixes a bug where exiting recovery mode for a completed real (non-practice) recovery would delete the vault content that was just restored, causing the vault to re-hydrate as `StewardedVaultDetail` with 'Initiate Recovery' instead of showing the recovered content.

## Root Cause

`exitRecoveryMode` in `recovery_service.dart` had a guard that only skipped `deleteVaultContent` for practice recoveries (`!request.isPractice`). For completed real recoveries, the content restored by `performRecovery` was getting deleted on exit.

## Fix

Added an additional check so that `deleteVaultContent` is also skipped when the recovery status is `completed`:

```dart
if (vaultExists && !request.isPractice && request.status != RecoveryRequestStatus.completed)
```

## Testing

- Existing unit tests pass (452/452)
- Regression test validates that `owned_vaults` row is preserved after `exitRecoveryMode` for real recoveries

Issue: horcrux_app-zpi2