### PR TITLE
Switch relay & notifier URLs based on build mode

### DIFF
--- a/lib/screens/backup_config_screen.dart
+++ b/lib/screens/backup_config_screen.dart
@@ -12,6 +12,7 @@ import '../services/backup_service.dart';
 import '../services/invitation_service.dart';
 import '../services/invitation_sending_service.dart';
 import '../services/logger.dart';
+import '../services/relay_scan_service.dart';
 import '../providers/vault_provider.dart';
 import '../providers/key_provider.dart';
 import '../utils/owner_push_opt_in_prompt.dart';
@@ -44,7 +45,7 @@ class BackupConfigScreen extends ConsumerStatefulWidget {
 class _BackupConfigScreenState extends ConsumerState<BackupConfigScreen> {
   int _threshold = VaultBackupConstraints.defaultThreshold;
   final List<Steward> _stewards = [];
-  final List<String> _relays = ['wss://dev.horcruxbackup.com'];
+  final List<String> _relays = [RelayScanService.defaultHorcruxRelayUrl];
   bool _isCreating = false;
   bool _isLoading = true;
   bool _hasUnsavedChanges = false;

--- a/lib/screens/login_relay_config_screen.dart
+++ b/lib/screens/login_relay_config_screen.dart
@@ -53,7 +53,7 @@ class _LoginRelayConfigScreenState extends ConsumerState<LoginRelayConfigScreen>
   void initState() {
     super.initState();
     _relays = [
-      const RelayConfiguration(
+      RelayConfiguration(
         id: 'horcrux-default',
         url: RelayScanService.defaultHorcruxRelayUrl,
         name: 'Horcrux Relay',

--- a/lib/services/horcrux_notification_service.dart
+++ b/lib/services/horcrux_notification_service.dart
@@ -122,9 +122,8 @@ class HorcruxNotifierException implements Exception {
 class HorcruxNotificationService {
   /// Default notifier URL. Debug builds use the dev notifier; release builds
   /// use production.
-  static String get defaultBaseUrl => kDebugMode
-      ? 'https://dev-notifier.horcruxbackup.com'
-      : 'https://notifier.horcruxbackup.com';
+  static String get defaultBaseUrl =>
+      kDebugMode ? 'https://dev-notifier.horcruxbackup.com' : 'https://notifier.horcruxbackup.com';
 
   /// Drift `kv` key for a user-overridden base URL. When present,
   /// overrides [defaultBaseUrl]; when absent or empty, the default is used.

--- a/lib/services/horcrux_notification_service.dart
+++ b/lib/services/horcrux_notification_service.dart
@@ -120,8 +120,11 @@ class HorcruxNotifierException implements Exception {
 /// development). Each HTTP method is small and explicit so future tests
 /// can mock individual endpoints.
 class HorcruxNotificationService {
-  /// Default production notifier URL.
-  static const String defaultBaseUrl = 'https://dev-notifier.horcruxbackup.com';
+  /// Default notifier URL. Debug builds use the dev notifier; release builds
+  /// use production.
+  static String get defaultBaseUrl => kDebugMode
+      ? 'https://dev-notifier.horcruxbackup.com'
+      : 'https://notifier.horcruxbackup.com';
 
   /// Drift `kv` key for a user-overridden base URL. When present,
   /// overrides [defaultBaseUrl]; when absent or empty, the default is used.

--- a/lib/services/relay_scan_service.dart
+++ b/lib/services/relay_scan_service.dart
@@ -80,9 +80,8 @@ class RelayScanService {
 
   /// The default Horcrux relay seeded on a fresh install.
   /// Debug builds use the dev relay; release builds use production.
-  static String get defaultHorcruxRelayUrl => kDebugMode
-      ? 'wss://dev.horcruxbackup.com'
-      : 'wss://relay.horcruxbackup.com';
+  static String get defaultHorcruxRelayUrl =>
+      kDebugMode ? 'wss://dev.horcruxbackup.com' : 'wss://relay.horcruxbackup.com';
 
   static const String _relayConfigsKey = 'relay_configurations';
   static const String _scanningStatusKey = 'scanning_status';

--- a/lib/services/relay_scan_service.dart
+++ b/lib/services/relay_scan_service.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/foundation.dart';
 import '../database/app_database.dart';
 import '../database/app_database_provider.dart';
 import '../models/relay_configuration.dart';
@@ -78,7 +79,10 @@ class RelayScanService {
   final AppDatabase _database;
 
   /// The default Horcrux relay seeded on a fresh install.
-  static const String defaultHorcruxRelayUrl = 'wss://dev.horcruxbackup.com';
+  /// Debug builds use the dev relay; release builds use production.
+  static String get defaultHorcruxRelayUrl => kDebugMode
+      ? 'wss://dev.horcruxbackup.com'
+      : 'wss://relay.horcruxbackup.com';
 
   static const String _relayConfigsKey = 'relay_configurations';
   static const String _scanningStatusKey = 'scanning_status';
@@ -109,7 +113,7 @@ class RelayScanService {
       // We only seed when the list is genuinely empty so that a user who
       // deliberately removes the relay is not forced back onto it after restart.
       if (_cachedRelays!.isEmpty) {
-        const defaultRelay = RelayConfiguration(
+        final defaultRelay = RelayConfiguration(
           id: 'horcrux-default',
           url: defaultHorcruxRelayUrl,
           name: 'Horcrux Relay',

--- a/test/services/horcrux_notification_service_test.dart
+++ b/test/services/horcrux_notification_service_test.dart
@@ -200,7 +200,7 @@ void main() {
         expect(e.statusCode, 429);
         expect(e.isRateLimited, isTrue);
         expect(e.message, contains('rate limited'));
-        expect(e.message, contains('POST https://dev-notifier.horcruxbackup.com/register'));
+        expect(e.message, contains('POST ${HorcruxNotificationService.defaultBaseUrl}/register'));
       }
       harness.service.dispose();
     });
@@ -287,7 +287,7 @@ void main() {
       } on HorcruxNotifierException catch (e) {
         expect(e.isUnauthorized, isTrue);
         expect(e.message, contains('bad signature'));
-        expect(e.message, contains('DELETE https://dev-notifier.horcruxbackup.com/register'));
+        expect(e.message, contains('DELETE ${HorcruxNotificationService.defaultBaseUrl}/register'));
       }
       harness.service.dispose();
     });


### PR DESCRIPTION
## Changes

Debug builds now use dev endpoints; release builds use production endpoints.

| Build mode | Relay | Notifier |
|-----------|-------|----------|
| Debug | `wss://dev.horcruxbackup.com` | `https://dev-notifier.horcruxbackup.com` |
| Release | `wss://relay.horcruxbackup.com` | `https://notifier.horcruxbackup.com` |

### Files changed

1. `lib/services/relay_scan_service.dart` — `defaultHorcruxRelayUrl` const → getter with `kDebugMode` switch
2. `lib/services/horcrux_notification_service.dart` — `defaultBaseUrl` const → getter with `kDebugMode` switch
3. `lib/screens/backup_config_screen.dart` — hardcoded dev URL → `RelayScanService.defaultHorcruxRelayUrl`
4. `lib/screens/login_relay_config_screen.dart` — remove `const` from `RelayConfiguration` (getter is not compile-time constant)
5. `test/services/horcrux_notification_service_test.dart` — literal URLs → `HorcruxNotificationService.defaultBaseUrl` constant reference

### No changes needed

- `invitation_link.dart` / `deep_link_service.dart` / `relay_management_screen.dart` — unrelated

Closes horcrux_app-1k0