### PR TITLE
Fix relay removal buttons always greyed out

### DIFF
--- a/lib/screens/relay_management_screen.dart
+++ b/lib/screens/relay_management_screen.dart
@@ -33,7 +33,6 @@ class _RelayManagementScreenState extends ConsumerState<RelayManagementScreen> {
 
   int _baselineVaultCount = 0;
   int _liveVaultCount = 0;
-  bool _vaultsLoaded = false;
 
   Timer? _progressTimer;
   double _progressValue = 0.0;
@@ -256,9 +255,6 @@ class _RelayManagementScreenState extends ConsumerState<RelayManagementScreen> {
       if ((_state == _ScanState.scanning || _state == _ScanState.results) && mounted) {
         setState(() => _liveVaultCount = count);
       }
-      if (next.hasValue && !_vaultsLoaded) {
-        setState(() => _vaultsLoaded = true);
-      }
     });
 
     return HorcruxScaffold(
@@ -291,7 +287,9 @@ class _RelayManagementScreenState extends ConsumerState<RelayManagementScreen> {
                 ..._relays.map(
                   (relay) => _RelayRow(
                     relay: relay,
-                    onDelete: _vaultsLoaded ? () => _removeRelay(relay) : null,
+                    onDelete: ref.read(vaultDetailListProvider).hasValue
+                        ? () => _removeRelay(relay)
+                        : null,
                   ),
                 ),
                 const SizedBox(height: 8),

--- a/test/screens/relay_management_screen_test.dart
+++ b/test/screens/relay_management_screen_test.dart
@@ -1,0 +1,86 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:horcrux/models/relay_configuration.dart';
+import 'package:horcrux/providers/vault_provider.dart';
+import 'package:horcrux/screens/relay_management_screen.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../helpers/golden_test_helpers.dart';
+import '../helpers/secure_storage_mock.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final secureStorageMock = SecureStorageMock();
+
+  setUpAll(() {
+    secureStorageMock.setUpAll();
+  });
+
+  tearDownAll(() {
+    secureStorageMock.tearDownAll();
+  });
+
+  // VaultDetailList provider that emits immediately — simulating the real
+  // case where vaults are already loaded when the user navigates here.
+  final loadedVaultListOverride = vaultDetailListProvider.overrideWith(
+    (ref) => Stream.value([]),
+  );
+
+  const String relayConfigsKey = 'relay_configurations';
+  final String seededRelayJson = json.encode([
+    const RelayConfiguration(
+      id: 'horcrux-default',
+      url: 'wss://dev.horcruxbackup.com',
+      name: 'Horcrux Relay',
+      isEnabled: true,
+      isTrusted: false,
+    ).toJson(),
+  ]);
+
+  group('RelayManagementScreen', () {
+    setUp(() async {
+      secureStorageMock.clear();
+      SharedPreferences.setMockInitialValues({
+        relayConfigsKey: seededRelayJson,
+      });
+    });
+
+    testWidgets('delete button is enabled when vault data is already loaded', (tester) async {
+      final harness = GoldenTestHarness.withOverrides(
+        [loadedVaultListOverride],
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ProviderScope(
+            overrides: goldenOverrides([loadedVaultListOverride]),
+            child: const RelayManagementScreen(),
+          ),
+        ),
+      );
+
+      // Wait for relay loading to complete
+      await tester.pumpAndSettle();
+
+      // The close (X) buttons should have a non-null onPressed
+      final closeButtons = find.byIcon(Icons.close);
+      expect(closeButtons, findsOneWidget);
+
+      // Pump a frame after find to ensure build() has run with listen
+      await tester.pump();
+
+      // Navigate up from Icon to IconButton
+      final button = tester.widget<IconButton>(
+        find.ancestor(of: find.byIcon(Icons.close), matching: find.byType(IconButton)).first,
+      );
+      expect(button.onPressed, isNotNull,
+          reason: 'Delete buttons should be enabled when vault data is already loaded. '
+              'If this fails, ref.listen is not firing for the initial provider value.');
+
+      harness.container.dispose();
+    });
+  });
+}


### PR DESCRIPTION
**Bead**: `horcrux_app-gwhu`

Fix: All X (close) buttons on the relay management screen were permanently greyed out. Root cause: `ref.listen(vaultDetailListProvider)` only fires on state **changes**, never the initial value. When vaults are already loaded when the user navigates to the screen, the listener never fires, `_vaultsLoaded` stays `false`, and `onDelete` stays `null`.

## Change

- Removed `_vaultsLoaded` flag entirely
- `onDelete` now checks `ref.read(vaultDetailListProvider).hasValue` inline — evaluates current provider state on every build, no race condition

## Test

- New widget test: verifies `IconButton.onPressed` is non-null when vault data is already loaded (simulates the exact bug scenario)