### PR TITLE
Add Docker two-instance test setup for e2e recovery testing

### DIFF
--- a/.cursor/docker-compose.two-instance.yml
+++ b/.cursor/docker-compose.two-instance.yml
@@ -1,0 +1,53 @@
+# Two-instance Docker setup for testing vault backup & recovery flows.
+#
+# Usage:
+#   docker compose -f .cursor/docker-compose.two-instance.yml up -d --build
+#   docker exec horcrux-owner bash -c 'source /setup-x11.sh && flutter run -d linux --debug --host-vmservice-port=8181 &> /tmp/flutter_run.log'
+#   docker exec horcrux-steward bash -c 'source /setup-x11.sh && flutter run -d linux --debug --host-vmservice-port=9181 &> /tmp/flutter_run.log'
+#   # Find VM service URIs in logs:
+#   docker exec horcrux-owner grep 'ws://' /tmp/flutter_run.log
+#   docker exec horcrux-steward grep 'ws://' /tmp/flutter_run.log
+#
+# Teardown:
+#   docker compose -f .cursor/docker-compose.two-instance.yml down -v
+#
+# Notes:
+#   - network_mode: host is required (bridge networking fails on this host)
+#   - Separate Flutter/Pub caches per container to avoid build collisions
+#   - Both containers share the workspace source volume (read-write)
+#   - Each container needs its own D-Bus session + gnome-keyring (handled by /setup-x11.sh)
+
+services:
+  owner:
+    build:
+      context: ..
+      dockerfile: .cursor/Dockerfile
+    container_name: horcrux-owner
+    network_mode: host
+    volumes:
+      - ../:/workspace
+      - flutter-cache-owner:/root/.flutter
+      - pub-cache-owner:/root/.pub-cache
+    environment:
+      - DISPLAY=:99
+    command: tail -f /dev/null
+
+  steward:
+    build:
+      context: ..
+      dockerfile: .cursor/Dockerfile
+    container_name: horcrux-steward
+    network_mode: host
+    volumes:
+      - ../:/workspace
+      - flutter-cache-steward:/root/.flutter
+      - pub-cache-steward:/root/.pub-cache
+    environment:
+      - DISPLAY=:99
+    command: tail -f /dev/null
+
+volumes:
+  flutter-cache-owner:
+  pub-cache-owner:
+  flutter-cache-steward:
+  pub-cache-steward:

--- a/scripts/run-app-in-docker.sh
+++ b/scripts/run-app-in-docker.sh
@@ -91,20 +91,14 @@ echo ""
 # Step 4: Start Xvfb, VNC, and Flutter app
 echo -e "${GREEN}[4/5] Starting Xvfb, VNC server, and Flutter app...${NC}"
 
-# Start Xvfb if not running
+# Start Xvfb if not running (needed for VNC server)
 docker exec "$CONTAINER_NAME" bash -c "
     if ! pgrep -x Xvfb > /dev/null; then
         Xvfb :99 -screen 0 600x1024x24 > /dev/null 2>&1 &
         sleep 2
         echo 'Xvfb started with resolution 600x1024 (portrait)'
     else
-        CURRENT_RES=\$(xdpyinfo -display :99 2>/dev/null | grep dimensions | awk '{print \$2}' || echo '')
-        if [ \"\$CURRENT_RES\" != \"600x1024\" ]; then
-            pkill -x Xvfb
-            sleep 1
-            Xvfb :99 -screen 0 600x1024x24 > /dev/null 2>&1 &
-            sleep 2
-        fi
+        echo 'Xvfb already running'
     fi
 "
 
@@ -195,29 +189,11 @@ cd /workspace
     
     ABS_BUNDLE=$(cd "$BUNDLE_DIR" && pwd)
     cd /workspace
-    export DISPLAY=:99
     export PATH="/tmp:$ABS_BUNDLE:/opt/flutter/bin:$PATH"
     export LD_LIBRARY_PATH="$ABS_BUNDLE/lib:$LD_LIBRARY_PATH"
 
-    # flutter_secure_storage_linux uses libsecret, which needs D-Bus + an unlocked keyring.
-    echo 'Starting session D-Bus and gnome-keyring for libsecret...' >> /tmp/flutter_run.log
-    eval "$(dbus-launch --sh-syntax)"
-    export DBUS_SESSION_BUS_ADDRESS
-    mkdir -p ~/.cache ~/.local/share/keyrings
-    printf '\n' | gnome-keyring-daemon --unlock >> /tmp/flutter_run.log 2>&1 \
-        || echo 'WARNING: gnome-keyring unlock failed (empty password)' >> /tmp/flutter_run.log
-    gnome-keyring-daemon --start --components=secrets --daemonize >> /tmp/flutter_run.log 2>&1 \
-        || echo 'WARNING: gnome-keyring daemon start failed' >> /tmp/flutter_run.log
-
-    # Exposes org.freedesktop.Notifications on the session bus for flutter_local_notifications.
-    echo 'Starting notification-daemon...' >> /tmp/flutter_run.log
-    if command -v notification-daemon >/dev/null 2>&1; then
-        notification-daemon >> /tmp/flutter_run.log 2>&1 &
-    elif [ -x /usr/lib/notification-daemon/notification-daemon ]; then
-        /usr/lib/notification-daemon/notification-daemon >> /tmp/flutter_run.log 2>&1 &
-    else
-        echo 'WARNING: notification-daemon not installed; Linux notifications disabled' >> /tmp/flutter_run.log
-    fi
+    # Setup X11, D-Bus, gnome-keyring, and notification daemon
+    SETUP_X11_LOG=/tmp/flutter_run.log source /workspace/scripts/setup-x11.sh
     sleep 1
     
     echo "Running Flutter app with hot reload support..." >> /tmp/flutter_run.log

--- a/scripts/run-two-instances.sh
+++ b/scripts/run-two-instances.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# Launch two Horcrux instances (owner + steward) in Docker for end-to-end testing.
+#
+# Usage:
+#   ./scripts/run-two-instances.sh           # Build + start + launch both apps
+#   ./scripts/run-two-instances.sh --attach   # Also stream owner logs (Ctrl+C to stop)
+#
+# After launch, check logs for VM service URIs:
+#   docker exec horcrux-owner grep 'ws://' /tmp/flutter_run.log
+#   docker exec horcrux-steward grep 'ws://' /tmp/flutter_run.log
+#
+# Cleanup:
+#   docker compose -f .cursor/docker-compose.two-instance.yml down -v
+
+set -e
+
+COMPOSE_FILE=".cursor/docker-compose.two-instance.yml"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ATTACH="${1:-}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+cleanup() {
+    echo ""
+    echo -e "${YELLOW}Stopping containers...${NC}"
+    cd "$PROJECT_ROOT"
+    docker compose -f "$COMPOSE_FILE" down 2>/dev/null || true
+    echo -e "${GREEN}Done.${NC}"
+    exit 0
+}
+trap cleanup INT TERM
+
+cd "$PROJECT_ROOT"
+
+echo -e "${BLUE}════════════════════════════════════════════════════════════${NC}"
+echo -e "${BLUE}  Horcrux Two-Instance Test Environment${NC}"
+echo -e "${BLUE}════════════════════════════════════════════════════════════${NC}"
+
+# Build and start
+echo -e "${GREEN}[1/3] Building and starting containers...${NC}"
+docker compose -f "$COMPOSE_FILE" up -d --build
+sleep 2
+
+# Fix ownership (container runs as root, host user may differ)
+for container in horcrux-owner horcrux-steward; do
+    docker exec "$container" chown -R 1001:1001 /workspace/ 2>/dev/null || true
+done
+
+# Install deps
+echo -e "${GREEN}[2/3] Installing Flutter dependencies...${NC}"
+for container in horcrux-owner horcrux-steward; do
+    docker exec "$container" bash -c "cd /workspace && flutter pub get" > /dev/null 2>&1 &
+done
+wait
+echo "Dependencies installed in both containers"
+
+# Launch apps
+echo -e "${GREEN}[3/3] Launching Flutter apps...${NC}"
+
+docker exec -d horcrux-owner bash -c "\
+    source /workspace/scripts/setup-x11.sh && \
+    cd /workspace && \
+    flutter run -d linux --debug --host-vmservice-port=8181 --no-dds \
+    &> /tmp/flutter_run.log"
+
+docker exec -d horcrux-steward bash -c "\
+    source /workspace/scripts/setup-x11.sh && \
+    cd /workspace && \
+    flutter run -d linux --debug --host-vmservice-port=9181 --no-dds \
+    &> /tmp/flutter_run.log"
+
+echo ""
+echo -e "${BLUE}Waiting for apps to start (this takes ~2-3 minutes)...${NC}"
+echo ""
+
+# Wait for VM service URIs
+for i in $(seq 1 36); do
+    OWNER_URI=$(docker exec horcrux-owner grep -o 'ws://[^\ ]*' /tmp/flutter_run.log 2>/dev/null | head -1 || true)
+    STEWARD_URI=$(docker exec horcrux-steward grep -o 'ws://[^\ ]*' /tmp/flutter_run.log 2>/dev/null | head -1 || true)
+    if [ -n "$OWNER_URI" ] && [ -n "$STEWARD_URI" ]; then
+        echo -e "${GREEN}Both apps are running!${NC}"
+        echo ""
+        echo -e "${BLUE}Owner VM service:${NC}    $OWNER_URI"
+        echo -e "${BLUE}Steward VM service:${NC}  $STEWARD_URI"
+        echo ""
+        echo "Connect Marionette MCP to these URIs to interact with each app."
+        echo "Use 'docker exec horcrux-owner tail -f /tmp/flutter_run.log' for owner logs."
+        echo "Use 'docker exec horcrux-steward tail -f /tmp/flutter_run.log' for steward logs."
+        break
+    fi
+    sleep 5
+done
+
+if [ "$ATTACH" = "--attach" ]; then
+    echo ""
+    echo -e "${YELLOW}Streaming owner logs (Ctrl+C to stop both containers)...${NC}"
+    docker exec horcrux-owner tail -f /tmp/flutter_run.log
+fi

--- a/scripts/setup-x11.sh
+++ b/scripts/setup-x11.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Setup X11 virtual display, D-Bus session, and gnome-keyring inside a Docker container.
+# Required by flutter_secure_storage (libsecret) and the Horcrux app at runtime.
+#
+# Usage: source /setup-x11.sh
+#   (must be sourced, not executed, so environment variables persist in the calling shell)
+
+set -e
+
+# Start Xvfb if not already running
+if ! pgrep -x Xvfb > /dev/null; then
+    Xvfb :99 -screen 0 600x1024x24 > /dev/null 2>&1 &
+    sleep 1
+    echo "Xvfb started (600x1024 portrait)"
+else
+    echo "Xvfb already running"
+fi
+export DISPLAY=:99
+
+# Start D-Bus session if not already running
+if [ -z "$DBUS_SESSION_BUS_ADDRESS" ]; then
+    eval "$(dbus-launch --sh-syntax)"
+    export DBUS_SESSION_BUS_ADDRESS
+    echo "D-Bus session started"
+else
+    echo "D-Bus session already active"
+fi
+
+# Unlock and start gnome-keyring for libsecret
+mkdir -p ~/.cache ~/.local/share/keyrings
+printf '\n' | gnome-keyring-daemon --unlock 2>/dev/null || true
+gnome-keyring-daemon --start --components=secrets --daemonize 2>/dev/null || true
+echo "gnome-keyring ready"
+
+# Start notification daemon (for flutter_local_notifications)
+if ! pgrep -f notification-daemon > /dev/null; then
+    notification-daemon 2>/dev/null &
+    sleep 0.5
+    echo "notification-daemon started"
+fi
+
+echo "X11 environment ready (DISPLAY=$DISPLAY)"

--- a/scripts/setup-x11.sh
+++ b/scripts/setup-x11.sh
@@ -2,18 +2,27 @@
 # Setup X11 virtual display, D-Bus session, and gnome-keyring inside a Docker container.
 # Required by flutter_secure_storage (libsecret) and the Horcrux app at runtime.
 #
-# Usage: source /setup-x11.sh
+# Usage: source /workspace/scripts/setup-x11.sh
 #   (must be sourced, not executed, so environment variables persist in the calling shell)
+#
+# Optional: Set SETUP_X11_LOG before sourcing to redirect output to a log file:
+#   SETUP_X11_LOG=/tmp/flutter_run.log source /workspace/scripts/setup-x11.sh
 
-set -e
+_log() {
+    if [ -n "$SETUP_X11_LOG" ]; then
+        echo "$1" >> "$SETUP_X11_LOG"
+    else
+        echo "$1"
+    fi
+}
 
 # Start Xvfb if not already running
 if ! pgrep -x Xvfb > /dev/null; then
     Xvfb :99 -screen 0 600x1024x24 > /dev/null 2>&1 &
     sleep 1
-    echo "Xvfb started (600x1024 portrait)"
+    _log "Xvfb started (600x1024 portrait)"
 else
-    echo "Xvfb already running"
+    _log "Xvfb already running"
 fi
 export DISPLAY=:99
 
@@ -21,22 +30,22 @@ export DISPLAY=:99
 if [ -z "$DBUS_SESSION_BUS_ADDRESS" ]; then
     eval "$(dbus-launch --sh-syntax)"
     export DBUS_SESSION_BUS_ADDRESS
-    echo "D-Bus session started"
+    _log "D-Bus session started"
 else
-    echo "D-Bus session already active"
+    _log "D-Bus session already active"
 fi
 
 # Unlock and start gnome-keyring for libsecret
 mkdir -p ~/.cache ~/.local/share/keyrings
 printf '\n' | gnome-keyring-daemon --unlock 2>/dev/null || true
 gnome-keyring-daemon --start --components=secrets --daemonize 2>/dev/null || true
-echo "gnome-keyring ready"
+_log "gnome-keyring ready"
 
 # Start notification daemon (for flutter_local_notifications)
 if ! pgrep -f notification-daemon > /dev/null; then
     notification-daemon 2>/dev/null &
     sleep 0.5
-    echo "notification-daemon started"
+    _log "notification-daemon started"
 fi
 
-echo "X11 environment ready (DISPLAY=$DISPLAY)"
+_log "X11 environment ready (DISPLAY=$DISPLAY)"


### PR DESCRIPTION
## What

Infrastructure for running two Horcrux instances (Owner + Steward) in Docker for end-to-end vault recovery testing.

## Usage

```bash
# One-command launch
./scripts/run-two-instances.sh

# Or step by step
docker compose -f .cursor/docker-compose.two-instance.yml up -d --build
docker exec horcrux-owner bash -c 'source /workspace/scripts/setup-x11.sh && cd /workspace && flutter run -d linux --debug --host-vmservice-port=8181 &> /tmp/flutter_run.log'
docker exec horcrux-steward bash -c 'source /workspace/scripts/setup-x11.sh && cd /workspace && flutter run -d linux --debug --host-vmservice-port=9181 &> /tmp/flutter_run.log'
```

## Tested

Full end-to-end vault recovery flow confirmed working with this setup:
- Vault creation → shard distribution → recovery initiation → steward approval → owner approval → secret reconstruction ✅

## Related

- PR #190 (marionette_flutter upgrade — needed for Marionette MCP to work)
- horcrux_app-7h2e (relay scanning auto-start bug discovered during testing)
- horcrux_app-mxbg (steward count bug discovered during testing)