### PR TITLE
Navigate to vault detail after invitation redemption

### DIFF
--- a/lib/screens/invitation_acceptance_screen.dart
+++ b/lib/screens/invitation_acceptance_screen.dart
@@ -12,6 +12,7 @@ import '../widgets/horcrux_scaffold.dart';
 import '../widgets/name_label.dart';
 import '../widgets/row_button.dart';
 import '../widgets/row_button_stack.dart';
+import 'vault_detail_screen.dart';
 
 /// Screen for accepting or denying an invitation link
 ///
@@ -411,26 +412,19 @@ class _InvitationAcceptanceScreenState extends ConsumerState<InvitationAcceptanc
 
     try {
       final invitationService = ref.read(invitationServiceProvider);
-      await invitationService.redeemInvitation(
+      final vaultId = await invitationService.redeemInvitation(
         inviteCode: widget.inviteCode,
         inviteePubkey: inviteePubkey,
       );
 
       if (mounted) {
-        context.showHorcruxSnackBar(
-          'Invitation accepted successfully!',
-          kind: HorcruxSnackKind.success,
+        // Remove the invitation screen and navigate to vault detail
+        Navigator.pushReplacement(
+          context,
+          MaterialPageRoute(
+            builder: (context) => VaultDetailScreen(vaultId: vaultId),
+          ),
         );
-
-        // Refresh the invitation data
-        ref.invalidate(invitationByCodeProvider(widget.inviteCode));
-
-        // Navigate back after a short delay
-        Future.delayed(const Duration(milliseconds: 500), () {
-          if (mounted) {
-            Navigator.pop(context);
-          }
-        });
       }
     } on InvitationAlreadyRedeemedException {
       setState(() {

--- a/lib/services/invitation_service.dart
+++ b/lib/services/invitation_service.dart
@@ -312,7 +312,7 @@ class InvitationService {
   /// Adds invitee to backup config as steward.
   /// Sends invitation acceptance event via InvitationSendingService.
   /// Updates invitation tracking.
-  Future<void> redeemInvitation({
+  Future<String> redeemInvitation({
     required String inviteCode,
     required String inviteePubkey, // Hex format
   }) async {
@@ -464,6 +464,7 @@ class InvitationService {
     _notifyInvitationsChanged();
 
     Log.info('Redeemed invitation $inviteCode by invitee $inviteePubkey');
+    return invitation.vaultId;
   }
 
   /// Processes invitation denial when invitee declines


### PR DESCRIPTION
**Bead**: `horcrux_app-7irc`

After accepting an invitation, navigates directly to the vault detail screen instead of popping back to the vault list. User no longer has to manually find the newly-accepted vault.

## Changes

1. **`redeemInvitation` returns vault ID** — `Future<String>` instead of `Future<void>`. Returns `invitation.vaultId` on success.
2. **`_acceptInvitation` navigates to VaultDetailScreen** — uses `Navigator.pushReplacement` so the invitation screen is removed from the stack (back button goes to vault list, not back to invitation). Replaces the old snackbar + 500ms delay + pop flow.

## Navigation stack

| Before | After |
|--------|-------|
| VaultList → InvitationAccept → pop → VaultList | VaultList → InvitationAccept → pushReplacement → VaultDetail |