### PR TITLE
fix: add libssl-dev and libsqlite3-dev to Dockerfile

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -35,6 +35,10 @@ RUN apt-get update && apt-get install -y \
     # Required by flutter_secure_storage_linux plugin (build + runtime libsecret)
     libsecret-1-dev \
     libjsoncpp-dev \
+    # Required by sqlcipher_flutter_libs (OpenSSL for SQLCipher)
+    libssl-dev \
+    # Required by drift database (SQLite for in-memory tests)
+    libsqlite3-dev \
     # Secret Service for libsecret: session D-Bus + gnome-keyring (headless Docker)
     dbus-x11 \
     gnome-keyring \


### PR DESCRIPTION
## What
Adds `libssl-dev` and `libsqlite3-dev` to the apt-get install list in `.cursor/Dockerfile`.

## Why
- `libssl-dev` is required by `sqlcipher_flutter_libs` — without it, CMake fails with `Could NOT find OpenSSL`
- `libsqlite3-dev` is required by drift for in-memory SQLite database tests — without it, database unit tests fail

## Testing
- Rebuilt Docker image from scratch — app compiles and runs without manual `apt-get install`
- Database unit tests pass (22/22) inside fresh container

Bead: horcrux_app-bp5b