### PR TITLE
Fix steward removal race: remove by ID not object equality (horcrux_app-xn6m)

### DIFF
--- a/lib/screens/backup_config_screen.dart
+++ b/lib/screens/backup_config_screen.dart
@@ -1184,7 +1184,7 @@ class _BackupConfigScreenState extends ConsumerState<BackupConfigScreen> {
     await _sendRemovalEventsForStewards([steward]);
 
     setState(() {
-      _stewards.remove(steward);
+      _stewards.removeWhere((s) => s.id == steward.id);
       if (steward.name != null) {
         _invitationLinksByInviteeName.remove(steward.name);
       }


### PR DESCRIPTION
## Summary

Fixes a bug where after removing a steward from a recovery plan, re-adding the same pubkey would fail with "A steward with this public key already exists."

## Root Cause

_removeSteward() starts async operations (invalidateInvitation, _sendRemovalEventsForStewards) that trigger _syncStewardsFromRepository via invitationsChangedStream *before* the setState that removes the steward from _stewards runs. The sync replaces _stewards with new Steward copies (via copyWith in _mergeStewardLists), and when _stewards.remove(steward) runs afterward, the original steward object no longer matches the new copies because freezed field-by-field equality detects changed fields (e.g., status).

## Fix

Changed `_stewards.remove(steward)` → `_stewards.removeWhere((s) => s.id == steward.id)`. Removal by stable ID is immune to object identity or field-value changes.

## Testing

This is a UI race condition. Manual verification: remove a steward who has accepted (has pubkey), then re-add the same pubkey — should succeed without error.

Fixes: horcrux_app-xn6m