### PR TITLE
Fix: recovery response dedup — gate misleading log, improve log messages, remove _backfillNostrEventId (horcrux_app-rhmo)

### DIFF
--- a/lib/services/ndk_service.dart
+++ b/lib/services/ndk_service.dart
@@ -742,7 +742,7 @@ class NdkService {
       ),
     );
 
-    await _ref.read(recoveryServiceProvider).processRecoveryResponse(
+    final processed = await _ref.read(recoveryServiceProvider).processRecoveryResponse(
           recoveryRequestId,
           senderPubkey,
           approved,
@@ -752,9 +752,12 @@ class NdkService {
           allowLocalNotification: allowLocalNotification,
         );
 
-    Log.info(
-      'Persisted recovery response: $recoveryRequestId from $senderPubkey',
-    );
+    if (processed) {
+      Log.info(
+        'Persisted recovery response: $recoveryRequestId from '
+        '${senderPubkey.substring(0, 8)}...',
+      );
+    }
   }
 
   /// Handle incoming invitation acceptance event (kind 1340). Errors propagate

--- a/lib/services/recovery_service.dart
+++ b/lib/services/recovery_service.dart
@@ -753,7 +753,12 @@ class RecoveryService {
           // nostrEventId (first check) rather than by respondedAt (second
           // check). This also improves log clarity — the echo shows
           // 'duplicate' instead of 'already processed'.
-          unawaited(_backfillNostrEventId(request.vaultId, recoveryRequestId, eventId));
+          unawaited(_backfillNostrEventId(
+            request.vaultId,
+            recoveryRequestId,
+            responderPubkey,
+            eventId,
+          ));
         } else {
           Log.warning('No relay URLs available for sending recovery response');
         }
@@ -1223,28 +1228,29 @@ class RecoveryService {
   Future<void> _backfillNostrEventId(
     String vaultId,
     String recoveryRequestId,
+    String responderPubkey,
     String eventId,
   ) async {
     try {
       final request = await getRecoveryRequest(recoveryRequestId);
       if (request == null) return;
-      for (final response in request.responses) {
-        if (response.nostrEventId == null && response.respondedAt != null) {
-          final updated = response.copyWith(nostrEventId: eventId);
-          final updatedRequest = request.withUpsertedResponse(response: updated);
-          await repository.updateRecoveryRequestInVault(
-            vaultId,
-            recoveryRequestId,
-            updatedRequest,
-          );
-          Log.info(
-            'Backfilled nostrEventId for response from '
-            '${response.pubkey.substring(0, 8)}... '
-            '(event: ${eventId.substring(0, 8)}...)',
-          );
-          return;
-        }
+      // Find the response for THIS pubkey (not the first match)
+      final existing = request.responseForPubkey(responderPubkey);
+      if (existing == null || existing.nostrEventId != null || existing.respondedAt == null) {
+        return;
       }
+      final updated = existing.copyWith(nostrEventId: eventId);
+      final updatedRequest = request.withUpsertedResponse(response: updated);
+      await repository.updateRecoveryRequestInVault(
+        vaultId,
+        recoveryRequestId,
+        updatedRequest,
+      );
+      Log.info(
+        'Backfilled nostrEventId for response from '
+        '${responderPubkey.substring(0, 8)}... '
+        '(event: ${eventId.substring(0, 8)}...)',
+      );
     } catch (e) {
       Log.error('Failed to backfill nostrEventId for recovery response', e);
     }

--- a/lib/services/recovery_service.dart
+++ b/lib/services/recovery_service.dart
@@ -747,18 +747,6 @@ class RecoveryService {
           Log.info(
             'Sent recovery response via Nostr for request $recoveryRequestId (approved: $approved, event: ${eventId.substring(0, 8)}...)',
           );
-
-          // Backfill the nostrEventId on the persisted response so that
-          // when the relay echo arrives, the duplicate check matches by
-          // nostrEventId (first check) rather than by respondedAt (second
-          // check). This also improves log clarity — the echo shows
-          // 'duplicate' instead of 'already processed'.
-          unawaited(_backfillNostrEventId(
-            request.vaultId,
-            recoveryRequestId,
-            responderPubkey,
-            eventId,
-          ));
         } else {
           Log.warning('No relay URLs available for sending recovery response');
         }
@@ -1220,40 +1208,6 @@ class RecoveryService {
     _isInitialized = false;
     _viewedNotificationIds = null;
     await initialize();
-  }
-
-  /// After sending a recovery response via Nostr, backfill the event id on the
-  /// persisted response so the relay echo can be matched by nostrEventId (first
-  /// check in [processRecoveryResponse]) rather than by respondedAt (second check).
-  Future<void> _backfillNostrEventId(
-    String vaultId,
-    String recoveryRequestId,
-    String responderPubkey,
-    String eventId,
-  ) async {
-    try {
-      final request = await getRecoveryRequest(recoveryRequestId);
-      if (request == null) return;
-      // Find the response for THIS pubkey (not the first match)
-      final existing = request.responseForPubkey(responderPubkey);
-      if (existing == null || existing.nostrEventId != null || existing.respondedAt == null) {
-        return;
-      }
-      final updated = existing.copyWith(nostrEventId: eventId);
-      final updatedRequest = request.withUpsertedResponse(response: updated);
-      await repository.updateRecoveryRequestInVault(
-        vaultId,
-        recoveryRequestId,
-        updatedRequest,
-      );
-      Log.info(
-        'Backfilled nostrEventId for response from '
-        '${responderPubkey.substring(0, 8)}... '
-        '(event: ${eventId.substring(0, 8)}...)',
-      );
-    } catch (e) {
-      Log.error('Failed to backfill nostrEventId for recovery response', e);
-    }
   }
 }
 

--- a/lib/services/recovery_service.dart
+++ b/lib/services/recovery_service.dart
@@ -542,13 +542,15 @@ class RecoveryService {
   /// Merges one steward's recovery response into local vault state (from Nostr or from this device).
   ///
   /// Since events are immutable, we skip processing if the response already exists.
+  /// Returns `true` when the response was actually processed, `false` when it was
+  /// skipped (duplicate or already processed).
   ///
   /// When [recoveryResponseSourceEvent] is set (relay-delivered event), may show a local OS
   /// notification per [RecoveryNotificationPolicy]. Local-only applies omit it. Pass
   /// `allowLocalNotification: false` when the caller has already shown the user a
   /// notification for this event (e.g. an FCM push the user just tapped) so we do
   /// not double-notify.
-  Future<void> processRecoveryResponse(
+  Future<bool> processRecoveryResponse(
     String recoveryRequestId,
     String responderPubkey,
     bool approved, {
@@ -571,16 +573,19 @@ class RecoveryService {
       // Check if this is a duplicate by comparing nostrEventId if provided
       if (nostrEventId != null && existingResponse.nostrEventId == nostrEventId) {
         Log.info(
-          'Ignoring duplicate recovery response for request $recoveryRequestId from $responderPubkey (nostrEventId: $nostrEventId)',
+          'Ignoring duplicate recovery response for request $recoveryRequestId from '
+          '${responderPubkey.substring(0, 8)}... (nostrEventId: $nostrEventId)',
         );
-        return;
+        return false;
       }
       // If response already exists and has respondedAt, skip processing (immutable event)
       if (existingResponse.respondedAt != null) {
         Log.info(
-          'Ignoring recovery response for request $recoveryRequestId from $responderPubkey - response already exists',
+          'Ignoring recovery response for request $recoveryRequestId from '
+          '${responderPubkey.substring(0, 8)}... - already processed '
+          '(respondedAt=${existingResponse.respondedAt})',
         );
-        return;
+        return false;
       }
     }
 
@@ -650,8 +655,10 @@ class RecoveryService {
     }
 
     Log.info(
-      'Updated recovery request $recoveryRequestId with response from ${responderPubkey.substring(0, 8)}... (approved: $approved)',
+      'Updated recovery request $recoveryRequestId with response from '
+      '${responderPubkey.substring(0, 8)}... (approved: $approved)',
     );
+    return true;
   }
 
   /// Approve or deny a recovery request with automatic shard data retrieval and Nostr sending
@@ -731,15 +738,22 @@ class RecoveryService {
         }
 
         if (relayUrls.isNotEmpty) {
-          await sendRecoveryResponseViaNostr(
+          final eventId = await sendRecoveryResponseViaNostr(
             request,
             stewardShare,
             approved,
             relays: relayUrls,
           );
           Log.info(
-            'Sent recovery response via Nostr for request $recoveryRequestId (approved: $approved)',
+            'Sent recovery response via Nostr for request $recoveryRequestId (approved: $approved, event: ${eventId.substring(0, 8)}...)',
           );
+
+          // Backfill the nostrEventId on the persisted response so that
+          // when the relay echo arrives, the duplicate check matches by
+          // nostrEventId (first check) rather than by respondedAt (second
+          // check). This also improves log clarity — the echo shows
+          // 'duplicate' instead of 'already processed'.
+          unawaited(_backfillNostrEventId(request.vaultId, recoveryRequestId, eventId));
         } else {
           Log.warning('No relay URLs available for sending recovery response');
         }
@@ -1201,6 +1215,39 @@ class RecoveryService {
     _isInitialized = false;
     _viewedNotificationIds = null;
     await initialize();
+  }
+
+  /// After sending a recovery response via Nostr, backfill the event id on the
+  /// persisted response so the relay echo can be matched by nostrEventId (first
+  /// check in [processRecoveryResponse]) rather than by respondedAt (second check).
+  Future<void> _backfillNostrEventId(
+    String vaultId,
+    String recoveryRequestId,
+    String eventId,
+  ) async {
+    try {
+      final request = await getRecoveryRequest(recoveryRequestId);
+      if (request == null) return;
+      for (final response in request.responses) {
+        if (response.nostrEventId == null && response.respondedAt != null) {
+          final updated = response.copyWith(nostrEventId: eventId);
+          final updatedRequest = request.withUpsertedResponse(response: updated);
+          await repository.updateRecoveryRequestInVault(
+            vaultId,
+            recoveryRequestId,
+            updatedRequest,
+          );
+          Log.info(
+            'Backfilled nostrEventId for response from '
+            '${response.pubkey.substring(0, 8)}... '
+            '(event: ${eventId.substring(0, 8)}...)',
+          );
+          return;
+        }
+      }
+    } catch (e) {
+      Log.error('Failed to backfill nostrEventId for recovery response', e);
+    }
   }
 }
 

--- a/test/services/logout_service_test.mocks.dart
+++ b/test/services/logout_service_test.mocks.dart
@@ -769,7 +769,7 @@ class MockRecoveryService extends _i1.Mock implements _i13.RecoveryService {
       ) as _i8.Future<_i14.RecoveryStatus?>);
 
   @override
-  _i8.Future<void> processRecoveryResponse(
+  _i8.Future<bool> processRecoveryResponse(
     String? recoveryRequestId,
     String? responderPubkey,
     bool? approved, {
@@ -793,9 +793,9 @@ class MockRecoveryService extends _i1.Mock implements _i13.RecoveryService {
             #allowLocalNotification: allowLocalNotification,
           },
         ),
-        returnValue: _i8.Future<void>.value(),
-        returnValueForMissingStub: _i8.Future<void>.value(),
-      ) as _i8.Future<void>);
+        returnValue: _i8.Future<bool>.value(false),
+        returnValueForMissingStub: _i8.Future<bool>.value(false),
+      ) as _i8.Future<bool>);
 
   @override
   _i8.Future<void> respondToRecoveryRequestWithShare(

--- a/test/services/recovery_service_test.dart
+++ b/test/services/recovery_service_test.dart
@@ -995,6 +995,218 @@ void main() {
     );
   });
 
+  group('processRecoveryResponse dedup', () {
+    late String testCreatorPubkey;
+    late LoginService loginService;
+    late VaultRepository repository;
+    late BackupService backupService;
+    late NdkService ndkService;
+    late MockLocalNotificationService mockLocalNotificationService;
+    late RecoveryService recoveryService;
+    late AppDatabase testDb;
+    const testKeyHolder1 = 'fedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321';
+    const testVaultId = 'vault-dedup-test';
+
+    setUp(() async {
+      secureStorageMock.clear();
+      loginService = LoginService();
+      await loginService.clearStoredKeys();
+      LoginService.resetCache();
+
+      final keyPair = await loginService.generateAndStoreNostrKey();
+      testCreatorPubkey = keyPair.publicKey;
+
+      testDb = newTestDatabase();
+      repository = VaultRepository(loginService, db: testDb);
+
+      final mockBackupService = MockBackupService();
+      final mockNdkService = MockNdkService();
+      mockLocalNotificationService = MockLocalNotificationService();
+      when(
+        mockLocalNotificationService.notifyRecoveryRequestProcessed(any),
+      ).thenAnswer((_) async {});
+      when(
+        mockLocalNotificationService.notifyRecoveryResponseProcessed(any),
+      ).thenAnswer((_) async {});
+      when(
+        mockNdkService.getCurrentPubkey(),
+      ).thenAnswer((_) async => testCreatorPubkey);
+
+      backupService = mockBackupService;
+      ndkService = mockNdkService;
+      final mockHorcruxNotificationService = MockHorcruxNotificationService();
+      when(
+        mockHorcruxNotificationService.tryPushForEvent(
+          event: anyNamed('event'),
+          kind: anyNamed('kind'),
+          vault: anyNamed('vault'),
+          relayHints: anyNamed('relayHints'),
+          recoveryApproved: anyNamed('recoveryApproved'),
+        ),
+      ).thenAnswer((_) async {});
+
+      recoveryService = RecoveryService(
+        repository,
+        backupService,
+        ndkService,
+        ProcessedNostrEventStore(),
+        mockLocalNotificationService,
+        mockHorcruxNotificationService,
+        testDb,
+      );
+      await recoveryService.clearAll();
+      await repository.clearAll();
+
+      // Create a test vault for recovery tests
+      final testVault = Vault(
+        id: testVaultId,
+        name: 'Dedup Test Vault',
+        createdAt: DateTime.now(),
+        ownerPubkey: testCreatorPubkey,
+      );
+      await repository.addVault(testVault);
+
+      final relayPlan = createBackupConfig(
+        vaultId: testVaultId,
+        threshold: 1,
+        totalKeys: 1,
+        stewards: [
+          createSteward(pubkey: testKeyHolder1).copyWith(status: StewardStatus.holdingKey),
+        ],
+        relays: ['wss://relay.example.com'],
+      );
+      await repository.updateBackupConfig(testVaultId, relayPlan);
+    });
+
+    tearDown(() async {
+      await repository.clearAll();
+      await loginService.clearStoredKeys();
+      LoginService.resetCache();
+      await testDb.close();
+    });
+
+    test('first response from a steward returns true', () async {
+      final request = await recoveryService.initiateRecovery(
+        testVaultId,
+        initiatorPubkey: testCreatorPubkey,
+        stewardPubkeys: [testKeyHolder1],
+        threshold: 1,
+      );
+
+      final result = await recoveryService.processRecoveryResponse(
+        request.id,
+        testKeyHolder1,
+        true,
+      );
+
+      expect(result, isTrue);
+    });
+
+    test('duplicate response by nostrEventId returns false', () async {
+      final request = await recoveryService.initiateRecovery(
+        testVaultId,
+        initiatorPubkey: testCreatorPubkey,
+        stewardPubkeys: [testKeyHolder1],
+        threshold: 1,
+      );
+
+      // First response with a nostrEventId
+      final first = await recoveryService.processRecoveryResponse(
+        request.id,
+        testKeyHolder1,
+        true,
+        nostrEventId: 'event-abc123',
+      );
+      expect(first, isTrue);
+
+      // Relay echo arrives with the same nostrEventId
+      final echo = await recoveryService.processRecoveryResponse(
+        request.id,
+        testKeyHolder1,
+        true,
+        nostrEventId: 'event-abc123',
+      );
+      expect(echo, isFalse);
+
+      // Verify only one response is stored
+      final updated = await recoveryService.getRecoveryRequest(request.id);
+      expect(updated!.responses.length, 1);
+      expect(updated.responseForPubkey(testKeyHolder1)!.nostrEventId, 'event-abc123');
+    });
+
+    test('duplicate response by respondedAt returns false', () async {
+      final request = await recoveryService.initiateRecovery(
+        testVaultId,
+        initiatorPubkey: testCreatorPubkey,
+        stewardPubkeys: [testKeyHolder1],
+        threshold: 1,
+      );
+
+      // First response without nostrEventId (simulates local auto-approve)
+      final first = await recoveryService.processRecoveryResponse(
+        request.id,
+        testKeyHolder1,
+        true,
+      );
+      expect(first, isTrue);
+
+      // Relay echo arrives without matching nostrEventId
+      // (backfill hasn't completed yet)
+      final echo = await recoveryService.processRecoveryResponse(
+        request.id,
+        testKeyHolder1,
+        true,
+        nostrEventId: 'event-xyz789',
+      );
+      expect(echo, isFalse);
+    });
+
+    test('different steward responses are both accepted', () async {
+      const testKeyHolder2 = 'abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdef1234';
+      final request = await recoveryService.initiateRecovery(
+        testVaultId,
+        initiatorPubkey: testCreatorPubkey,
+        stewardPubkeys: [testKeyHolder1, testKeyHolder2],
+        threshold: 2,
+      );
+
+      final result1 = await recoveryService.processRecoveryResponse(
+        request.id,
+        testKeyHolder1,
+        true,
+        nostrEventId: 'event-steward1',
+      );
+      expect(result1, isTrue);
+
+      final result2 = await recoveryService.processRecoveryResponse(
+        request.id,
+        testKeyHolder2,
+        true,
+        nostrEventId: 'event-steward2',
+      );
+      expect(result2, isTrue);
+    });
+
+    test('response without existing placeholder is accepted', () async {
+      // If a response arrives from a pubkey not in the placeholder list,
+      // processRecoveryResponse should still accept it (creates new entry)
+      const unknownSteward = '1111111111111111111111111111111111111111111111111111111111111111';
+      final request = await recoveryService.initiateRecovery(
+        testVaultId,
+        initiatorPubkey: testCreatorPubkey,
+        stewardPubkeys: [testKeyHolder1],
+        threshold: 1,
+      );
+
+      final result = await recoveryService.processRecoveryResponse(
+        request.id,
+        unknownSteward,
+        true,
+        nostrEventId: 'event-unknown',
+      );
+      expect(result, isTrue);
+    });
+  });
   group('RecoveryService - performRecovery', () {
     late String testCreatorPubkey;
     late LoginService loginService;

--- a/test/services/vault_share_service_test.dart
+++ b/test/services/vault_share_service_test.dart
@@ -980,6 +980,7 @@ void main() {
     late MockNdkService mockNdkService;
     late MockHorcruxNotificationService mockNotificationService;
     late MockPushNotificationReceiver mockPushReceiver;
+    late MockRelayScanService mockRelayScanService;
     late VaultRepository repository;
     late VaultShareService service;
 
@@ -995,6 +996,7 @@ void main() {
           .thenAnswer((_) async => stewardPubkey);
       mockNotificationService = MockHorcruxNotificationService();
       mockPushReceiver = MockPushNotificationReceiver();
+      mockRelayScanService = MockRelayScanService();
 
       repository = VaultRepository(mockLoginService);
       service = VaultShareService(
@@ -1002,6 +1004,7 @@ void main() {
         () => mockNdkService,
         () => mockNotificationService,
         () => mockPushReceiver,
+        () => mockRelayScanService,
       );
     });
 

--- a/test/services/vault_share_service_test.dart
+++ b/test/services/vault_share_service_test.dart
@@ -934,4 +934,147 @@ void main() {
       },
     );
   });
+
+  group('processKeyHolderRemoval', () {
+    const ownerPubkey = TestHexPubkeys.alice;
+    const stewardPubkey = TestHexPubkeys.bob;
+    const vaultId = 'test-removal-vault';
+
+    late MockLoginService mockLoginService;
+    late MockNdkService mockNdkService;
+    late MockHorcruxNotificationService mockNotificationService;
+    late MockPushNotificationReceiver mockPushReceiver;
+    late VaultRepository repository;
+    late VaultShareService service;
+
+    setUp(() {
+      mockLoginService = MockLoginService();
+      when(mockLoginService.encryptText(any))
+          .thenAnswer((inv) async => inv.positionalArguments[0] as String);
+      when(mockLoginService.decryptText(any))
+          .thenAnswer((inv) async => inv.positionalArguments[0] as String);
+
+      mockNdkService = MockNdkService();
+      when(mockNdkService.getCurrentPubkey())
+          .thenAnswer((_) async => stewardPubkey);
+      mockNotificationService = MockHorcruxNotificationService();
+      mockPushReceiver = MockPushNotificationReceiver();
+
+      repository = VaultRepository(mockLoginService);
+      service = VaultShareService(
+        repository,
+        () => mockNdkService,
+        () => mockNotificationService,
+        () => mockPushReceiver,
+      );
+    });
+
+    tearDown(() async {
+      await repository.clearAll();
+    });
+
+    Nip01Event makeRemovalEvent({String? vaultIdTag}) {
+      return Nip01Event(
+        kind: NostrKind.keyHolderRemoved.value,
+        pubKey: ownerPubkey,
+        tags: [
+          ['vault_id', vaultIdTag ?? vaultId],
+        ],
+        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        content: '', // canonical format: vault_id is in tags, not content
+      );
+    }
+
+    Future<void> addTestVaultWithShare() async {
+      final vault = Vault(
+        id: vaultId,
+        name: 'Test Vault',
+        createdAt: DateTime.now(),
+        ownerPubkey: ownerPubkey,
+      );
+      await repository.addVault(vault);
+      final share = createShare(
+        payload: 'test-shard-payload',
+        threshold: 1,
+        shareIndex: 0,
+        totalShares: 2,
+        primeMod: 'test-prime-mod',
+        creatorPubkey: ownerPubkey,
+        vaultId: vaultId,
+      );
+      await repository.addShareToVault(vaultId, share);
+    }
+
+    test('archives the vault with reason Removed by owner', () async {
+      await addTestVaultWithShare();
+      final event = makeRemovalEvent();
+      await service.processKeyHolderRemoval(event: event);
+
+      final vault = await repository.getVault(vaultId);
+      expect(vault, isNotNull);
+      expect(vault!.isArchived, isTrue);
+      expect(vault.archivedReason, 'Removed by owner');
+    });
+
+    test('removes the held share', () async {
+      await addTestVaultWithShare();
+      // Verify share exists before removal
+      final sharesBefore = await repository.getSharesForVault(vaultId);
+      expect(sharesBefore, isNotEmpty);
+
+      final event = makeRemovalEvent();
+      await service.processKeyHolderRemoval(event: event);
+
+      final sharesAfter = await repository.getSharesForVault(vaultId);
+      expect(sharesAfter, isEmpty);
+    });
+
+    test('reads vault_id from tags (canonical format)', () async {
+      await addTestVaultWithShare();
+      // The fix for T1: vault_id comes from tags, not JSON content
+      final event = makeRemovalEvent();
+      expect(event.content, isEmpty); // content is empty in canonical format
+      await service.processKeyHolderRemoval(event: event);
+
+      // Verify it processed successfully by checking the vault is archived
+      final vault = await repository.getVault(vaultId);
+      expect(vault!.isArchived, isTrue);
+    });
+
+    test('throws ArgumentError when vault_id tag is missing', () async {
+      final event = Nip01Event(
+        kind: NostrKind.keyHolderRemoved.value,
+        pubKey: ownerPubkey,
+        tags: [], // no vault_id tag
+        createdAt: 1,
+        content: '',
+      );
+
+      expect(
+        () => service.processKeyHolderRemoval(event: event),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('throws ArgumentError on wrong event kind', () async {
+      final event = Nip01Event(
+        kind: 9999, // wrong kind
+        pubKey: ownerPubkey,
+        tags: [['vault_id', vaultId]],
+        createdAt: 1,
+        content: '',
+      );
+
+      expect(
+        () => service.processKeyHolderRemoval(event: event),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('no-ops when vault not found (already deleted)', () async {
+      final event = makeRemovalEvent(vaultIdTag: 'nonexistent-vault');
+      // Should not throw, just log and return
+      await service.processKeyHolderRemoval(event: event);
+    });
+  });
 }


### PR DESCRIPTION
## Summary
Fixes confusing dedup behavior when relay echoes arrive for auto-approved recovery responses.

## Three changes
1. **`processRecoveryResponse` returns `bool`** — `true` when response was actually persisted, `false` when skipped (duplicate/already processed). The misleading "Persisted recovery response" log in `ndk_service.dart` is gated on the return value.
2. **Improved log messages** — all dedup logs show truncated pubkeys (8 chars) and include context about why a response was skipped (duplicate nostrEventId vs already processed).
3. **Removed `_backfillNostrEventId`** — unnecessary defensive complexity. The existing `respondedAt` dedup check already handles the relay echo correctly. Removed the method and its call site entirely per project owner request.

## Tests
5 new dedup tests in `recovery_service_test.dart`:
- first response from a steward returns true
- duplicate response by nostrEventId returns false
- duplicate response by respondedAt returns false
- different steward responses are both accepted
- response without existing placeholder is accepted

All 491 tests pass. Static analysis clean.

Bead: `horcrux_app-rhmo`