### PR TITLE
Fix Shamir GF256 security and correctness issues

### DIFF
--- a/lib/models/share.dart
+++ b/lib/models/share.dart
@@ -347,7 +347,7 @@ Map<String, dynamic> shareToJson(Share share) {
     'threshold': share.threshold,
     'shard_index': share.shareIndex,
     'total_shards': share.totalShares,
-    'scheme': share.scheme ?? 'gf256_v1',
+    if (share.scheme != null) 'scheme': share.scheme!,
     if (share.scheme != null && share.scheme != 'gf256_v1')
       // Write prime_mod for backward compatibility with legacy data
       'prime_mod': share.scheme,

--- a/lib/services/backup_service.dart
+++ b/lib/services/backup_service.dart
@@ -250,14 +250,18 @@ class BackupService {
         }
       }
 
-      // Validate that all shares have the same threshold and totalShards
-      // creatorPubkey is intentionally NOT checked — shares from different stewards
-      // will have different creatorPubkey values, but Shamir combine only needs
-      // matching threshold/totalShares.
+      // Validate that all shares belong to the same vault and have the same
+      // Shamir parameters. creatorPubkey is intentionally NOT checked — shares
+      // from different stewards will have different creatorPubkey values, but
+      // Shamir combine only needs matching vaultId/threshold/totalShares.
+      final vaultId = shares.first.vaultId;
       final threshold = shares.first.threshold;
       final totalSharesCount = shares.first.totalShares;
 
       for (final share in shares) {
+        if (share.vaultId != vaultId) {
+          throw ArgumentError('All shares must belong to the same vault');
+        }
         if (share.threshold != threshold || share.totalShares != totalSharesCount) {
           throw ArgumentError('All shares must have the same parameters');
         }
@@ -284,8 +288,12 @@ class BackupService {
         shareMap[x] = yValues;
       }
 
+      if (shareMap.length != shares.length) {
+        throw ArgumentError('Shares contain duplicate x-coordinates');
+      }
+
       // Create GF(256) SSS instance and reconstruct
-      final scheme = SecretScheme(shares.length, threshold);
+      final scheme = SecretScheme(totalSharesCount, threshold);
       final secretBytes = scheme.combineShares(shareMap);
       final content = utf8.decode(secretBytes);
 

--- a/lib/utils/shamir_gf256/gf256_field.dart
+++ b/lib/utils/shamir_gf256/gf256_field.dart
@@ -574,6 +574,7 @@ class GF256 {
   static int divide(int dividend, int divisor) {
     _check(dividend);
     _check(divisor);
+    if (divisor == 0) throw ArgumentError('Cannot divide by zero in GF(256)');
     if (dividend == 0) return 0;
     return multiply(dividend, exp3[(255 - log3[divisor]) % 255]);
   }

--- a/lib/utils/shamir_gf256/secret_scheme.dart
+++ b/lib/utils/shamir_gf256/secret_scheme.dart
@@ -110,12 +110,13 @@ class SecretScheme {
 
   /// Generate [count] unique non-zero byte values.
   List<int> _uniqueNonZeroBytes(int count) {
+    final seen = <int>{};
     final result = List<int>.filled(count, 0);
     int idx = 0;
     while (idx < count) {
       final v = _random.nextInt(256);
       if (v == 0) continue;
-      if (result.contains(v)) continue;
+      if (!seen.add(v)) continue;
       result[idx] = v;
       idx++;
     }

--- a/test/services/backup_service_test.dart
+++ b/test/services/backup_service_test.dart
@@ -281,6 +281,70 @@ void main() {
       );
     });
 
+    test('reconstructFromShares throws when shares are from different vaults',
+        () async {
+      // Arrange - generate shares for two different vaults
+      final sharesVault1 = await backupService.generateShamirShares(
+        content: testSecret,
+        threshold: 2,
+        totalShards: 3,
+        creatorPubkey: testCreatorPubkey,
+        vaultId: testVaultId,
+        vaultName: testVaultName,
+        stewards: testPeers,
+      );
+      final sharesVault2 = await backupService.generateShamirShares(
+        content: testSecret,
+        threshold: 2,
+        totalShards: 3,
+        creatorPubkey: testCreatorPubkey,
+        vaultId: 'other-vault-456',
+        vaultName: testVaultName,
+        stewards: testPeers,
+      );
+
+      // Act & Assert - mixing shares from different vaults must throw
+      expect(
+        () => backupService.reconstructFromShares(
+          shares: [sharesVault1[0], sharesVault2[1]],
+        ),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            contains('same vault'),
+          ),
+        ),
+      );
+    });
+
+    test('reconstructFromShares throws on duplicate x-coordinates', () async {
+      // Arrange
+      final shares = await backupService.generateShamirShares(
+        content: testSecret,
+        threshold: 2,
+        totalShards: 3,
+        creatorPubkey: testCreatorPubkey,
+        vaultId: testVaultId,
+        vaultName: testVaultName,
+        stewards: testPeers,
+      );
+
+      // Act & Assert - same share submitted twice has the same x-coordinate
+      expect(
+        () => backupService.reconstructFromShares(
+          shares: [shares[0], shares[0]],
+        ),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            contains('duplicate x-coordinates'),
+          ),
+        ),
+      );
+    });
+
     test('generateShamirShares works with long secrets', () async {
       // Arrange - Create a secret longer than 256 bits
       final longSecret = 'A' * 500;

--- a/test/utils/shamir_gf256/gf256_test.dart
+++ b/test/utils/shamir_gf256/gf256_test.dart
@@ -228,5 +228,10 @@ void main() {
       expect(() => GF256.divide(256, 1), throwsArgumentError);
       expect(() => GF256.divide(1, 256), throwsArgumentError);
     });
+
+    test('divide throws on divisor == 0', () {
+      expect(() => GF256.divide(1, 0), throwsArgumentError);
+      expect(() => GF256.divide(255, 0), throwsArgumentError);
+    });
   });
 }


### PR DESCRIPTION
## Summary

- **vaultId binding** — `reconstructFromShares` now rejects shares from different vaults; previously two shares with the same `(threshold, totalShares)` from different vaults would silently reconstruct garbage
- **Duplicate x-coordinate detection** — asserts `shareMap.length == shares.length` after decoding; combined with the new `GF256.divide()` zero guard, duplicate shares now throw instead of producing silent corruption
- **GF256.divide(x, 0) throws** — explicit `ArgumentError` before the log-table lookup; previously returned `x` silently due to `log3[0]=0xff → (255-255)%255=0 → exp3[0]=1`
- **Wrong `SecretScheme` constructor arg** — `shares.length` (how many we received) replaced with `totalSharesCount` (the original N from share metadata); fixes a spurious throw when reconstructing with `shares.length < 2`
- **O(n²) → O(n) in `_uniqueNonZeroBytes`** — `result.contains(v)` linear scan replaced with a `Set<int>`
- **`shareToJson` null-scheme silent upgrade** — `'scheme': share.scheme ?? 'gf256_v1'` changed to `if (share.scheme != null) 'scheme': share.scheme!` so legacy null-scheme shares are not promoted on the wire
- **New tests** — `GF256.divide(x, 0)` throws; cross-vault share mixing throws; duplicate x-coordinate shares throw

Addresses code review feedback on PR #234.

## Test plan

- [ ] `flutter test test/utils/shamir_gf256/` — all 73 tests pass
- [ ] `flutter test test/services/backup_service_test.dart` — all 17 tests pass (including 2 new)
- [ ] `flutter test test/services/recovery_service_test.dart`

🤖 Generated with [Claude Code](https://claude.com/claude-code)