### PR TITLE
Kind 1337 inbound: receive shares in canonical tag-based format

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,32 +1,32 @@
 PODS:
   - app_links (6.4.1):
     - Flutter
-  - Firebase/CoreOnly (12.12.0):
-    - FirebaseCore (~> 12.12.0)
-  - Firebase/Messaging (12.12.0):
+  - Firebase/CoreOnly (12.13.0):
+    - FirebaseCore (~> 12.13.0)
+  - Firebase/Messaging (12.13.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 12.12.0)
-  - firebase_core (4.7.0):
-    - Firebase/CoreOnly (= 12.12.0)
+    - FirebaseMessaging (~> 12.13.0)
+  - firebase_core (4.9.0):
+    - Firebase/CoreOnly (= 12.13.0)
     - Flutter
-  - firebase_messaging (16.2.0):
-    - Firebase/Messaging (= 12.12.0)
+  - firebase_messaging (16.2.2):
+    - Firebase/Messaging (= 12.13.0)
     - firebase_core
     - Flutter
-  - FirebaseCore (12.12.1):
-    - FirebaseCoreInternal (~> 12.12.0)
+  - FirebaseCore (12.13.0):
+    - FirebaseCoreInternal (~> 12.13.0)
     - GoogleUtilities/Environment (~> 8.1)
     - GoogleUtilities/Logger (~> 8.1)
-  - FirebaseCoreInternal (12.12.0):
+  - FirebaseCoreInternal (12.13.0):
     - "GoogleUtilities/NSData+zlib (~> 8.1)"
-  - FirebaseInstallations (12.12.0):
-    - FirebaseCore (~> 12.12.0)
+  - FirebaseInstallations (12.13.0):
+    - FirebaseCore (~> 12.13.0)
     - GoogleUtilities/Environment (~> 8.1)
     - GoogleUtilities/UserDefaults (~> 8.1)
     - PromisesObjC (~> 2.4)
-  - FirebaseMessaging (12.12.0):
-    - FirebaseCore (~> 12.12.0)
-    - FirebaseInstallations (~> 12.12.0)
+  - FirebaseMessaging (12.13.0):
+    - FirebaseCore (~> 12.13.0)
+    - FirebaseInstallations (~> 12.13.0)
     - GoogleDataTransport (~> 10.1)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
     - GoogleUtilities/Environment (~> 8.1)
@@ -77,9 +77,6 @@ PODS:
   - nanopb/encode (3.30910.0)
   - package_info_plus (0.4.5):
     - Flutter
-  - path_provider_foundation (0.0.1):
-    - Flutter
-    - FlutterMacOS
   - PromisesObjC (2.4.0)
   - share_plus (0.0.1):
     - Flutter
@@ -107,7 +104,6 @@ DEPENDENCIES:
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - local_auth_darwin (from `.symlinks/plugins/local_auth_darwin/darwin`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
-  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sqlcipher_flutter_libs (from `.symlinks/plugins/sqlcipher_flutter_libs/ios`)
@@ -145,8 +141,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/local_auth_darwin/darwin"
   package_info_plus:
     :path: ".symlinks/plugins/package_info_plus/ios"
-  path_provider_foundation:
-    :path: ".symlinks/plugins/path_provider_foundation/darwin"
   share_plus:
     :path: ".symlinks/plugins/share_plus/ios"
   shared_preferences_foundation:
@@ -158,13 +152,13 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   app_links: 3dbc685f76b1693c66a6d9dd1e9ab6f73d97dc0a
-  Firebase: aa154fee4e9b8eac17aa42344988865b3e857d33
-  firebase_core: 9156a152117c843440b0b990c785aa0259bc5447
-  firebase_messaging: 0d962ab44ff24ed36deb8fa2ee043c4671858269
-  FirebaseCore: 86241206e656f5c80c995e370e6c975913b9b284
-  FirebaseCoreInternal: 7c12fc3011d889085e765e317d7b9fd1cef97af9
-  FirebaseInstallations: 4e6e162aa4abaaeeeb01dd00179dfc5ad9c2194e
-  FirebaseMessaging: 341004946fa7ffc741344b20f1b667514fc93e31
+  Firebase: 7d62445aeabdaea36f7d372f33052fed9a72514f
+  firebase_core: 0013f886fbd0b4950865551eaab47784424bfdb5
+  firebase_messaging: b875e4088ddd9ecd1834f6c89f6e0a1ffc7d98f0
+  FirebaseCore: 58905958aa00a061397a0fd759ae4b55bddb3576
+  FirebaseCoreInternal: 37bee58388fc6d183f0ab1b32d69ae44f2cf8aad
+  FirebaseInstallations: 134bde50e477628ded76070efdb12d515d53f948
+  FirebaseMessaging: 30564b85d2f81a96f9d312bd23acf8186ff092ae
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_local_notifications: 395056b3175ba4f08480a7c5de30cd36d69827e4
   flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
@@ -174,7 +168,6 @@ SPEC CHECKSUMS:
   local_auth_darwin: c3ee6cce0a8d56be34c8ccb66ba31f7f180aaebb
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
-  path_provider_foundation: bb55f6dbba17d0dccd6737fe6f7f34fbd0376880
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -31,7 +31,6 @@ Future<void> main() async {
   } else {
     WidgetsFlutterBinding.ensureInitialized();
   }
-
   try {
     await initializeAppLogFile();
   } catch (e, st) {

--- a/lib/models/steward_status.dart
+++ b/lib/models/steward_status.dart
@@ -22,6 +22,25 @@ enum StewardStatus {
   revoked,
 }
 
+/// Derives steward status from ack version vs the vault's current distribution.
+///
+/// Used when hydrating from DB ([VaultRepository._stewardFromRow]) and when
+/// persisting kind-1342 confirmations so read and write paths stay aligned.
+StewardStatus stewardStatusFromDistributionAck({
+  required int? acknowledgedDistributionVersion,
+  required int currentDistributionVersion,
+}) {
+  if (acknowledgedDistributionVersion != null &&
+      acknowledgedDistributionVersion == currentDistributionVersion) {
+    return StewardStatus.holdingKey;
+  }
+  if (acknowledgedDistributionVersion != null &&
+      acknowledgedDistributionVersion < currentDistributionVersion) {
+    return StewardStatus.awaitingNewKey;
+  }
+  return StewardStatus.awaitingKey;
+}
+
 /// Extension methods for StewardStatus
 extension StewardStatusExtension on StewardStatus {
   /// Get a human-readable description of the status

--- a/lib/providers/vault_detail_repository.dart
+++ b/lib/providers/vault_detail_repository.dart
@@ -306,16 +306,13 @@ class VaultDetailRepository {
     final acknowledgedAt =
         acknowledgedAtMs == null ? null : DateTime.fromMillisecondsSinceEpoch(acknowledgedAtMs);
     final acknowledgedVersion = distributionShareRow?.acknowledgmentDistributionVersion;
-    final isCurrentAck =
-        acknowledgedVersion != null && acknowledgedVersion == currentDistributionVersion;
 
     final status = isInvited
         ? StewardStatus.invited
-        : isCurrentAck
-            ? StewardStatus.holdingKey
-            : acknowledgedVersion != null && acknowledgedVersion < currentDistributionVersion
-                ? StewardStatus.awaitingNewKey
-                : StewardStatus.awaitingKey;
+        : stewardStatusFromDistributionAck(
+            acknowledgedDistributionVersion: acknowledgedVersion,
+            currentDistributionVersion: currentDistributionVersion,
+          );
     final giftWrapEventId = distributionShareRow?.giftWrapEventId;
 
     return Steward(

--- a/lib/providers/vault_provider.dart
+++ b/lib/providers/vault_provider.dart
@@ -255,10 +255,16 @@ class VaultRepository {
     return vault.backupConfig;
   }
 
+  /// Updates a steward row and distribution-share state.
+  ///
+  /// [status] is optional: when omitted and ack fields are set, status is derived
+  /// via [stewardStatusFromDistributionAck]; otherwise the prior status is kept.
+  /// Pass [status] explicitly for non-ack transitions (e.g. [StewardStatus.error],
+  /// [StewardStatus.awaitingKey] after publish).
   Future<void> updateStewardStatus({
     required String vaultId,
     required String pubkey,
-    required StewardStatus status,
+    StewardStatus? status,
     DateTime? acknowledgedAt,
     String? acknowledgmentEventId,
     int? acknowledgedDistributionVersion,
@@ -278,8 +284,17 @@ class VaultRepository {
     }
     final updatedStewards = List<Steward>.from(config.stewards);
     final prior = updatedStewards[stewardIndex];
+    final currentDistributionVersion = config.distributionVersion;
+    final resolvedStatus = status ??
+        (acknowledgedAt != null || acknowledgedDistributionVersion != null
+            ? stewardStatusFromDistributionAck(
+                acknowledgedDistributionVersion:
+                    acknowledgedDistributionVersion ?? currentDistributionVersion,
+                currentDistributionVersion: currentDistributionVersion,
+              )
+            : prior.status);
     updatedStewards[stewardIndex] = prior.copyWith(
-      status: status,
+      status: resolvedStatus,
       acknowledgedAt: acknowledgedAt,
       acknowledgmentEventId: acknowledgmentEventId,
       acknowledgedDistributionVersion: acknowledgedDistributionVersion,
@@ -291,14 +306,14 @@ class VaultRepository {
       vaultId: vaultId,
       stewardId: prior.id,
       stewardGiftWrapEventId: prior.giftWrapEventId,
-      status: status,
+      status: resolvedStatus,
       giftWrapEventId: giftWrapEventId,
       acknowledgedAt: acknowledgedAt,
       acknowledgmentEventId: acknowledgmentEventId,
       acknowledgedDistributionVersion: acknowledgedDistributionVersion,
       currentDistributionVersion: updated.distributionVersion,
     );
-    Log.info('Updated steward $pubkey status to $status in vault $vaultId');
+    Log.info('Updated steward $pubkey status to $resolvedStatus in vault $vaultId');
   }
 
   // ========== Share management (`held_shares` table) ==========
@@ -919,16 +934,13 @@ class VaultRepository {
     final acknowledgedAt =
         acknowledgedAtMs == null ? null : DateTime.fromMillisecondsSinceEpoch(acknowledgedAtMs);
     final acknowledgedVersion = distributionShareRow?.acknowledgmentDistributionVersion;
-    final isCurrentAck =
-        acknowledgedVersion != null && acknowledgedVersion == currentDistributionVersion;
 
     final status = isInvited
         ? StewardStatus.invited
-        : isCurrentAck
-            ? StewardStatus.holdingKey
-            : acknowledgedVersion != null && acknowledgedVersion < currentDistributionVersion
-                ? StewardStatus.awaitingNewKey
-                : StewardStatus.awaitingKey;
+        : stewardStatusFromDistributionAck(
+            acknowledgedDistributionVersion: acknowledgedVersion,
+            currentDistributionVersion: currentDistributionVersion,
+          );
 
     final giftWrapEventId = distributionShareRow?.giftWrapEventId;
     return Steward(
@@ -983,8 +995,13 @@ class VaultRepository {
     required int? acknowledgedDistributionVersion,
     required int currentDistributionVersion,
   }) async {
-    final distributionVersion = acknowledgedDistributionVersion ?? currentDistributionVersion;
-    final distributionId = _distributionId(vaultId, distributionVersion);
+    final recordingInboundAck = acknowledgmentEventId != null && acknowledgedAt != null;
+    // Kind-1342 acks attach to the *current* distribution share row so hydration
+    // can compare [acknowledgmentDistributionVersion] to [currentDistributionVersion].
+    final distributionVersionForRow = recordingInboundAck
+        ? currentDistributionVersion
+        : (acknowledgedDistributionVersion ?? currentDistributionVersion);
+    final distributionId = _distributionId(vaultId, distributionVersionForRow);
     final shareId = '${distributionId}_$stewardId';
     final nowMs = DateTime.now().millisecondsSinceEpoch;
 
@@ -992,9 +1009,9 @@ class VaultRepository {
           DistributionsCompanion.insert(
             id: distributionId,
             vaultId: vaultId,
-            version: distributionVersion,
+            version: distributionVersionForRow,
             createdAt: nowMs,
-            contentHmac: _placeholderHmac('$vaultId:$distributionVersion'),
+            contentHmac: _placeholderHmac('$vaultId:$distributionVersionForRow'),
           ),
         );
 
@@ -1012,15 +1029,21 @@ class VaultRepository {
 
     final sentAtMs =
         giftWrapEventId != null && giftWrapEventId.isNotEmpty ? nowMs : existing?.sentAt;
-    final acknowledgedAtMs = status == StewardStatus.holdingKey
-        ? (acknowledgedAt ?? DateTime.now()).millisecondsSinceEpoch
-        : existing?.acknowledgedAt;
-    final ackEvent = status == StewardStatus.holdingKey
-        ? (acknowledgmentEventId ?? existing?.acknowledgmentEventId)
-        : existing?.acknowledgmentEventId;
-    final ackVersion = status == StewardStatus.holdingKey
-        ? (acknowledgedDistributionVersion ?? distributionVersion)
-        : existing?.acknowledgmentDistributionVersion;
+    final acknowledgedAtMs = recordingInboundAck
+        ? acknowledgedAt.millisecondsSinceEpoch
+        : status == StewardStatus.holdingKey
+            ? (acknowledgedAt ?? DateTime.now()).millisecondsSinceEpoch
+            : existing?.acknowledgedAt;
+    final ackEvent = recordingInboundAck
+        ? acknowledgmentEventId
+        : status == StewardStatus.holdingKey
+            ? (acknowledgmentEventId ?? existing?.acknowledgmentEventId)
+            : existing?.acknowledgmentEventId;
+    final ackVersion = recordingInboundAck
+        ? (acknowledgedDistributionVersion ?? distributionVersionForRow)
+        : status == StewardStatus.holdingKey
+            ? (acknowledgedDistributionVersion ?? distributionVersionForRow)
+            : existing?.acknowledgmentDistributionVersion;
 
     await _db.into(_db.distributionShares).insertOnConflictUpdate(
           DistributionSharesCompanion(

--- a/lib/screens/vault_detail_screen.dart
+++ b/lib/screens/vault_detail_screen.dart
@@ -351,7 +351,12 @@ class _VaultDetailScreenState extends ConsumerState<VaultDetailScreen> {
 
     try {
       final backupService = ref.read(backupServiceProvider);
-      await backupService.createAndDistributeBackup(vaultId: vault.id);
+      final config = vault.backupConfig;
+      if (config != null && config.hasBeenDistributed) {
+        await backupService.redistributeKeys(vaultId: vault.id);
+      } else {
+        await backupService.createAndDistributeBackup(vaultId: vault.id);
+      }
 
       // Close dialog using root navigator key (works even if context is unmounted)
       navigatorKey.currentState?.pop();

--- a/lib/services/backup_service.dart
+++ b/lib/services/backup_service.dart
@@ -482,26 +482,23 @@ class BackupService {
     );
   }
 
-  /// Owner changed [Vault.pushEnabled] without other backup-config edits.
+  /// Bumps [BackupConfig.distributionVersion], resets steward ack state so
+  /// previously holding-key stewards move to [StewardStatus.awaitingNewKey],
+  /// then runs [createAndDistributeBackup] with the new version.
   ///
-  /// Stewards learn `push_enabled` from shard payloads; without a new
-  /// distribution they would keep a stale value and could still trigger
-  /// recovery pushes. Bumps [BackupConfig.distributionVersion], resets
-  /// steward distribution state like [mergeBackupConfig], then runs
-  /// [createAndDistributeBackup] so new shards carry the current preference.
+  /// Used by the owner-initiated "Redistribute Keys" action and by paths that
+  /// must force a fresh distribution (e.g. push-preference change).
   ///
   /// No-ops when there is no config or [BackupConfig.canDistribute] is false.
-  Future<void> redistributeForPushPreferenceChange({
-    required String vaultId,
-  }) async {
+  Future<void> redistributeKeys({required String vaultId}) async {
     final config = await _repository.getBackupConfig(vaultId);
     if (config == null) {
-      Log.info('BackupService: skip push redistribution (no backup config)');
+      Log.info('BackupService: skip redistribution (no backup config)');
       return;
     }
     if (!config.canDistribute) {
       Log.info(
-        'BackupService: skip push redistribution (not all stewards have pubkeys yet)',
+        'BackupService: skip redistribution (not all stewards have pubkeys yet)',
       );
       return;
     }
@@ -511,11 +508,21 @@ class BackupService {
     await _repository.updateBackupConfig(vaultId, updatedConfig);
     Log.info(
       'BackupService: incremented distributionVersion to ${updatedConfig.distributionVersion} '
-      'for vault $vaultId (owner push preference)',
+      'for vault $vaultId (redistribute)',
     );
 
     await createAndDistributeBackup(vaultId: vaultId);
   }
+
+  /// Owner changed [Vault.pushEnabled] without other backup-config edits.
+  ///
+  /// Stewards learn `push_enabled` from shard payloads; without a new
+  /// distribution they would keep a stale value and could still trigger
+  /// recovery pushes.
+  Future<void> redistributeForPushPreferenceChange({
+    required String vaultId,
+  }) =>
+      redistributeKeys(vaultId: vaultId);
 
   /// Check if keys should be auto-distributed and distribute if necessary
   ///

--- a/lib/services/ndk_service.dart
+++ b/lib/services/ndk_service.dart
@@ -195,6 +195,34 @@ class NdkService {
     }
   }
 
+  /// Replace the active relay set in one shot and (re)build subscriptions once.
+  ///
+  /// Prefer this over multiple [addRelay] calls at startup: each [addRelay]
+  /// invocation tears down and rebuilds every NDK subscription, and doing
+  /// that N times in rapid succession can leave the first-added relay's
+  /// per-relay REQ in an inconsistent state (observed: events stopped flowing
+  /// from the first relay while later-added relays delivered normally).
+  Future<void> setActiveRelays(List<String> relayUrls) async {
+    if (!_isInitialized) {
+      await initialize();
+    }
+    final unique = <String>{...relayUrls}.toList();
+    _activeRelays
+      ..clear()
+      ..addAll(unique);
+    Log.info(
+      'setActiveRelays: ${_activeRelays.length} relays (${_activeRelays.join(', ')})',
+    );
+    if (_activeRelays.isEmpty) {
+      await closeSubscriptions();
+    } else {
+      await _setupSubscriptions();
+    }
+    for (final url in unique) {
+      unawaited(_publishService.onRelayReconnected(url));
+    }
+  }
+
   /// Remove a relay from active listening
   Future<void> removeRelay(String relayUrl) async {
     _activeRelays.remove(relayUrl);
@@ -540,43 +568,40 @@ class NdkService {
 
       await _processedEventStore.recordProcessed(event.id);
       await _processedEventStore.recordLastSeen(relayUrl, event.createdAt);
-    } catch (e) {
+    } catch (e, st) {
+      // Per-kind handlers throw on failure (validation, lookup, DB error).
+      // Release the claim so the next delivery (subscription replay) retries
+      // instead of permanently marking this event processed.
       await _processedEventStore.releaseClaimedEvent(event.id);
-      Log.error('Error handling gift wrap event ${event.id}', e);
+      Log.error('Error handling gift wrap event ${event.id}', e, st);
     }
   }
 
-  /// Handle incoming shard data (kind 1337)
+  /// Handle incoming shard data (kind 1337). Errors propagate so the outer
+  /// dispatcher releases the dedup claim and retries on next delivery.
   Future<void> _handleShare(
     Nip01Event event, {
     bool allowLocalNotification = true,
   }) async {
-    try {
-      Log.info('Processing shard data event: ${event.id}');
+    Log.info('Processing shard data event: ${event.id}');
 
-      // Use canonical tag-based format
-      final shardData = shareFromNostr(event).copyWith(nostrEventId: event.id);
+    final shardData = shareFromNostr(event).copyWith(nostrEventId: event.id);
+    Log.debug('Shard data: $shardData');
 
-      Log.debug('Shard data: $shardData');
+    final vaultId = shardData.vaultId;
+    if (vaultId == null || vaultId.isEmpty) {
+      throw ArgumentError(
+        'Cannot process shard data event ${event.id}: missing vault_id in shard data',
+      );
+    }
 
-      final vaultId = shardData.vaultId;
-      if (vaultId == null || vaultId.isEmpty) {
-        Log.error(
-          'Cannot process shard data event ${event.id}: missing vault_id in shard data',
-        );
-        return;
-      }
+    final vaultShareService = _ref.read(vaultShareServiceProvider);
+    await vaultShareService.processVaultShare(vaultId, shardData);
 
-      final vaultShareService = _ref.read(vaultShareServiceProvider);
-      await vaultShareService.processVaultShare(vaultId, shardData);
-
-      if (allowLocalNotification) {
-        await _ref
-            .read(localNotificationServiceProvider)
-            .notifyShareDataProcessed(event: event, share: shardData);
-      }
-    } catch (e) {
-      Log.error('Error handling shard data event ${event.id}', e);
+    if (allowLocalNotification) {
+      await _ref
+          .read(localNotificationServiceProvider)
+          .notifyShareDataProcessed(event: event, share: shardData);
     }
   }
 
@@ -732,73 +757,51 @@ class NdkService {
     );
   }
 
-  /// Handle incoming invitation acceptance event (kind 1340)
+  /// Handle incoming invitation acceptance event (kind 1340). Errors propagate
+  /// so the outer dispatcher releases the dedup claim and retries.
   Future<void> _handleInvitationAcceptance(Nip01Event event) async {
-    try {
-      Log.info('Processing invitation acceptance event: ${event.id}');
-      Log.debug(
-        'Invitation acceptance event before processing: kind=${event.kind}, content length=${event.content.length}, content preview=${event.content.length > 100 ? event.content.substring(0, 100) : event.content}',
-      );
-      final invitationService = _getInvitationService();
-      await invitationService.processInvitationAcceptanceEvent(event: event);
-      Log.info(
-        'Successfully processed invitation acceptance event: ${event.id}',
-      );
-    } catch (e) {
-      Log.error('Error handling invitation acceptance event ${event.id}', e);
-    }
+    Log.info('Processing invitation acceptance event: ${event.id}');
+    final invitationService = _getInvitationService();
+    await invitationService.processInvitationAcceptanceEvent(event: event);
+    Log.info(
+      'Successfully processed invitation acceptance event: ${event.id}',
+    );
   }
 
-  /// Handle incoming invitation denial event (kind 1341)
+  /// Handle incoming invitation denial event (kind 1341). Errors propagate.
   Future<void> _handleInvitationDenial(Nip01Event event) async {
-    try {
-      Log.info('Processing invitation denial event: ${event.id}');
-      final invitationService = _getInvitationService();
-      await invitationService.processDenialEvent(event: event);
-      Log.info('Successfully processed denial event: ${event.id}');
-    } catch (e) {
-      Log.error('Error handling invitation denial event ${event.id}', e);
-    }
+    Log.info('Processing invitation denial event: ${event.id}');
+    final invitationService = _getInvitationService();
+    await invitationService.processDenialEvent(event: event);
+    Log.info('Successfully processed denial event: ${event.id}');
   }
 
-  /// Handle incoming shard confirmation event (kind 1342)
+  /// Handle incoming shard confirmation event (kind 1342). Errors propagate so
+  /// the outer dispatcher releases the dedup claim and retries on next delivery.
   Future<void> _handleShareConfirmation(
     Nip01Event event, {
     bool allowLocalNotification = true,
   }) async {
-    try {
-      Log.info('Processing shard confirmation event: ${event.id}');
-      Log.debug('Shard confirmation event tags: ${event.tags}');
-      final shardDistributionService = _ref.read(
-        shareDistributionServiceProvider,
-      );
-      await shardDistributionService.processShareConfirmationEvent(
-        event: event,
-      );
-      Log.info('Successfully processed shard confirmation event: ${event.id}');
+    Log.info('Processing shard confirmation event: ${event.id}');
+    Log.debug('Shard confirmation event tags: ${event.tags}');
+    await _ref.read(shareDistributionServiceProvider).processShareConfirmationEvent(event: event);
+    Log.info('Successfully processed shard confirmation event: ${event.id}');
 
-      final vaultId = _firstTagValue(event.tags, 'vault_id');
-      if (vaultId != null && allowLocalNotification) {
-        await _ref
-            .read(localNotificationServiceProvider)
-            .notifyShareConfirmationProcessed(event: event, vaultId: vaultId);
-      }
-    } catch (e) {
-      Log.error('Error handling shard confirmation event ${event.id}', e);
+    final vaultId = _firstTagValue(event.tags, 'vault_id');
+    if (vaultId != null && allowLocalNotification) {
+      await _ref
+          .read(localNotificationServiceProvider)
+          .notifyShareConfirmationProcessed(event: event, vaultId: vaultId);
     }
   }
 
-  /// Handle incoming steward removed event (kind 1345)
+  /// Handle incoming steward removed event (kind 1345). Errors propagate.
   Future<void> _handleKeyHolderRemoved(Nip01Event event) async {
-    try {
-      Log.info('Processing steward removed event: ${event.id}');
-      Log.debug('Key holder removed event tags: ${event.tags}');
-      final vaultShareService = _ref.read(vaultShareServiceProvider);
-      await vaultShareService.processKeyHolderRemoval(event: event);
-      Log.info('Successfully processed steward removed event: ${event.id}');
-    } catch (e) {
-      Log.error('Error handling steward removed event ${event.id}', e);
-    }
+    Log.info('Processing steward removed event: ${event.id}');
+    Log.debug('Key holder removed event tags: ${event.tags}');
+    final vaultShareService = _ref.read(vaultShareServiceProvider);
+    await vaultShareService.processKeyHolderRemoval(event: event);
+    Log.info('Successfully processed steward removed event: ${event.id}');
   }
 
   /// Close all active gift-wrap subscriptions.
@@ -818,6 +821,13 @@ class NdkService {
         }
       }
     }
+
+    // Cancel and clear Dart-side stream listeners so the next setup starts
+    // from an empty list — otherwise stale listeners accumulate across calls.
+    for (final sub in _subscriptionStreamSubs) {
+      await sub.cancel();
+    }
+    _subscriptionStreamSubs.clear();
   }
 
   /// Get the list of active relays

--- a/lib/services/ndk_service.dart
+++ b/lib/services/ndk_service.dart
@@ -554,14 +554,8 @@ class NdkService {
     try {
       Log.info('Processing shard data event: ${event.id}');
 
-      // Try legacy JSON content first, fall back to tag-based canonical format
-      late Share shardData;
-      try {
-        shardData = shareFromJson(json.decode(event.content) as Map<String, dynamic>)
-            .copyWith(nostrEventId: event.id);
-      } catch (_) {
-        shardData = shareFromNostr(event).copyWith(nostrEventId: event.id);
-      }
+      // Use canonical tag-based format
+      final shardData = shareFromNostr(event).copyWith(nostrEventId: event.id);
 
       Log.debug('Shard data: $shardData');
 

--- a/lib/services/ndk_service.dart
+++ b/lib/services/ndk_service.dart
@@ -389,7 +389,7 @@ class NdkService {
         );
         return null;
       }
-      return shareFromJson(json.decode(inner.content) as Map<String, dynamic>);
+      return shareFromNostr(inner);
     } catch (e, st) {
       Log.warning(
         'loadShareDataFromPublishedDistributionGiftWrap failed',
@@ -409,12 +409,7 @@ class NdkService {
       final inner = await _ndk!.giftWrap.fromGiftWrap(giftWrap: giftWrap);
       switch (inner.kind) {
         case 1337: // [NostrKind.shareData]
-          // Try JSON content first (legacy), fall back to tags (new format)
-          Map<String, dynamic>? m;
-          try {
-            m = json.decode(inner.content) as Map<String, dynamic>;
-          } catch (_) {}
-          final id = _vaultIdFromReader(m, inner.tags);
+          final id = _firstTagValue(inner.tags, 'vault_id');
           return (id != null && id.isNotEmpty) ? id : null;
         case 1338: // [NostrKind.recoveryRequest]
           final id = _firstTagValue(inner.tags, 'vault_id');

--- a/lib/services/relay_scan_service.dart
+++ b/lib/services/relay_scan_service.dart
@@ -393,11 +393,11 @@ class RelayScanService {
       await ndkService.initialize();
       Log.info('NDK initialized for relay scanning');
 
-      // Add all enabled relays to NDK for real-time listening
+      // Add all enabled relays to NDK in one batched call so subscriptions
+      // are built exactly once instead of N times (the per-call teardown can
+      // leave the first relay's NDK REQ in a bad state).
       final enabledRelays = _cachedRelays!.where((r) => r.isEnabled).toList();
-      for (final relay in enabledRelays) {
-        await ndkService.addRelay(relay.url);
-      }
+      await ndkService.setActiveRelays(enabledRelays.map((r) => r.url).toList());
       Log.info('Added ${enabledRelays.length} enabled relays to NDK');
     } catch (e) {
       Log.error('Error initializing NDK', e);

--- a/lib/services/share_distribution_service.dart
+++ b/lib/services/share_distribution_service.dart
@@ -350,7 +350,8 @@ class ShareDistributionService {
   ///
   /// Tag-only wire (empty content): [vault_id], [share_index],
   /// optional [distribution_version]. Steward identity is [Nip01Event.pubKey]
-  /// (gift-wrap seal author), not a redundant tag. Status is derived from ack
+  /// (gift-wrap seal author), not a redundant tag. Confirmations tagged with a
+  /// future [distribution_version] are dropped. Status is derived from ack
   /// version vs current distribution version.
   Future<void> processShareConfirmationEvent({
     required Nip01Event event,
@@ -402,13 +403,16 @@ class ShareDistributionService {
     final currentDistributionVersion = config?.distributionVersion ?? 0;
     final keyHolderPubkey = event.pubKey;
 
-    final acknowledgedDistributionVersion = tagDistributionVersion ?? currentDistributionVersion;
     if (tagDistributionVersion != null && tagDistributionVersion > currentDistributionVersion) {
-      Log.warning(
-        'Share confirmation for future distribution v$tagDistributionVersion '
-        '(current v$currentDistributionVersion) on vault $vaultId',
+      // Return without throwing so NDK records the gift wrap processed (no retry).
+      Log.error(
+        'Cannot process share confirmation for future distribution v$tagDistributionVersion '
+        '(current v$currentDistributionVersion) on vault $vaultId, share $shareIndex',
       );
+      return;
     }
+
+    final acknowledgedDistributionVersion = tagDistributionVersion ?? currentDistributionVersion;
     await _repository.updateStewardStatus(
       vaultId: vaultId,
       pubkey: keyHolderPubkey,

--- a/lib/services/share_distribution_service.dart
+++ b/lib/services/share_distribution_service.dart
@@ -151,7 +151,6 @@ class ShareDistributionService {
               await _repository.updateStewardStatus(
                 vaultId: config.vaultId,
                 pubkey: ownerPubkey,
-                status: StewardStatus.holdingKey,
                 acknowledgedAt: DateTime.now(),
                 // Owner self-steward: provenance is distribution version + outbound
                 // wrap id only — no separate ack event id (stewards infer the same).
@@ -318,7 +317,6 @@ class ShareDistributionService {
             await _repository.updateStewardStatus(
               vaultId: vaultId,
               pubkey: shareEvent.recipientPubkey, // Hex format
-              status: StewardStatus.holdingKey,
               acknowledgedAt: DateTime.now(),
               acknowledgmentEventId: acknowledgmentEventId,
               acknowledgedDistributionVersion: currentDistributionVersion,
@@ -347,8 +345,9 @@ class ShareDistributionService {
 
   /// Processes share confirmation event received from steward (kind 1342).
   ///
-  /// Validates vault ID and share index from tags ([shard_index] on wire).
-  /// Updates steward status to "holding key".
+  /// Tag-only wire (empty content): [vault_id], [share_index],
+  /// optional [distribution_version], [confirmed_at]. Steward identity is
+  /// [Nip01Event.pubKey] (gift-wrap seal author), not a redundant tag.
   Future<void> processShareConfirmationEvent({
     required Nip01Event event,
   }) async {
@@ -367,10 +366,8 @@ class ShareDistributionService {
       );
     }
 
-    // Extract vault ID, share index, and distribution version from tags
-    // All confirmation data is stored in tags (no content)
     final vaultId = _extractTagValue(event.tags, 'vault_id');
-    final shareIndexStr = _extractTagValue(event.tags, 'shard_index');
+    final shareIndexStr = _extractTagValue(event.tags, 'share_index');
     final distributionVersionStr = _extractTagValue(
       event.tags,
       'distribution_version',
@@ -381,34 +378,46 @@ class ShareDistributionService {
     }
 
     if (shareIndexStr == null) {
-      throw ArgumentError(
-        'Missing shard_index tag in share confirmation event',
-      );
+      throw ArgumentError('Missing share_index tag in share confirmation event');
     }
 
     final shareIndex = int.tryParse(shareIndexStr);
     if (shareIndex == null) {
       throw ArgumentError(
-        'Invalid share index in share confirmation event: $shareIndexStr',
+        'Invalid share_index in share confirmation event: $shareIndexStr',
       );
     }
 
-    final distributionVersion =
+    final tagDistributionVersion =
         distributionVersionStr != null ? int.tryParse(distributionVersionStr) : null;
 
-    // Update steward status
+    final vaultBefore = await _repository.getVault(vaultId);
+    final config = vaultBefore?.backupConfig;
+    final currentDistributionVersion = config?.distributionVersion ?? 0;
     final keyHolderPubkey = event.pubKey;
+
+    final acknowledgedDistributionVersion = tagDistributionVersion ?? currentDistributionVersion;
+    if (tagDistributionVersion != null && tagDistributionVersion > currentDistributionVersion) {
+      Log.warning(
+        'Share confirmation for future distribution v$tagDistributionVersion '
+        '(current v$currentDistributionVersion) on vault $vaultId',
+      );
+    }
     await _repository.updateStewardStatus(
       vaultId: vaultId,
       pubkey: keyHolderPubkey,
-      status: StewardStatus.holdingKey,
       acknowledgedAt: DateTime.now(),
       acknowledgmentEventId: event.id,
-      acknowledgedDistributionVersion: distributionVersion,
+      acknowledgedDistributionVersion: acknowledgedDistributionVersion,
     );
 
+    final status = stewardStatusFromDistributionAck(
+      acknowledgedDistributionVersion: acknowledgedDistributionVersion,
+      currentDistributionVersion: currentDistributionVersion,
+    );
     Log.info(
-      'Processed share confirmation event for vault $vaultId, share $shareIndex from steward $keyHolderPubkey',
+      'Processed share confirmation event for vault $vaultId, share $shareIndex '
+      'from steward $keyHolderPubkey (ack v$acknowledgedDistributionVersion, status $status)',
     );
   }
 

--- a/lib/services/vault_share_service.dart
+++ b/lib/services/vault_share_service.dart
@@ -2,7 +2,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ndk/ndk.dart';
 import '../models/invitation_link.dart';
 import '../models/share.dart';
-import '../models/steward_status.dart';
 import '../models/vault.dart';
 import '../models/nostr_kinds.dart';
 import '../providers/vault_provider.dart';
@@ -256,8 +255,7 @@ class VaultShareService {
 
       final tags = [
         ['vault_id', vaultId],
-        ['shard_index', shareIndex.toString()],
-        ['steward_pubkey', currentPubkey],
+        ['share_index', shareIndex.toString()],
         ['confirmed_at', DateTime.now().toIso8601String()],
         if (distributionVersion != null) ['distribution_version', distributionVersion.toString()],
       ];
@@ -533,7 +531,6 @@ class VaultShareService {
       await repository.updateStewardStatus(
         vaultId: vaultId,
         pubkey: ownerPk,
-        status: StewardStatus.holdingKey,
         acknowledgedAt: DateTime.now(),
         acknowledgmentEventId: null,
         acknowledgedDistributionVersion: shareDist,

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -76,9 +76,6 @@ PODS:
   - nanopb/encode (3.30910.0)
   - package_info_plus (0.0.1):
     - FlutterMacOS
-  - path_provider_foundation (0.0.1):
-    - Flutter
-    - FlutterMacOS
   - PromisesObjC (2.4.0)
   - share_plus (0.0.1):
     - FlutterMacOS
@@ -105,7 +102,6 @@ DEPENDENCIES:
   - FlutterMacOS (from `Flutter/ephemeral`)
   - local_auth_darwin (from `Flutter/ephemeral/.symlinks/plugins/local_auth_darwin/darwin`)
   - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
-  - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
   - share_plus (from `Flutter/ephemeral/.symlinks/plugins/share_plus/macos`)
   - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sqlcipher_flutter_libs (from `Flutter/ephemeral/.symlinks/plugins/sqlcipher_flutter_libs/macos`)
@@ -141,8 +137,6 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/local_auth_darwin/darwin
   package_info_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos
-  path_provider_foundation:
-    :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
   share_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/share_plus/macos
   shared_preferences_foundation:
@@ -169,7 +163,6 @@ SPEC CHECKSUMS:
   local_auth_darwin: c3ee6cce0a8d56be34c8ccb66ba31f7f180aaebb
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   package_info_plus: f0052d280d17aa382b932f399edf32507174e870
-  path_provider_foundation: bb55f6dbba17d0dccd6737fe6f7f34fbd0376880
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   share_plus: 510bf0af1a42cd602274b4629920c9649c52f4cc
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb

--- a/test/models/steward_test.dart
+++ b/test/models/steward_test.dart
@@ -305,4 +305,46 @@ void main() {
       });
     });
   });
+
+  group('stewardStatusFromDistributionAck', () {
+    test('holdingKey when ack version matches current', () {
+      expect(
+        stewardStatusFromDistributionAck(
+          acknowledgedDistributionVersion: 3,
+          currentDistributionVersion: 3,
+        ),
+        StewardStatus.holdingKey,
+      );
+    });
+
+    test('awaitingNewKey when ack version is older than current', () {
+      expect(
+        stewardStatusFromDistributionAck(
+          acknowledgedDistributionVersion: 2,
+          currentDistributionVersion: 3,
+        ),
+        StewardStatus.awaitingNewKey,
+      );
+    });
+
+    test('awaitingKey when no ack version', () {
+      expect(
+        stewardStatusFromDistributionAck(
+          acknowledgedDistributionVersion: null,
+          currentDistributionVersion: 3,
+        ),
+        StewardStatus.awaitingKey,
+      );
+    });
+
+    test('awaitingKey when ack version is newer than current', () {
+      expect(
+        stewardStatusFromDistributionAck(
+          acknowledgedDistributionVersion: 4,
+          currentDistributionVersion: 3,
+        ),
+        StewardStatus.awaitingKey,
+      );
+    });
+  });
 }

--- a/test/providers/vault_distribution_state_persistence_test.dart
+++ b/test/providers/vault_distribution_state_persistence_test.dart
@@ -67,7 +67,6 @@ void main() {
       await repository.updateStewardStatus(
         vaultId: vaultId,
         pubkey: stewardPubkey,
-        status: StewardStatus.holdingKey,
         acknowledgedAt: acknowledgedAt,
         acknowledgmentEventId: 'ack-event-1',
         acknowledgedDistributionVersion: 1,
@@ -107,7 +106,6 @@ void main() {
       await repository.updateStewardStatus(
         vaultId: vaultId,
         pubkey: stewardPubkey,
-        status: StewardStatus.holdingKey,
         acknowledgedAt: acknowledgedAt,
         acknowledgmentEventId: 'ack-event-2',
         acknowledgedDistributionVersion: 1,

--- a/test/services/backup_service_test.mocks.dart
+++ b/test/services/backup_service_test.mocks.dart
@@ -233,7 +233,7 @@ class MockVaultRepository extends _i1.Mock implements _i5.VaultRepository {
   _i6.Future<void> updateStewardStatus({
     required String? vaultId,
     required String? pubkey,
-    required _i9.StewardStatus? status,
+    _i9.StewardStatus? status,
     DateTime? acknowledgedAt,
     String? acknowledgmentEventId,
     int? acknowledgedDistributionVersion,

--- a/test/services/horcrux_notification_service_test.mocks.dart
+++ b/test/services/horcrux_notification_service_test.mocks.dart
@@ -413,7 +413,7 @@ class MockVaultRepository extends _i1.Mock implements _i6.VaultRepository {
   _i4.Future<void> updateStewardStatus({
     required String? vaultId,
     required String? pubkey,
-    required _i9.StewardStatus? status,
+    _i9.StewardStatus? status,
     DateTime? acknowledgedAt,
     String? acknowledgmentEventId,
     int? acknowledgedDistributionVersion,

--- a/test/services/invitation_acceptance_format_test.mocks.dart
+++ b/test/services/invitation_acceptance_format_test.mocks.dart
@@ -124,6 +124,16 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
       ) as _i7.Future<void>);
 
   @override
+  _i7.Future<void> setActiveRelays(List<String>? relayUrls) => (super.noSuchMethod(
+        Invocation.method(
+          #setActiveRelays,
+          [relayUrls],
+        ),
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
+
+  @override
   _i7.Future<void> removeRelay(String? relayUrl) => (super.noSuchMethod(
         Invocation.method(
           #removeRelay,
@@ -1572,6 +1582,17 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
         Invocation.method(
           #handleContentChange,
           [vaultId],
+        ),
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
+
+  @override
+  _i7.Future<void> redistributeKeys({required String? vaultId}) => (super.noSuchMethod(
+        Invocation.method(
+          #redistributeKeys,
+          [],
+          {#vaultId: vaultId},
         ),
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),

--- a/test/services/invitation_acceptance_format_test.mocks.dart
+++ b/test/services/invitation_acceptance_format_test.mocks.dart
@@ -717,7 +717,7 @@ class MockVaultRepository extends _i1.Mock implements _i12.VaultRepository {
   _i7.Future<void> updateStewardStatus({
     required String? vaultId,
     required String? pubkey,
-    required _i14.StewardStatus? status,
+    _i14.StewardStatus? status,
     DateTime? acknowledgedAt,
     String? acknowledgmentEventId,
     int? acknowledgedDistributionVersion,

--- a/test/services/invitation_service_test.mocks.dart
+++ b/test/services/invitation_service_test.mocks.dart
@@ -124,6 +124,16 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
       ) as _i7.Future<void>);
 
   @override
+  _i7.Future<void> setActiveRelays(List<String>? relayUrls) => (super.noSuchMethod(
+        Invocation.method(
+          #setActiveRelays,
+          [relayUrls],
+        ),
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
+
+  @override
   _i7.Future<void> removeRelay(String? relayUrl) => (super.noSuchMethod(
         Invocation.method(
           #removeRelay,
@@ -1572,6 +1582,17 @@ class MockBackupService extends _i1.Mock implements _i18.BackupService {
         Invocation.method(
           #handleContentChange,
           [vaultId],
+        ),
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
+
+  @override
+  _i7.Future<void> redistributeKeys({required String? vaultId}) => (super.noSuchMethod(
+        Invocation.method(
+          #redistributeKeys,
+          [],
+          {#vaultId: vaultId},
         ),
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),

--- a/test/services/invitation_service_test.mocks.dart
+++ b/test/services/invitation_service_test.mocks.dart
@@ -717,7 +717,7 @@ class MockVaultRepository extends _i1.Mock implements _i12.VaultRepository {
   _i7.Future<void> updateStewardStatus({
     required String? vaultId,
     required String? pubkey,
-    required _i14.StewardStatus? status,
+    _i14.StewardStatus? status,
     DateTime? acknowledgedAt,
     String? acknowledgmentEventId,
     int? acknowledgedDistributionVersion,

--- a/test/services/local_notification_service_navigation_test.mocks.dart
+++ b/test/services/local_notification_service_navigation_test.mocks.dart
@@ -194,7 +194,7 @@ class MockVaultRepository extends _i1.Mock implements _i2.VaultRepository {
   _i3.Future<void> updateStewardStatus({
     required String? vaultId,
     required String? pubkey,
-    required _i6.StewardStatus? status,
+    _i6.StewardStatus? status,
     DateTime? acknowledgedAt,
     String? acknowledgmentEventId,
     int? acknowledgedDistributionVersion,

--- a/test/services/logout_service_test.mocks.dart
+++ b/test/services/logout_service_test.mocks.dart
@@ -265,7 +265,7 @@ class MockVaultRepository extends _i1.Mock implements _i2.VaultRepository {
   _i8.Future<void> updateStewardStatus({
     required String? vaultId,
     required String? pubkey,
-    required _i11.StewardStatus? status,
+    _i11.StewardStatus? status,
     DateTime? acknowledgedAt,
     String? acknowledgmentEventId,
     int? acknowledgedDistributionVersion,

--- a/test/services/push_notification_receiver_test.mocks.dart
+++ b/test/services/push_notification_receiver_test.mocks.dart
@@ -75,6 +75,16 @@ class MockNdkService extends _i1.Mock implements _i3.NdkService {
       ) as _i4.Future<void>);
 
   @override
+  _i4.Future<void> setActiveRelays(List<String>? relayUrls) => (super.noSuchMethod(
+        Invocation.method(
+          #setActiveRelays,
+          [relayUrls],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+
+  @override
   _i4.Future<void> removeRelay(String? relayUrl) => (super.noSuchMethod(
         Invocation.method(
           #removeRelay,

--- a/test/services/recovery_service_test.mocks.dart
+++ b/test/services/recovery_service_test.mocks.dart
@@ -326,6 +326,17 @@ class MockBackupService extends _i1.Mock implements _i6.BackupService {
       ) as _i7.Future<void>);
 
   @override
+  _i7.Future<void> redistributeKeys({required String? vaultId}) => (super.noSuchMethod(
+        Invocation.method(
+          #redistributeKeys,
+          [],
+          {#vaultId: vaultId},
+        ),
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
+
+  @override
   _i7.Future<void> redistributeForPushPreferenceChange({required String? vaultId}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -698,6 +709,16 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
         Invocation.method(
           #addRelay,
           [relayUrl],
+        ),
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
+
+  @override
+  _i7.Future<void> setActiveRelays(List<String>? relayUrls) => (super.noSuchMethod(
+        Invocation.method(
+          #setActiveRelays,
+          [relayUrls],
         ),
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),

--- a/test/services/share_distribution_service_test.dart
+++ b/test/services/share_distribution_service_test.dart
@@ -868,6 +868,43 @@ void main() {
         ).called(1);
       });
 
+      test('drops confirmation for future distribution_version', () async {
+        final cfg = createBackupConfig(
+          vaultId: 'vault-confirm',
+          threshold: 2,
+          totalKeys: 2,
+          stewards: [
+            createOwnerSteward(pubkey: alicePubHex, name: 'Alice'),
+            createSteward(pubkey: bobPubHex, name: 'Bob'),
+          ],
+          relays: TestBackupConfigs.simple2of2Relays,
+        ).copyWith(distributionVersion: 3);
+        await stubVaultForConfirmation(id: 'vault-confirm', config: cfg);
+
+        await service.processShareConfirmationEvent(
+          event: confirmationEvent(
+            stewardPubkey: bobPubHex,
+            tags: [
+              ['vault_id', 'vault-confirm'],
+              ['share_index', '1'],
+              ['distribution_version', '99'],
+            ],
+          ),
+        );
+
+        verifyNever(
+          mockRepository.updateStewardStatus(
+            vaultId: anyNamed('vaultId'),
+            pubkey: anyNamed('pubkey'),
+            status: anyNamed('status'),
+            acknowledgedAt: anyNamed('acknowledgedAt'),
+            acknowledgmentEventId: anyNamed('acknowledgmentEventId'),
+            acknowledgedDistributionVersion: anyNamed('acknowledgedDistributionVersion'),
+            giftWrapEventId: anyNamed('giftWrapEventId'),
+          ),
+        );
+      });
+
       test('defaults ack version to current when tag is absent', () async {
         final cfg = createBackupConfig(
           vaultId: 'vault-confirm',

--- a/test/services/share_distribution_service_test.dart
+++ b/test/services/share_distribution_service_test.dart
@@ -8,7 +8,6 @@ import 'package:ndk/shared/nips/nip01/bip340.dart';
 import 'package:horcrux/models/backup_config.dart';
 import 'package:horcrux/models/share.dart';
 import 'package:horcrux/models/steward.dart';
-import 'package:horcrux/models/steward_status.dart';
 import 'package:horcrux/models/event_status.dart';
 import 'package:horcrux/models/nostr_kinds.dart';
 import 'package:horcrux/models/vault.dart';
@@ -575,7 +574,6 @@ void main() {
           mockRepository.updateStewardStatus(
             vaultId: vaultId,
             pubkey: alicePubHex,
-            status: StewardStatus.holdingKey,
             acknowledgedAt: anyNamed('acknowledgedAt'),
             acknowledgmentEventId: null,
             acknowledgedDistributionVersion: 42,
@@ -596,5 +594,279 @@ void main() {
         ).called(1);
       },
     );
+  });
+
+  group('ShareDistributionService.processShareConfirmationEvent', () {
+    late MockVaultRepository mockRepository;
+    late MockLoginService mockLoginService;
+    late MockNdkService mockNdkService;
+    late MockHorcruxNotificationService mockNotificationService;
+    late ShareDistributionService service;
+    late String alicePubHex;
+    late String bobPubHex;
+
+    setUp(() {
+      mockRepository = MockVaultRepository();
+      mockLoginService = MockLoginService();
+      mockNdkService = MockNdkService();
+      mockNotificationService = MockHorcruxNotificationService();
+      service = ShareDistributionService(
+        mockRepository,
+        mockLoginService,
+        mockNdkService,
+        mockNotificationService,
+      );
+      alicePubHex = TestHexPubkeys.alice;
+      bobPubHex = TestHexPubkeys.bob;
+      when(mockLoginService.getCurrentPublicKey()).thenAnswer((_) async => alicePubHex);
+    });
+
+    Nip01Event confirmationEvent({
+      required String stewardPubkey,
+      List<List<String>>? tags,
+    }) {
+      return Nip01Event(
+        kind: NostrKind.shareConfirmation.value,
+        pubKey: stewardPubkey,
+        tags: tags ??
+            [
+              ['vault_id', 'vault-confirm'],
+              ['share_index', '1'],
+              ['distribution_version', '3'],
+            ],
+        createdAt: 1,
+        content: '',
+      );
+    }
+
+    test('uses gift-wrap author pubkey for steward lookup', () async {
+      final cfg = createBackupConfig(
+        vaultId: 'vault-confirm',
+        threshold: 2,
+        totalKeys: 2,
+        stewards: [
+          createOwnerSteward(pubkey: alicePubHex, name: 'Alice'),
+          createSteward(pubkey: bobPubHex, name: 'Bob'),
+        ],
+        relays: TestBackupConfigs.simple2of2Relays,
+      ).copyWith(distributionVersion: 3);
+
+      when(mockRepository.getVault('vault-confirm')).thenAnswer((_) async {
+        return Vault(
+          id: 'vault-confirm',
+          name: 'Test',
+          createdAt: DateTime.utc(2024),
+          ownerPubkey: alicePubHex,
+          backupConfig: cfg,
+        );
+      });
+      when(
+        mockRepository.updateStewardStatus(
+          vaultId: anyNamed('vaultId'),
+          pubkey: anyNamed('pubkey'),
+          status: anyNamed('status'),
+          acknowledgedAt: anyNamed('acknowledgedAt'),
+          acknowledgmentEventId: anyNamed('acknowledgmentEventId'),
+          acknowledgedDistributionVersion: anyNamed('acknowledgedDistributionVersion'),
+          giftWrapEventId: anyNamed('giftWrapEventId'),
+        ),
+      ).thenAnswer((_) async {});
+
+      await service.processShareConfirmationEvent(
+        event: confirmationEvent(stewardPubkey: bobPubHex),
+      );
+
+      verify(
+        mockRepository.updateStewardStatus(
+          vaultId: 'vault-confirm',
+          pubkey: bobPubHex,
+          acknowledgedAt: anyNamed('acknowledgedAt'),
+          acknowledgmentEventId: anyNamed('acknowledgmentEventId'),
+          acknowledgedDistributionVersion: 3,
+          giftWrapEventId: anyNamed('giftWrapEventId'),
+        ),
+      ).called(1);
+    });
+
+    test('throws when share_index tag is missing', () async {
+      final cfg = createBackupConfig(
+        vaultId: 'vault-confirm',
+        threshold: 2,
+        totalKeys: 2,
+        stewards: [
+          createOwnerSteward(pubkey: alicePubHex, name: 'Alice'),
+          createSteward(pubkey: bobPubHex, name: 'Bob'),
+        ],
+        relays: TestBackupConfigs.simple2of2Relays,
+      );
+      when(mockRepository.getVault('vault-confirm')).thenAnswer((_) async {
+        return Vault(
+          id: 'vault-confirm',
+          name: 'Test',
+          createdAt: DateTime.utc(2024),
+          ownerPubkey: alicePubHex,
+          backupConfig: cfg,
+        );
+      });
+
+      expect(
+        () => service.processShareConfirmationEvent(
+          event: confirmationEvent(
+            stewardPubkey: bobPubHex,
+            tags: [
+              ['vault_id', 'vault-confirm'],
+              ['distribution_version', '3'],
+            ],
+          ),
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('stores stale distribution_version and derives awaitingNewKey', () async {
+      final cfg = createBackupConfig(
+        vaultId: 'vault-confirm',
+        threshold: 2,
+        totalKeys: 2,
+        stewards: [
+          createOwnerSteward(pubkey: alicePubHex, name: 'Alice'),
+          createSteward(pubkey: bobPubHex, name: 'Bob'),
+        ],
+        relays: TestBackupConfigs.simple2of2Relays,
+      ).copyWith(distributionVersion: 3);
+
+      when(mockRepository.getVault('vault-confirm')).thenAnswer((_) async {
+        return Vault(
+          id: 'vault-confirm',
+          name: 'Test',
+          createdAt: DateTime.utc(2024),
+          ownerPubkey: alicePubHex,
+          backupConfig: cfg,
+        );
+      });
+      when(
+        mockRepository.updateStewardStatus(
+          vaultId: anyNamed('vaultId'),
+          pubkey: anyNamed('pubkey'),
+          status: anyNamed('status'),
+          acknowledgedAt: anyNamed('acknowledgedAt'),
+          acknowledgmentEventId: anyNamed('acknowledgmentEventId'),
+          acknowledgedDistributionVersion: anyNamed('acknowledgedDistributionVersion'),
+          giftWrapEventId: anyNamed('giftWrapEventId'),
+        ),
+      ).thenAnswer((_) async {});
+
+      await service.processShareConfirmationEvent(
+        event: confirmationEvent(
+          stewardPubkey: bobPubHex,
+          tags: [
+            ['vault_id', 'vault-confirm'],
+            ['share_index', '1'],
+            ['distribution_version', '2'],
+          ],
+        ),
+      );
+
+      verify(
+        mockRepository.updateStewardStatus(
+          vaultId: 'vault-confirm',
+          pubkey: bobPubHex,
+          acknowledgedAt: anyNamed('acknowledgedAt'),
+          acknowledgmentEventId: anyNamed('acknowledgmentEventId'),
+          acknowledgedDistributionVersion: 2,
+          giftWrapEventId: anyNamed('giftWrapEventId'),
+        ),
+      ).called(1);
+    });
+
+    test('defaults ack version to current when tag is absent', () async {
+      final cfg = createBackupConfig(
+        vaultId: 'vault-confirm',
+        threshold: 2,
+        totalKeys: 2,
+        stewards: [
+          createOwnerSteward(pubkey: alicePubHex, name: 'Alice'),
+          createSteward(pubkey: bobPubHex, name: 'Bob'),
+        ],
+        relays: TestBackupConfigs.simple2of2Relays,
+      ).copyWith(distributionVersion: 3);
+
+      when(mockRepository.getVault('vault-confirm')).thenAnswer((_) async {
+        return Vault(
+          id: 'vault-confirm',
+          name: 'Test',
+          createdAt: DateTime.utc(2024),
+          ownerPubkey: alicePubHex,
+          backupConfig: cfg,
+        );
+      });
+      when(
+        mockRepository.updateStewardStatus(
+          vaultId: anyNamed('vaultId'),
+          pubkey: anyNamed('pubkey'),
+          status: anyNamed('status'),
+          acknowledgedAt: anyNamed('acknowledgedAt'),
+          acknowledgmentEventId: anyNamed('acknowledgmentEventId'),
+          acknowledgedDistributionVersion: anyNamed('acknowledgedDistributionVersion'),
+          giftWrapEventId: anyNamed('giftWrapEventId'),
+        ),
+      ).thenAnswer((_) async {});
+
+      await service.processShareConfirmationEvent(
+        event: confirmationEvent(
+          stewardPubkey: bobPubHex,
+          tags: [
+            ['vault_id', 'vault-confirm'],
+            ['share_index', '1'],
+          ],
+        ),
+      );
+
+      verify(
+        mockRepository.updateStewardStatus(
+          vaultId: 'vault-confirm',
+          pubkey: bobPubHex,
+          acknowledgedAt: anyNamed('acknowledgedAt'),
+          acknowledgmentEventId: anyNamed('acknowledgmentEventId'),
+          acknowledgedDistributionVersion: 3,
+          giftWrapEventId: anyNamed('giftWrapEventId'),
+        ),
+      ).called(1);
+    });
+
+    test('throws when only legacy shard_index tag is present', () async {
+      final cfg = createBackupConfig(
+        vaultId: 'vault-confirm',
+        threshold: 2,
+        totalKeys: 2,
+        stewards: [
+          createOwnerSteward(pubkey: alicePubHex, name: 'Alice'),
+          createSteward(pubkey: bobPubHex, name: 'Bob'),
+        ],
+        relays: TestBackupConfigs.simple2of2Relays,
+      );
+      when(mockRepository.getVault('vault-confirm')).thenAnswer((_) async {
+        return Vault(
+          id: 'vault-confirm',
+          name: 'Test',
+          createdAt: DateTime.utc(2024),
+          ownerPubkey: alicePubHex,
+          backupConfig: cfg,
+        );
+      });
+
+      expect(
+        () => service.processShareConfirmationEvent(
+          event: confirmationEvent(
+            stewardPubkey: bobPubHex,
+            tags: [
+              ['vault_id', 'vault-confirm'],
+              ['shard_index', '1'],
+            ],
+          ),
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
   });
 }

--- a/test/services/share_distribution_service_test.mocks.dart
+++ b/test/services/share_distribution_service_test.mocks.dart
@@ -818,7 +818,7 @@ class MockVaultRepository extends _i1.Mock implements _i7.VaultRepository {
   _i4.Future<void> updateStewardStatus({
     required String? vaultId,
     required String? pubkey,
-    required _i10.StewardStatus? status,
+    _i10.StewardStatus? status,
     DateTime? acknowledgedAt,
     String? acknowledgmentEventId,
     int? acknowledgedDistributionVersion,

--- a/test/services/share_distribution_service_test.mocks.dart
+++ b/test/services/share_distribution_service_test.mocks.dart
@@ -1358,6 +1358,16 @@ class MockNdkService extends _i1.Mock implements _i14.NdkService {
       ) as _i4.Future<void>);
 
   @override
+  _i4.Future<void> setActiveRelays(List<String>? relayUrls) => (super.noSuchMethod(
+        Invocation.method(
+          #setActiveRelays,
+          [relayUrls],
+        ),
+        returnValue: _i4.Future<void>.value(),
+        returnValueForMissingStub: _i4.Future<void>.value(),
+      ) as _i4.Future<void>);
+
+  @override
   _i4.Future<void> removeRelay(String? relayUrl) => (super.noSuchMethod(
         Invocation.method(
           #removeRelay,

--- a/test/services/vault_share_service_test.dart
+++ b/test/services/vault_share_service_test.dart
@@ -237,6 +237,64 @@ void main() {
     );
   });
 
+  group('VaultShareService.sendShareConfirmationEvent wire tags', () {
+    late MockLoginService mockLoginService;
+    late MockNdkService mockNdkService;
+    late MockHorcruxNotificationService mockNotificationService;
+    late VaultShareService service;
+    List<List<String>>? capturedTags;
+
+    setUp(() {
+      mockLoginService = MockLoginService();
+      mockNdkService = MockNdkService();
+      mockNotificationService = MockHorcruxNotificationService();
+      capturedTags = null;
+      when(mockNdkService.getCurrentPubkey()).thenAnswer((_) async => TestHexPubkeys.bob);
+      when(
+        mockNdkService.publishEncryptedEvent(
+          content: anyNamed('content'),
+          kind: anyNamed('kind'),
+          recipientPubkey: anyNamed('recipientPubkey'),
+          relays: anyNamed('relays'),
+          tags: anyNamed('tags'),
+        ),
+      ).thenAnswer((invocation) async {
+        capturedTags = invocation.namedArguments[#tags] as List<List<String>>?;
+        return Nip01Event(
+          kind: NostrKind.shareConfirmation.value,
+          pubKey: TestHexPubkeys.bob,
+          tags: const [],
+          content: '',
+          createdAt: 1,
+        );
+      });
+      service = VaultShareService(
+        VaultRepository(mockLoginService),
+        () => mockNdkService,
+        () => mockNotificationService,
+        () => MockPushNotificationReceiver(),
+      );
+    });
+
+    test('publishes share_index without steward_pubkey tag', () async {
+      await service.sendShareConfirmationEvent(
+        vaultId: 'vault-wire',
+        shareIndex: 2,
+        ownerPubkey: TestHexPubkeys.alice,
+        relayUrls: ['wss://relay.example.com'],
+        distributionVersion: 4,
+      );
+
+      expect(capturedTags, isNotNull);
+      expect(
+        capturedTags!.any((t) => t[0] == 'share_index' && t[1] == '2'),
+        isTrue,
+      );
+      expect(capturedTags!.any((t) => t[0] == 'shard_index'), isFalse);
+      expect(capturedTags!.any((t) => t[0] == 'steward_pubkey'), isFalse);
+    });
+  });
+
   group('VaultShareService steward shard_index placement', () {
     late AppDatabase db;
     late MockLoginService mockLoginService;

--- a/test/services/vault_share_service_test.mocks.dart
+++ b/test/services/vault_share_service_test.mocks.dart
@@ -293,6 +293,16 @@ class MockNdkService extends _i1.Mock implements _i7.NdkService {
       ) as _i5.Future<void>);
 
   @override
+  _i5.Future<void> setActiveRelays(List<String>? relayUrls) => (super.noSuchMethod(
+        Invocation.method(
+          #setActiveRelays,
+          [relayUrls],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   _i5.Future<void> removeRelay(String? relayUrl) => (super.noSuchMethod(
         Invocation.method(
           #removeRelay,


### PR DESCRIPTION
## Summary

Update kind 1337 inbound handlers to use the canonical tag-based format via `shareFromNostr()`, removing the legacy JSON fallback.

### Changes to lib/services/ndk_service.dart

- `loadShareDataFromPublishedDistributionGiftWrap()`: `shareFromJson(json.decode(...))` → `shareFromNostr(inner)`
- `resolveVaultIdForGiftWrap()` case 1337: JSON decode + `_vaultIdFromReader()` → `_firstTagValue(inner.tags, 'vault_id')`
- `_handleShare()`: Legacy JSON fallback try/catch → direct `shareFromNostr(event).copyWith(nostrEventId: event.id)`

### Context
- `shareFromNostr` sets `creatorPubkey` from `event.pubKey` — no changes needed in `vault_share_service.dart` (already reads from Share object)
- All dependencies are closed: 00pj (NDK parsing), 9d0l (shareToNostr/shareFromNostr), gv2v (kind 1337 outbound)

## Bead
`horcrux_app-0s26`