### PR TITLE
Fix CI Flutter version mismatch (horcrux_app-111o)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version-file: "pubspec.yaml"
+          flutter-version-file: ".fvmrc"
           channel: "stable"
           cache: true
           # Use explicit path instead of wildcard to avoid macOS hashFiles issues


### PR DESCRIPTION
## horcrux_app-111o

Fix the recurring CI codegen drift caused by Flutter version mismatch between local dev and CI.

**Root cause:** CI uses `flutter-version-file: "pubspec.yaml"` which reads the SDK constraint `^3.5.3` and resolves to Flutter 3.35.0 (oldest matching version). Local dev uses `.fvmrc` which pins 3.41.9. The version difference causes `build_runner` to generate different `.mocks.dart` and `.g.dart` files, breaking CI on multiple PRs.

**Fix:** One line change — point CI to `.fvmrc` instead of `pubspec.yaml`. The `subosito/flutter-action@v2` action reads the `flutter` key from `.fvmrc` natively.

**Impact:** This has caused CI failures on PRs #197, #201, #223, #226 and others. Once merged, all future PRs will use the same Flutter version locally and in CI, eliminating codegen drift entirely.