### PR TITLE
fix: unblock callers when publish outbox retries dead relays

### DIFF
--- a/lib/services/ndk_service.dart
+++ b/lib/services/ndk_service.dart
@@ -898,10 +898,12 @@ class NdkService {
   /// Creates a rumor event with the given content and kind, wraps it in a
   /// gift wrap for the recipient, and broadcasts it to the specified relays.
   ///
-  /// Returns the signed gift wrap event on success, or `null` when every
-  /// relay rejected it. Callers that only care about the event ID can read
-  /// `.id` off the result; callers that need to forward the wrap elsewhere
-  /// (e.g. to `horcrux-notifier` for push) can pass the whole event.
+  /// Returns the signed gift wrap once the event is enqueued for relay delivery
+  /// (persistence in the outbox), or `null` only when enqueue fails. Relay
+  /// broadcast outcomes are retried asynchronously and do not block this
+  /// call. Callers that only care about the event ID can read `.id` off the
+  /// result; callers that need to forward the wrap elsewhere (e.g. to
+  /// `horcrux-notifier` for push) can pass the whole event.
   Future<Nip01Event?> publishEncryptedEvent({
     required String content,
     required int kind,
@@ -923,9 +925,6 @@ class NdkService {
     }
 
     try {
-      final pubkeySnippet =
-          recipientPubkey.length > 8 ? recipientPubkey.substring(0, 8) : recipientPubkey;
-
       final giftWrap = await _buildGiftWrapEvent(
         content: content,
         kind: kind,
@@ -941,21 +940,9 @@ class NdkService {
         vaultId: vaultId,
       );
 
-      if (result.successfulRelays.isEmpty) {
-        Log.error(
-          'Failed to publish encrypted event (kind $kind) to $pubkeySnippet after retries',
-        );
-        return null;
-      }
-
-      if (result.failedRelays.isNotEmpty) {
-        Log.warning(
-          'Encrypted event published with partial success (event ${result.eventId}): '
-          'successful relays=${result.successfulRelays.length}, failed=${result.failedRelays.length}',
-        );
-      } else {
-        Log.info('Encrypted event published to all relays: ${result.eventId}');
-      }
+      Log.info(
+        'Encrypted event (kind $kind) enqueued for ${relays.length} relay(s): ${result.eventId}',
+      );
 
       return giftWrap;
     } catch (e, stackTrace) {

--- a/lib/services/publish_service.dart
+++ b/lib/services/publish_service.dart
@@ -27,10 +27,8 @@ class PublishQueueResult {
 /// Persists publish work in the `outbox` / `outbox_relays` tables and drains it
 /// with periodic retries (replacing the legacy SharedPreferences queue).
 class PublishService {
-  PublishService({
-    required NdkSupplier getNdk,
-    required AppDatabase database,
-  })  : _getNdk = getNdk,
+  PublishService({required NdkSupplier getNdk, required AppDatabase database})
+      : _getNdk = getNdk,
         _db = database;
 
   static const _maxAttemptsPerRelay = 15;
@@ -40,7 +38,6 @@ class PublishService {
   final NdkSupplier _getNdk;
   final AppDatabase _db;
 
-  final Map<String, Completer<PublishQueueResult>> _completers = {};
   Timer? _workerTimer;
   bool _isProcessing = false;
   bool _isInitialized = false;
@@ -63,6 +60,11 @@ class PublishService {
     Log.info('PublishService initialized ($c pending outbox relay row(s))');
   }
 
+  /// Persists the event + per-relay outbox rows and returns a [PublishQueueResult]
+  /// as soon as the database transaction commits — not after relays respond.
+  ///
+  /// Background relay delivery continues in [_processQueue] and retries up to
+  /// [_maxAttemptsPerRelay] times, but those outcomes do not block the caller.
   Future<PublishQueueResult> enqueueEvent({
     required Nip01Event event,
     required List<String> relays,
@@ -77,21 +79,18 @@ class PublishService {
     final dedupedRelays = relays.toSet().toList();
     final id = event.id;
 
-    final existingCompleter = _completers[id];
-    if (existingCompleter != null) {
-      return existingCompleter.future;
-    }
-
     final existingRow = await _db.outboxDao.getById(id);
     if (existingRow != null) {
-      final c = Completer<PublishQueueResult>();
-      _completers[id] = c;
+      Log.info(
+        'enqueueEvent: $id already queued for ${dedupedRelays.length} relay(s)',
+      );
       _scheduleImmediateWork();
-      return c.future;
+      return PublishQueueResult(
+        eventId: id,
+        successfulRelays: const [],
+        failedRelays: const [],
+      );
     }
-
-    final completer = Completer<PublishQueueResult>();
-    _completers[id] = completer;
 
     try {
       final now = DateTime.now().millisecondsSinceEpoch;
@@ -120,22 +119,25 @@ class PublishService {
         }
       });
     } catch (e, st) {
-      _completers.remove(id);
-      if (!completer.isCompleted) {
-        completer.completeError(e, st);
-      }
       Log.error('enqueueEvent: failed to persist outbox for $id', e, st);
       rethrow;
     }
 
+    Log.info('enqueueEvent: $id enqueued for ${dedupedRelays.length} relay(s)');
     _scheduleImmediateWork();
-    return completer.future;
+    return PublishQueueResult(
+      eventId: id,
+      successfulRelays: const [],
+      failedRelays: const [],
+    );
   }
 
   Future<void> onRelayReconnected(String relayUrl) async {
     final now = DateTime.now().millisecondsSinceEpoch;
     await (_db.update(_db.outboxRelays)
-          ..where((r) => r.relayUrl.equals(relayUrl) & r.status.equals('pending')))
+          ..where(
+            (r) => r.relayUrl.equals(relayUrl) & r.status.equals('pending'),
+          ))
         .write(OutboxRelaysCompanion(nextAttemptAt: Value(now)));
     _scheduleImmediateWork();
   }
@@ -203,7 +205,10 @@ class PublishService {
     }
   }
 
-  Future<void> _processOneRelay(OutboxRelayRow relayRow, {required int nowMs}) async {
+  Future<void> _processOneRelay(
+    OutboxRelayRow relayRow, {
+    required int nowMs,
+  }) async {
     final out = await _db.outboxDao.getById(relayRow.outboxId);
     if (out == null) {
       return;
@@ -211,7 +216,9 @@ class PublishService {
 
     Nip01Event event;
     try {
-      event = Nip01Event.fromJson(json.decode(out.eventJson) as Map<String, dynamic>);
+      event = Nip01Event.fromJson(
+        json.decode(out.eventJson) as Map<String, dynamic>,
+      );
     } catch (e, st) {
       Log.error('Outbox ${out.id}: invalid event_json', e, st);
       await _markRelayFailed(
@@ -280,6 +287,10 @@ class PublishService {
     );
   }
 
+  /// Cleans up the outbox row once every relay attempt has settled.
+  ///
+  /// The caller future has already resolved when the DB rows were first
+  /// committed, so this only handles storage cleanup.
   Future<void> _finalizeOutboxIfComplete(String outboxId) async {
     final relays = await _db.outboxDao.relaysFor(outboxId);
     if (relays.isEmpty) {
@@ -293,25 +304,11 @@ class PublishService {
       return;
     }
 
-    final out = await _db.outboxDao.getById(outboxId);
-    if (out == null) {
-      return;
-    }
-
-    final successfulRelays =
-        relays.where((r) => r.status == 'success').map((r) => r.relayUrl).toList();
-    final failedRelays = relays.where((r) => r.status == 'failed').map((r) => r.relayUrl).toList();
-
-    final result = PublishQueueResult(
-      eventId: out.eventId,
-      successfulRelays: successfulRelays,
-      failedRelays: failedRelays,
+    final successCount = relays.where((r) => r.status == 'success').length;
+    final failedCount = relays.where((r) => r.status != 'success').length;
+    Log.info(
+      'Outbox $outboxId finalized: $successCount succeeded, $failedCount failed/exhausted',
     );
-
-    final completer = _completers.remove(outboxId);
-    if (completer != null && !completer.isCompleted) {
-      completer.complete(result);
-    }
 
     await _db.outboxDao.deleteOutboxCascade(outboxId);
   }
@@ -345,30 +342,10 @@ class PublishService {
         message: relayResult.msg,
       );
     } catch (e) {
-      final message = e.toString();
-      if (message.contains('Bad state: No element')) {
-        try {
-          final ndk = await _getNdk();
-          final response = ndk.broadcast.broadcast(nostrEvent: event);
-          final results = await response.broadcastDoneFuture;
-          final success = results.any((result) => result.broadcastSuccessful);
-          final fallbackMessage = results.isNotEmpty ? results.first.msg : '';
-          return _RelayAttemptOutcome(
-            success: success,
-            message: success ? '' : (fallbackMessage.isNotEmpty ? fallbackMessage : message),
-          );
-        } catch (fallbackError) {
-          return _RelayAttemptOutcome(
-            success: false,
-            message: fallbackError.toString(),
-          );
-        }
-      }
-
-      return _RelayAttemptOutcome(
-        success: false,
-        message: message,
-      );
+      // Treat all broadcast errors (including NDK's "Bad state: No element"
+      // when no relay connection is established) as a normal per-relay failure.
+      // The worker will retry with exponential backoff up to _maxAttemptsPerRelay.
+      return _RelayAttemptOutcome(success: false, message: e.toString());
     }
   }
 
@@ -384,8 +361,5 @@ class _RelayAttemptOutcome {
   final bool success;
   final String? message;
 
-  _RelayAttemptOutcome({
-    required this.success,
-    required this.message,
-  });
+  _RelayAttemptOutcome({required this.success, required this.message});
 }

--- a/test/services/publish_service_test.dart
+++ b/test/services/publish_service_test.dart
@@ -28,8 +28,7 @@ void main() {
         final db = newTestDatabase();
         addTearDown(() async => db.close());
 
-        // NDK supplier whose broadcast future never completes — simulates wss://3.com.
-        final broadcastCompleter = Completer<void>();
+        // NDK supplier that throws on connect — simulates unreachable relay.
         final service = PublishService(
           getNdk: () async {
             throw StateError('Bad state: No element');
@@ -61,8 +60,6 @@ void main() {
         expect(relayRows, hasLength(1));
         expect(relayRows.first.status, 'pending');
         expect(relayRows.first.relayUrl, 'wss://dead.example.com');
-
-        broadcastCompleter.complete(); // allow clean-up if needed
       },
     );
 
@@ -72,11 +69,8 @@ void main() {
         final db = newTestDatabase();
         addTearDown(() async => db.close());
 
-        var broadcastCalls = 0;
         final service = PublishService(
           getNdk: () async {
-            broadcastCalls++;
-            // Return a forever-pending response.
             throw StateError('Bad state: No element');
           },
           database: db,

--- a/test/services/publish_service_test.dart
+++ b/test/services/publish_service_test.dart
@@ -1,0 +1,174 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ndk/ndk.dart';
+
+import 'package:horcrux/services/publish_service.dart';
+
+import '../helpers/test_database.dart';
+
+/// Creates a minimal [Nip01Event] with a deterministic ID.
+Nip01Event _makeEvent(String id) {
+  final event = Nip01Event(
+    pubKey: 'a' * 64,
+    kind: 1059,
+    tags: const [],
+    content: 'test',
+    createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+  );
+  event.id = id;
+  return event;
+}
+
+void main() {
+  group('PublishService', () {
+    test(
+      'enqueueEvent resolves promptly even when the relay broadcast never settles',
+      () async {
+        final db = newTestDatabase();
+        addTearDown(() async => db.close());
+
+        // NDK supplier whose broadcast future never completes — simulates wss://3.com.
+        final broadcastCompleter = Completer<void>();
+        final service = PublishService(
+          getNdk: () async {
+            throw StateError('Bad state: No element');
+          },
+          database: db,
+        );
+        await service.initialize();
+        addTearDown(service.disposeSync);
+
+        final event = _makeEvent('a' * 64);
+        final stopwatch = Stopwatch()..start();
+
+        final result =
+            await service.enqueueEvent(event: event, relays: ['wss://dead.example.com']).timeout(
+          const Duration(seconds: 5),
+          onTimeout: () => throw TimeoutException(
+            'enqueueEvent did not return within 5 seconds',
+          ),
+        );
+
+        stopwatch.stop();
+
+        // Should resolve almost immediately — well under 1 second.
+        expect(stopwatch.elapsedMilliseconds, lessThan(1000));
+        expect(result.eventId, event.id);
+
+        // Relay rows are left pending for the background worker to retry.
+        final relayRows = await db.outboxDao.relaysFor(event.id);
+        expect(relayRows, hasLength(1));
+        expect(relayRows.first.status, 'pending');
+        expect(relayRows.first.relayUrl, 'wss://dead.example.com');
+
+        broadcastCompleter.complete(); // allow clean-up if needed
+      },
+    );
+
+    test(
+      'enqueueEvent persists outbox row and resolves before any broadcast attempt',
+      () async {
+        final db = newTestDatabase();
+        addTearDown(() async => db.close());
+
+        var broadcastCalls = 0;
+        final service = PublishService(
+          getNdk: () async {
+            broadcastCalls++;
+            // Return a forever-pending response.
+            throw StateError('Bad state: No element');
+          },
+          database: db,
+        );
+        await service.initialize();
+        addTearDown(service.disposeSync);
+
+        final event = _makeEvent('b' * 64);
+
+        // Call enqueueEvent and verify it returns before _processQueue fires.
+        // Because _processQueue is scheduled via Future.microtask, awaiting the
+        // result here means the microtask hasn't necessarily run yet.
+        final result = await service.enqueueEvent(
+          event: event,
+          relays: ['wss://a.example.com', 'wss://b.example.com'],
+        );
+
+        expect(result.eventId, event.id);
+        // successfulRelays is always empty immediately after enqueue.
+        expect(result.successfulRelays, isEmpty);
+
+        // Outbox row must exist.
+        final outboxRow = await db.outboxDao.getById(event.id);
+        expect(outboxRow, isNotNull);
+
+        // Both relay rows persisted.
+        final relayRows = await db.outboxDao.relaysFor(event.id);
+        expect(relayRows, hasLength(2));
+      },
+    );
+
+    test(
+      'duplicate enqueue for same event ID returns promptly without re-inserting',
+      () async {
+        final db = newTestDatabase();
+        addTearDown(() async => db.close());
+
+        final service = PublishService(
+          getNdk: () async => throw StateError('Bad state: No element'),
+          database: db,
+        );
+        await service.initialize();
+        addTearDown(service.disposeSync);
+
+        final event = _makeEvent('c' * 64);
+
+        final r1 = await service.enqueueEvent(
+          event: event,
+          relays: ['wss://x.example.com'],
+        );
+        final r2 = await service.enqueueEvent(
+          event: event,
+          relays: ['wss://x.example.com'],
+        );
+
+        expect(r1.eventId, event.id);
+        expect(r2.eventId, event.id);
+
+        // Still only one outbox row.
+        final outboxRow = await db.outboxDao.getById(event.id);
+        expect(outboxRow, isNotNull);
+      },
+    );
+
+    test(
+      'Bad state: No element from NDK is recorded as a per-relay failure, not a crash',
+      () async {
+        final db = newTestDatabase();
+        addTearDown(() async => db.close());
+
+        final service = PublishService(
+          getNdk: () async => throw StateError('Bad state: No element'),
+          database: db,
+        );
+        await service.initialize();
+        addTearDown(service.disposeSync);
+
+        final event = _makeEvent('d' * 64);
+        await service.enqueueEvent(
+          event: event,
+          relays: ['wss://dead.example.com'],
+        );
+
+        // Let the microtask-scheduled worker run.
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        final relayRows = await db.outboxDao.relaysFor(event.id);
+        expect(relayRows, hasLength(1));
+        // After one attempt the relay row is still pending (not fatal).
+        expect(relayRows.first.attempts, 1);
+        expect(relayRows.first.lastError, contains('Bad state'));
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Bead
No bead — aligns with internal plan “tay8 publish blocking hypothesis” (dead relay in `BackupConfig.relays` caused `enqueueEvent` to await until all outbox relay rows finished, blocking distribute/recovery for hours).

## What
- `PublishService.enqueueEvent` returns immediately after the outbox transaction commits; relay delivery and exponential backoff continue in the background.
- `_finalizeOutboxIfComplete` only cleans up finished outbox rows (no caller completers).
- `_broadcastToRelay`: treat all errors (including NDK `Bad state: No element`) as per-relay failures; remove broadcast-to-all-relays fallback so events stay on user-selected relays.
- `NdkService.publishEncryptedEvent`: return the signed gift wrap after enqueue; document that `null` means enqueue failure, not per-relay outcome.
- Add `test/services/publish_service_test.dart`.

## Testing
- `flutter analyze lib/services/ndk_service.dart lib/services/publish_service.dart`
- `flutter test test/services/publish_service_test.dart --exclude-tags=golden`


Made with [Cursor](https://cursor.com)