### PR TITLE
Fix relay scanning auto-start on fresh install (horcrux_app-7h2e)

### DIFF
--- a/lib/services/relay_scan_service.dart
+++ b/lib/services/relay_scan_service.dart
@@ -211,13 +211,9 @@ class RelayScanService {
     final jsonData = await _loadStateString(_scanningStatusKey);
 
     if (jsonData == null || jsonData.isEmpty) {
-      _scanningStatus = const ScanningStatus(
-        isActive: false,
-        totalRelays: 0,
-        activeRelays: 0,
-        sharesFound: 0,
-        requestsFound: 0,
-      );
+      // Leave _scanningStatus as null so initialize() treats this as
+      // 'no previous session' and auto-starts scanning.
+      _scanningStatus = null;
       return;
     }
 
@@ -227,13 +223,9 @@ class RelayScanService {
       Log.info('Loaded scanning status from storage');
     } catch (e) {
       Log.error('Error loading scanning status', e);
-      _scanningStatus = const ScanningStatus(
-        isActive: false,
-        totalRelays: 0,
-        activeRelays: 0,
-        sharesFound: 0,
-        requestsFound: 0,
-      );
+      // Leave _scanningStatus as null rather than defaulting to
+      // isActive: false, so initialize() will auto-start on errors.
+      _scanningStatus = null;
     }
   }
 


### PR DESCRIPTION
## Summary

After app restart on a fresh install, relay scanning fails to auto-start. The log shows: "Skipping auto-start: scanning was explicitly stopped by user" even though the user never explicitly stopped scanning. Stewards become invisible to the Nostr network until they manually navigate to Settings > Relays > Start Scanning.

### Root Cause

`_loadScanningStatus()` always set `_scanningStatus` to `ScanningStatus(isActive: false)` when no persisted data existed (fresh install) or on load errors. This made the null check in `initialize()` unreachable:

```dart
final shouldAutoStart = _scanningStatus == null || _scanningStatus!.isActive;
```

Since `_scanningStatus` was never null, and the default was `isActive: false`, `shouldAutoStart` was always false on fresh install.

### The Fix (1 file, 6 lines)

`_loadScanningStatus()` now leaves `_scanningStatus` as null in both the null-data and catch branches, instead of assigning `ScanningStatus(isActive: false)`. The auto-start logic correctly treats null as "no previous session" and auto-starts scanning.

### Verification

- All 485 tests pass, no regressions
- Flutter analyze: clean, no issues
- Logic verified: `_scanningStatus == null` → auto-starts; `isActive: false` (user stopped) → skips

### Note: Test Gap

`RelayScanService` has no existing unit tests. A test for this fix would require an in-memory database + mocked `NdkService`. The fix is trivially correct (removing an incorrect default assignment), but a test for the `initialize()` auto-start logic would provide regression protection. Consider adding in a follow-up.

Fixes: horcrux_app-7h2e