### PR TITLE
Ignore your own recovery requests from before you logged in

### DIFF
--- a/lib/providers/vault_provider.dart
+++ b/lib/providers/vault_provider.dart
@@ -18,6 +18,7 @@ import '../models/vault.dart';
 import '../models/vault_detail.dart';
 import '../services/login_service.dart';
 import '../services/logger.dart';
+import '../services/notification_recency.dart';
 import 'key_provider.dart';
 import 'vault_detail_repository.dart';
 
@@ -95,10 +96,6 @@ final vaultDetailListProvider = StreamProvider.autoDispose<List<VaultDetail>>((r
 ///   the same triple back atomically.
 class VaultRepository {
   final AppDatabase _db;
-  // Held for parity with the legacy API; encryption is handled by SQLCipher
-  // at the DB layer rather than by per-row NIP-44 (except for
-  // `owned_vaults.content`, which `BackupService` already encrypts).
-  // ignore: unused_field
   final LoginService _loginService;
 
   final StreamController<List<Vault>> _vaultsController = StreamController<List<Vault>>.broadcast();
@@ -361,17 +358,19 @@ class VaultRepository {
             ))
           .go();
 
-      await _db.heldShareDao.insertIfNew(HeldSharesCompanion.insert(
-        id: id,
-        vaultId: vaultId,
-        shareIndex: share.shareIndex,
-        sharePayload: share.payload,
-        distributionVersion: dist,
-        receivedAt: now,
-        nostrEventId: Value(share.nostrEventId),
-        lastSeenRelay: Value(share.relayUrls?.isNotEmpty == true ? share.relayUrls!.first : null),
-        pushEnabled: Value(share.pushEnabled ?? true),
-      ));
+      await _db.heldShareDao.insertIfNew(
+        HeldSharesCompanion.insert(
+          id: id,
+          vaultId: vaultId,
+          shareIndex: share.shareIndex,
+          sharePayload: share.payload,
+          distributionVersion: dist,
+          receivedAt: now,
+          nostrEventId: Value(share.nostrEventId),
+          lastSeenRelay: Value(share.relayUrls?.isNotEmpty == true ? share.relayUrls!.first : null),
+          pushEnabled: Value(share.pushEnabled ?? true),
+        ),
+      );
       await _db.heldShareDao.pruneOldVersions(vaultId);
       // Write primeMod to the vault row when provided so that
       // _shareFromHeldShareRow can hydrate valid Share objects. For owned
@@ -379,10 +378,7 @@ class VaultRepository {
       // carry it); persisting it here fills that gap. For steward vaults
       // mergeVaultRowFromIncomingShare already set it, so this is idempotent.
       final vaultsUpdate = share.primeMod.isNotEmpty
-          ? VaultsCompanion(
-              primeMod: Value(share.primeMod),
-              lastSyncedAt: Value(now),
-            )
+          ? VaultsCompanion(primeMod: Value(share.primeMod), lastSyncedAt: Value(now))
           : VaultsCompanion(lastSyncedAt: Value(now));
       await (_db.update(_db.vaults)..where((v) => v.id.equals(vaultId))).write(vaultsUpdate);
     });
@@ -454,7 +450,9 @@ class VaultRepository {
             ))
           .get();
       for (final row in incumbents) {
-        await (_db.update(_db.stewards)..where((s) => s.id.equals(row.id)))
+        await (_db.update(
+          _db.stewards,
+        )..where((s) => s.id.equals(row.id)))
             .write(StewardsCompanion(leftAt: Value(now)));
       }
 
@@ -573,9 +571,10 @@ class VaultRepository {
               createdBySelfAt: createdAtMs,
             ),
           );
-      await (_db.update(_db.vaults)..where((v) => v.id.equals(vaultId))).write(
-        VaultsCompanion(lastSyncedAt: Value(now)),
-      );
+      await (_db.update(
+        _db.vaults,
+      )..where((v) => v.id.equals(vaultId)))
+          .write(VaultsCompanion(lastSyncedAt: Value(now)));
     });
     Log.info('saveOwnedVaultContent: wrote content for vault $vaultId');
   }
@@ -593,9 +592,10 @@ class VaultRepository {
     final now = DateTime.now().millisecondsSinceEpoch;
     await _db.transaction(() async {
       await (_db.delete(_db.ownedVaults)..where((v) => v.vaultId.equals(vaultId))).go();
-      await (_db.update(_db.vaults)..where((v) => v.id.equals(vaultId))).write(
-        VaultsCompanion(lastSyncedAt: Value(now)),
-      );
+      await (_db.update(
+        _db.vaults,
+      )..where((v) => v.id.equals(vaultId)))
+          .write(VaultsCompanion(lastSyncedAt: Value(now)));
     });
     Log.info('deleteVaultContent: removed owned_vaults row for vault $vaultId');
   }
@@ -608,10 +608,23 @@ class VaultRepository {
 
   // ========== Recovery Request Management (Phase 3) ==========
 
-  Future<void> addRecoveryRequestToVault(
-    String vaultId,
-    RecoveryRequest request,
-  ) async {
+  Future<void> addRecoveryRequestToVault(String vaultId, RecoveryRequest request) async {
+    final eventTime = request.eventCreationTime;
+    if (eventTime != null) {
+      final currentPubkey = await _loginService.getCurrentPublicKey();
+      if (currentPubkey != null && request.initiatorPubkey == currentPubkey) {
+        final firstOpen = await getFirstAppOpenUtc(database: _db);
+        if (eventTime.isBefore(firstOpen)) {
+          Log.info(
+            'addRecoveryRequestToVault: ignored stale self-initiated request '
+            '${request.id} for vault $vaultId '
+            '(eventCreationTime=$eventTime < firstOpen=$firstOpen)',
+          );
+          return;
+        }
+      }
+    }
+
     final vaultRow = await _db.vaultDao.getById(vaultId);
     if (vaultRow == null) {
       throw ArgumentError('Vault not found: $vaultId');
@@ -639,10 +652,7 @@ class VaultRepository {
         for (final pubkey in request.stewardPubkeys) {
           b.insert(
             _db.recoveryRequestParticipants,
-            RecoveryRequestParticipantsCompanion.insert(
-              requestId: request.id,
-              pubkey: pubkey,
-            ),
+            RecoveryRequestParticipantsCompanion.insert(requestId: request.id, pubkey: pubkey),
             mode: InsertMode.insertOrIgnore,
           );
         }
@@ -748,9 +758,7 @@ class VaultRepository {
     }
   }
 
-  Future<List<RecoveryRequest>> getRecoveryRequestsForVault(
-    String vaultId,
-  ) async {
+  Future<List<RecoveryRequest>> getRecoveryRequestsForVault(String vaultId) async {
     final vault = await getVault(vaultId);
     if (vault == null) {
       throw ArgumentError('Vault not found: $vaultId');
@@ -793,9 +801,7 @@ class VaultRepository {
     );
     // Prefer invite code from the invitations table when present; otherwise keep the overlay
     // value (e.g. stewards not yet written through InvitationService).
-    return cached.copyWith(
-      inviteCode: dbSteward.inviteCode ?? cached.inviteCode,
-    );
+    return cached.copyWith(inviteCode: dbSteward.inviteCode ?? cached.inviteCode);
   }
 
   Future<Vault> _hydrate(VaultRow row) async {
@@ -822,9 +828,7 @@ class VaultRepository {
       final overlay = _backupConfigOverlay[row.id];
       final stewards = overlay == null
           ? dbStewards
-          : [
-              for (final s in dbStewards) _mergeDbStewardWithBackupOverlay(s, overlay),
-            ];
+          : [for (final s in dbStewards) _mergeDbStewardWithBackupOverlay(s, overlay)];
       backupConfig = BackupConfig(
         vaultId: row.id,
         threshold: row.threshold,
@@ -945,7 +949,9 @@ class VaultRepository {
     }
 
     final distributionId = _distributionId(vaultId, distributionVersion);
-    final byId = await (_db.select(_db.distributions)..where((d) => d.id.equals(distributionId)))
+    final byId = await (_db.select(
+      _db.distributions,
+    )..where((d) => d.id.equals(distributionId)))
         .getSingleOrNull();
     final distribution = byId ??
         await (_db.select(_db.distributions)
@@ -985,7 +991,9 @@ class VaultRepository {
           ),
         );
 
-    final existing = await (_db.select(_db.distributionShares)..where((s) => s.id.equals(shareId)))
+    final existing = await (_db.select(
+      _db.distributionShares,
+    )..where((s) => s.id.equals(shareId)))
         .getSingleOrNull();
     final persistedGiftWrapEventId = giftWrapEventId ??
         existing?.giftWrapEventId ??
@@ -1026,9 +1034,10 @@ class VaultRepository {
 
   Future<void> _bumpVaultSync(String vaultId) async {
     final now = DateTime.now().millisecondsSinceEpoch;
-    await (_db.update(_db.vaults)..where((v) => v.id.equals(vaultId))).write(
-      VaultsCompanion(lastSyncedAt: Value(now)),
-    );
+    await (_db.update(
+      _db.vaults,
+    )..where((v) => v.id.equals(vaultId)))
+        .write(VaultsCompanion(lastSyncedAt: Value(now)));
   }
 
   Future<void> _persistVault(Vault vault) async {
@@ -1050,9 +1059,7 @@ class VaultRepository {
               ownerName: Value(vault.ownerName),
               threshold: config?.threshold ?? 0,
               totalShares: config?.totalKeys ?? 0,
-              currentDistributionVersion: Value(
-                config?.distributionVersion ?? 0,
-              ),
+              currentDistributionVersion: Value(config?.distributionVersion ?? 0),
               instructions: Value(config?.instructions),
               pushEnabled: Value(vault.pushEnabled),
               archivedAt: Value(archivedAtMs),
@@ -1074,17 +1081,16 @@ class VaultRepository {
           _db.stewards,
         )..where((s) => s.vaultId.equals(vault.id) & s.leftAt.isNull()))
             .get();
-        final shareIndexByStewardId = {
-          for (final row in existing) row.id: row.shareIndex,
-        };
+        final shareIndexByStewardId = {for (final row in existing) row.id: row.shareIndex};
         final incomingStewardIds = config.stewards.map((s) => s.id).toSet();
         // Preserve historical Shamir slots for stable ingest-side writes when the
         // steward set is unchanged (ack/metadata-only paths). When the backed-up
         // roster introduces any steward id the DB has never seen, treat backup
         // config ordering as authoritative and assign contiguous indices again so
         // owners can insert rows ahead of existing stewards.
-        final hasNewStewardId =
-            incomingStewardIds.any((id) => !shareIndexByStewardId.containsKey(id));
+        final hasNewStewardId = incomingStewardIds.any(
+          (id) => !shareIndexByStewardId.containsKey(id),
+        );
 
         for (final existingRow in existing) {
           // Retire rows removed from the config permanently, and rows that ARE
@@ -1101,10 +1107,9 @@ class VaultRepository {
           }
           final conflictsOnPosition = willReinsert && targetShareIndex != existingRow.shareIndex;
           if (!willReinsert || conflictsOnPosition) {
-            await (_db.update(
-              _db.stewards,
-            )..where((s) => s.id.equals(existingRow.id)))
-                .write(StewardsCompanion(leftAt: Value(nowMs)));
+            await (_db.update(_db.stewards)..where((s) => s.id.equals(existingRow.id))).write(
+              StewardsCompanion(leftAt: Value(nowMs)),
+            );
           }
         }
 
@@ -1153,20 +1158,11 @@ class VaultRepository {
             .get();
         final nowMs = DateTime.now().millisecondsSinceEpoch;
         for (final existingRow in existing) {
-          await (_db.update(
-            _db.stewards,
-          )..where((s) => s.id.equals(existingRow.id)))
-              .write(
-            StewardsCompanion(
-              leftAt: Value(nowMs),
-            ),
+          await (_db.update(_db.stewards)..where((s) => s.id.equals(existingRow.id))).write(
+            StewardsCompanion(leftAt: Value(nowMs)),
           );
         }
-        await _db.vaultRelayDao.replaceForVault(
-          vaultId: vault.id,
-          role: 'owner',
-          rows: [],
-        );
+        await _db.vaultRelayDao.replaceForVault(vaultId: vault.id, role: 'owner', rows: []);
       }
     });
   }

--- a/test/providers/vault_repository_recovery_test.dart
+++ b/test/providers/vault_repository_recovery_test.dart
@@ -8,11 +8,21 @@ import 'package:horcrux/models/recovery_request.dart';
 import 'package:horcrux/models/share.dart';
 import 'package:horcrux/providers/vault_provider.dart';
 import 'package:horcrux/services/login_service.dart';
+import 'package:horcrux/services/notification_recency.dart';
 
 import '../fixtures/test_keys.dart';
 import '../helpers/test_database.dart';
 
 class _MockLoginService extends Mock implements LoginService {}
+
+/// [LoginService] that only implements [getCurrentPublicKey]; other methods use [Mock]'s noSuchMethod.
+class _LoginServiceWithPubkey extends Mock implements LoginService {
+  _LoginServiceWithPubkey(this._pubkey);
+  final String? _pubkey;
+
+  @override
+  Future<String?> getCurrentPublicKey() async => _pubkey;
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -203,6 +213,147 @@ void main() {
       final responses = await db.recoveryDao.responsesFor(fixture.requestId);
       expect(responses, hasLength(1));
       expect(responses.single.sharePayload, contains('still-there'));
+    });
+  });
+
+  group('addRecoveryRequestToVault recency gate', () {
+    late AppDatabase db;
+    late VaultRepository repository;
+
+    tearDown(() async {
+      repository.dispose();
+      await db.close();
+    });
+
+    test('drops self-initiated request when eventCreationTime predates first app open', () async {
+      db = newTestDatabase();
+      repository = VaultRepository(_LoginServiceWithPubkey(TestHexPubkeys.alice), db: db);
+      final vault = await VaultFixture.stewarded(
+        db,
+        ownerPubkey: TestHexPubkeys.alice,
+        threshold: 2,
+        totalShares: 3,
+      );
+      final firstOpen = DateTime.utc(2024, 6, 1, 12, 0, 0);
+      await db.appStateDao.setInt(
+        key: firstAppOpenUtcKey,
+        value: firstOpen.millisecondsSinceEpoch,
+      );
+
+      final request = RecoveryRequest.makeFromParticipants(
+        id: 'req-stale-self',
+        vaultId: vault.vaultId,
+        initiatorPubkey: TestHexPubkeys.alice,
+        requestedAt: DateTime.utc(2024, 5, 15, 12, 0, 0),
+        eventCreationTime: DateTime.utc(2024, 5, 10, 12, 0, 0),
+        status: RecoveryRequestStatus.inProgress,
+        threshold: 2,
+        stewardPubkeys: const [TestHexPubkeys.bob, TestHexPubkeys.charlie],
+      );
+
+      await repository.addRecoveryRequestToVault(vault.vaultId, request);
+
+      expect(await db.recoveryDao.getById(request.id), isNull);
+    });
+
+    test('persists self-initiated request when eventCreationTime is after first app open',
+        () async {
+      db = newTestDatabase();
+      repository = VaultRepository(_LoginServiceWithPubkey(TestHexPubkeys.alice), db: db);
+      final vault = await VaultFixture.stewarded(
+        db,
+        ownerPubkey: TestHexPubkeys.alice,
+        threshold: 2,
+        totalShares: 3,
+      );
+      final firstOpen = DateTime.utc(2024, 6, 1, 12, 0, 0);
+      await db.appStateDao.setInt(
+        key: firstAppOpenUtcKey,
+        value: firstOpen.millisecondsSinceEpoch,
+      );
+
+      final request = RecoveryRequest.makeFromParticipants(
+        id: 'req-recent-self',
+        vaultId: vault.vaultId,
+        initiatorPubkey: TestHexPubkeys.alice,
+        requestedAt: DateTime.utc(2024, 6, 15, 12, 0, 0),
+        eventCreationTime: DateTime.utc(2024, 6, 15, 12, 0, 0),
+        status: RecoveryRequestStatus.inProgress,
+        threshold: 2,
+        stewardPubkeys: const [TestHexPubkeys.bob, TestHexPubkeys.charlie],
+      );
+
+      await repository.addRecoveryRequestToVault(vault.vaultId, request);
+
+      final row = await db.recoveryDao.getById(request.id);
+      expect(row, isNotNull);
+      expect(row!.initiatorPubkey, TestHexPubkeys.alice);
+    });
+
+    test('persists self-initiated request when eventCreationTime is null (local create path)',
+        () async {
+      db = newTestDatabase();
+      repository = VaultRepository(_LoginServiceWithPubkey(TestHexPubkeys.alice), db: db);
+      final vault = await VaultFixture.stewarded(
+        db,
+        ownerPubkey: TestHexPubkeys.alice,
+        threshold: 2,
+        totalShares: 3,
+      );
+      final firstOpen = DateTime.utc(2024, 6, 1, 12, 0, 0);
+      await db.appStateDao.setInt(
+        key: firstAppOpenUtcKey,
+        value: firstOpen.millisecondsSinceEpoch,
+      );
+
+      final request = RecoveryRequest.makeFromParticipants(
+        id: 'req-local-self',
+        vaultId: vault.vaultId,
+        initiatorPubkey: TestHexPubkeys.alice,
+        requestedAt: DateTime.utc(2024, 1, 1, 12, 0, 0),
+        status: RecoveryRequestStatus.pending,
+        threshold: 2,
+        stewardPubkeys: const [TestHexPubkeys.bob, TestHexPubkeys.charlie],
+      );
+
+      await repository.addRecoveryRequestToVault(vault.vaultId, request);
+
+      final row = await db.recoveryDao.getById(request.id);
+      expect(row, isNotNull);
+      expect(row!.status, RecoveryRequestStatus.pending.name);
+    });
+
+    test('persists other-initiator request even when event predates first app open', () async {
+      db = newTestDatabase();
+      repository = VaultRepository(_LoginServiceWithPubkey(TestHexPubkeys.alice), db: db);
+      final vault = await VaultFixture.stewarded(
+        db,
+        ownerPubkey: TestHexPubkeys.alice,
+        threshold: 2,
+        totalShares: 3,
+      );
+      final firstOpen = DateTime.utc(2024, 6, 1, 12, 0, 0);
+      await db.appStateDao.setInt(
+        key: firstAppOpenUtcKey,
+        value: firstOpen.millisecondsSinceEpoch,
+      );
+
+      final request = RecoveryRequest.makeFromParticipants(
+        id: 'req-other-stale',
+        vaultId: vault.vaultId,
+        initiatorPubkey: TestHexPubkeys.bob,
+        requestedAt: DateTime.utc(2024, 5, 15, 12, 0, 0),
+        eventCreationTime: DateTime.utc(2024, 5, 10, 12, 0, 0),
+        status: RecoveryRequestStatus.inProgress,
+        threshold: 2,
+        stewardPubkeys: const [TestHexPubkeys.alice, TestHexPubkeys.charlie],
+      );
+
+      await repository.addRecoveryRequestToVault(vault.vaultId, request);
+
+      final row = await db.recoveryDao.getById(request.id);
+      expect(row, isNotNull);
+      expect(row!.initiatorPubkey, TestHexPubkeys.bob);
     });
   });
 }


### PR DESCRIPTION
## Bead

horcrux_app-tdnc

## What

- In `VaultRepository.addRecoveryRequestToVault`, skip persisting relay-delivered recovery requests when `eventCreationTime` is set, the initiator is the logged-in user, and that time is strictly before `getFirstAppOpenUtc`.
- Local initiations keep `eventCreationTime` unset and are unchanged.
- Adds unit coverage in `test/providers/vault_repository_recovery_test.dart` (`_LoginServiceWithPubkey` stub).

## Why

Supersedes the approach in #179 (startup + own-1337 archive sweep). Filtering at ingest avoids clearing legitimate in-flight sessions and matches the same first-open / relay-backfill idea used by notification policy.

## Testing

- `fvm flutter analyze`
- `fvm flutter test --exclude-tags=golden`

## Breaking changes

None.

---

Closes/replaces review direction for #179; close that PR once this merges.

Made with [Cursor](https://cursor.com)