### PR TITLE
Fix vault share owner validation

### DIFF
--- a/lib/services/backup_service.dart
+++ b/lib/services/backup_service.dart
@@ -822,7 +822,7 @@ class BackupService {
         stewards.add(stewardMap);
       }
 
-      final shards = await generateShamirShares(
+      final shares = await generateShamirShares(
         content: content,
         threshold: configToDistribute.threshold,
         totalShards: configToDistribute.totalKeys,
@@ -836,13 +836,13 @@ class BackupService {
         // (or re-learn, on redistribution) whether this vault uses push.
         pushEnabled: vaultDetail.pushEnabled,
       );
-      Log.info('Generated ${shards.length} Shamir shares');
+      Log.info('Generated ${shares.length} Shamir shares');
 
       // Step 6: Distribute shards using injected service
       await _shareDistributionService.distributeShares(
         ownerPubkey: creatorPubkey,
         config: configToDistribute,
-        shares: shards,
+        shares: shares,
       );
       Log.info('Successfully distributed all shards');
 

--- a/lib/services/ndk_service.dart
+++ b/lib/services/ndk_service.dart
@@ -4,6 +4,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:ndk/entities.dart' show GiftWrapUnwrapResult;
 import 'package:ndk/ndk.dart';
 import '../database/app_database_provider.dart';
 import '../providers/key_provider.dart';
@@ -44,6 +45,11 @@ int computeSinceTime({
     return 0;
   }
   return math.min(windowStartSec, last);
+}
+
+@visibleForTesting
+bool isVerifiedGiftWrapUnwrapResult(GiftWrapUnwrapResult result) {
+  return result.isSealSignatureValid && result.isPubkeyMatch;
 }
 
 /// Event emitted when a recovery response is received
@@ -526,7 +532,22 @@ class NdkService {
     try {
       Log.info('Received subscription Nostr event: ${event.id}');
 
-      final unwrappedEvent = await _ndk!.giftWrap.fromGiftWrap(giftWrap: event);
+      final unwrapResult = await _ndk!.giftWrap.fromGiftWrapWithInfo(
+        giftWrap: event,
+      );
+      if (!isVerifiedGiftWrapUnwrapResult(unwrapResult)) {
+        Log.warning(
+          'Rejecting gift wrap ${event.id}: '
+          'sealSignatureValid=${unwrapResult.isSealSignatureValid}, '
+          'sealPubkeyMatchesRumor=${unwrapResult.isPubkeyMatch}',
+        );
+        await _processedEventStore.recordProcessed(event.id);
+        await _processedEventStore.recordLastSeen(relayUrl, event.createdAt);
+        return;
+      }
+
+      final unwrappedEvent = unwrapResult.rumor;
+      final verifiedSenderPubkey = unwrapResult.seal.pubKey;
 
       Log.info(
         'Unwrapped event: kind=${unwrappedEvent.kind}, id=${unwrappedEvent.id}',
@@ -537,6 +558,7 @@ class NdkService {
       if (unwrappedEvent.kind == NostrKind.shareData.value) {
         await _handleShare(
           unwrappedEvent,
+          verifiedSenderPubkey: verifiedSenderPubkey,
           allowLocalNotification: allowLocalNotification,
         );
       } else if (unwrappedEvent.kind == NostrKind.recoveryRequest.value) {
@@ -579,6 +601,7 @@ class NdkService {
   /// dispatcher releases the dedup claim and retries on next delivery.
   Future<void> _handleShare(
     Nip01Event event, {
+    required String verifiedSenderPubkey,
     bool allowLocalNotification = true,
   }) async {
     Log.info('Processing shard data event: ${event.id}');
@@ -594,7 +617,11 @@ class NdkService {
     }
 
     final vaultShareService = _ref.read(vaultShareServiceProvider);
-    await vaultShareService.processVaultShare(vaultId, shardData);
+    await vaultShareService.processVaultShare(
+      vaultId,
+      shardData,
+      verifiedSenderPubkey: verifiedSenderPubkey,
+    );
 
     if (allowLocalNotification) {
       await _ref

--- a/lib/services/vault_share_service.dart
+++ b/lib/services/vault_share_service.dart
@@ -138,8 +138,28 @@ class VaultShareService {
   /// manifests or held shares), a **stale** manifest (lower or equal
   /// [Share.distributionVersion]) is ignored so relays cannot roll back
   /// metadata.
-  Future<void> processVaultShare(String vaultId, Share shardData) async {
+  Future<void> processVaultShare(
+    String vaultId,
+    Share shardData, {
+    required String verifiedSenderPubkey,
+  }) async {
     if (!shardData.isValid) throw ArgumentError('Invalid shard data');
+
+    final existingVault = await repository.getVault(vaultId);
+    if (verifiedSenderPubkey != shardData.creatorPubkey) {
+      Log.warning(
+        'processVaultShare: rejected share for vault $vaultId because verified '
+        'sender does not match creatorPubkey',
+      );
+      return;
+    }
+    if (existingVault != null && shardData.creatorPubkey != existingVault.ownerPubkey) {
+      Log.warning(
+        'processVaultShare: rejected share for vault $vaultId because creator '
+        'does not match existing vault owner',
+      );
+      return;
+    }
 
     // Dedup by nostrEventId. If the vault doesn't exist yet, skip the check
     // and let addVaultShare create it.
@@ -162,7 +182,7 @@ class VaultShareService {
     }
 
     if (shardData.isManifest) {
-      final vault = await repository.getVault(vaultId);
+      final vault = existingVault;
       if (vault != null) {
         final maxHeldDist = await repository.maxHeldShareDistributionVersion(vaultId);
         final vaultRowDist = vault.backupConfig?.distributionVersion ?? -1;

--- a/test/models/share_test.dart
+++ b/test/models/share_test.dart
@@ -345,8 +345,7 @@ void main() {
           reason: 'null scheme must not appear in serialized JSON');
 
       final decodedShare = shareFromJson(json);
-      expect(decodedShare.scheme, isNull,
-          reason: 'null scheme round-trip must preserve null');
+      expect(decodedShare.scheme, isNull, reason: 'null scheme round-trip must preserve null');
     });
 
     test('shareFromJson handles null receivedAt correctly', () {

--- a/test/services/invitation_acceptance_format_test.mocks.dart
+++ b/test/services/invitation_acceptance_format_test.mocks.dart
@@ -6,23 +6,24 @@
 import 'dart:async' as _i7;
 
 import 'package:horcrux/models/backup_config.dart' as _i6;
-import 'package:horcrux/models/backup_status.dart' as _i21;
-import 'package:horcrux/models/key_holder_removal_reason.dart' as _i17;
-import 'package:horcrux/models/nostr_kinds.dart' as _i9;
-import 'package:horcrux/models/recovery_request.dart' as _i15;
-import 'package:horcrux/models/relay_configuration.dart' as _i18;
-import 'package:horcrux/models/share.dart' as _i8;
-import 'package:horcrux/models/steward.dart' as _i20;
-import 'package:horcrux/models/steward_status.dart' as _i14;
-import 'package:horcrux/models/vault.dart' as _i13;
-import 'package:horcrux/providers/vault_provider.dart' as _i12;
-import 'package:horcrux/services/backup_service.dart' as _i19;
-import 'package:horcrux/services/invitation_sending_service.dart' as _i16;
-import 'package:horcrux/services/login_service.dart' as _i10;
+import 'package:horcrux/models/backup_status.dart' as _i22;
+import 'package:horcrux/models/key_holder_removal_reason.dart' as _i18;
+import 'package:horcrux/models/nostr_kinds.dart' as _i10;
+import 'package:horcrux/models/recovery_request.dart' as _i16;
+import 'package:horcrux/models/relay_configuration.dart' as _i19;
+import 'package:horcrux/models/share.dart' as _i9;
+import 'package:horcrux/models/steward.dart' as _i21;
+import 'package:horcrux/models/steward_status.dart' as _i15;
+import 'package:horcrux/models/vault.dart' as _i14;
+import 'package:horcrux/providers/vault_provider.dart' as _i13;
+import 'package:horcrux/services/backup_service.dart' as _i20;
+import 'package:horcrux/services/invitation_sending_service.dart' as _i17;
+import 'package:horcrux/services/login_service.dart' as _i11;
 import 'package:horcrux/services/ndk_service.dart' as _i4;
 import 'package:horcrux/services/relay_scan_service.dart' as _i5;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i11;
+import 'package:mockito/src/dummies.dart' as _i12;
+import 'package:ndk/entities.dart' as _i8;
 import 'package:ndk/ndk.dart' as _i2;
 import 'package:ndk/shared/nips/nip01/key_pair.dart' as _i3;
 
@@ -146,7 +147,7 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
 
   @override
   _i7.Future<void> processGiftWrapFromForegroundPush(
-    _i2.Nip01Event? event, {
+    _i8.Nip01Event? event, {
     bool? allowLocalNotification = true,
   }) =>
       (super.noSuchMethod(
@@ -160,7 +161,7 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
       ) as _i7.Future<void>);
 
   @override
-  _i7.Future<_i2.Nip01Event?> fetchGiftWrapByIdForPush({
+  _i7.Future<_i8.Nip01Event?> fetchGiftWrapByIdForPush({
     required String? eventIdHex,
     List<String>? relayHints,
   }) =>
@@ -173,11 +174,11 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
             #relayHints: relayHints,
           },
         ),
-        returnValue: _i7.Future<_i2.Nip01Event?>.value(),
-      ) as _i7.Future<_i2.Nip01Event?>);
+        returnValue: _i7.Future<_i8.Nip01Event?>.value(),
+      ) as _i7.Future<_i8.Nip01Event?>);
 
   @override
-  _i7.Future<_i8.Share?> loadShareDataFromPublishedDistributionGiftWrap({
+  _i7.Future<_i9.Share?> loadShareDataFromPublishedDistributionGiftWrap({
     required String? giftWrapEventId,
     required List<String>? relayHints,
   }) =>
@@ -190,11 +191,11 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
             #relayHints: relayHints,
           },
         ),
-        returnValue: _i7.Future<_i8.Share?>.value(),
-      ) as _i7.Future<_i8.Share?>);
+        returnValue: _i7.Future<_i9.Share?>.value(),
+      ) as _i7.Future<_i9.Share?>);
 
   @override
-  _i7.Future<String?> resolveVaultIdForGiftWrap(_i2.Nip01Event? giftWrap) => (super.noSuchMethod(
+  _i7.Future<String?> resolveVaultIdForGiftWrap(_i8.Nip01Event? giftWrap) => (super.noSuchMethod(
         Invocation.method(
           #resolveVaultIdForGiftWrap,
           [giftWrap],
@@ -203,15 +204,14 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
       ) as _i7.Future<String?>);
 
   @override
-  _i7.Future<({_i9.NostrKind kind, String recoveryRequestId})?> resolveRecoveryRequestIdForGiftWrap(
-          _i2.Nip01Event? giftWrap) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #resolveRecoveryRequestIdForGiftWrap,
-          [giftWrap],
-        ),
-        returnValue: _i7.Future<({_i9.NostrKind kind, String recoveryRequestId})?>.value(),
-      ) as _i7.Future<({_i9.NostrKind kind, String recoveryRequestId})?>);
+  _i7.Future<({_i10.NostrKind kind, String recoveryRequestId})?>
+      resolveRecoveryRequestIdForGiftWrap(_i8.Nip01Event? giftWrap) => (super.noSuchMethod(
+            Invocation.method(
+              #resolveRecoveryRequestIdForGiftWrap,
+              [giftWrap],
+            ),
+            returnValue: _i7.Future<({_i10.NostrKind kind, String recoveryRequestId})?>.value(),
+          ) as _i7.Future<({_i10.NostrKind kind, String recoveryRequestId})?>);
 
   @override
   _i7.Future<void> closeSubscriptions() => (super.noSuchMethod(
@@ -254,7 +254,7 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
       ) as _i7.Future<String?>);
 
   @override
-  _i7.Future<_i2.Nip01Event?> publishEncryptedEvent({
+  _i7.Future<_i8.Nip01Event?> publishEncryptedEvent({
     required String? content,
     required int? kind,
     required String? recipientPubkey,
@@ -279,11 +279,11 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
             #nip40Expiration: nip40Expiration,
           },
         ),
-        returnValue: _i7.Future<_i2.Nip01Event?>.value(),
-      ) as _i7.Future<_i2.Nip01Event?>);
+        returnValue: _i7.Future<_i8.Nip01Event?>.value(),
+      ) as _i7.Future<_i8.Nip01Event?>);
 
   @override
-  _i7.Future<List<_i2.Nip01Event?>> publishEncryptedEventToMultiple({
+  _i7.Future<List<_i8.Nip01Event?>> publishEncryptedEventToMultiple({
     required String? content,
     required int? kind,
     required List<String>? recipientPubkeys,
@@ -308,8 +308,8 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
             #nip40Expiration: nip40Expiration,
           },
         ),
-        returnValue: _i7.Future<List<_i2.Nip01Event?>>.value(<_i2.Nip01Event?>[]),
-      ) as _i7.Future<List<_i2.Nip01Event?>>);
+        returnValue: _i7.Future<List<_i8.Nip01Event?>>.value(<_i8.Nip01Event?>[]),
+      ) as _i7.Future<List<_i8.Nip01Event?>>);
 
   @override
   _i7.Future<_i2.Ndk> getNdk() => (super.noSuchMethod(
@@ -358,7 +358,7 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
 /// A class which mocks [LoginService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockLoginService extends _i1.Mock implements _i10.LoginService {
+class MockLoginService extends _i1.Mock implements _i11.LoginService {
   MockLoginService() {
     _i1.throwOnMissingStub(this);
   }
@@ -466,7 +466,7 @@ class MockLoginService extends _i1.Mock implements _i10.LoginService {
           #encryptText,
           [plaintext],
         ),
-        returnValue: _i7.Future<String>.value(_i11.dummyValue<String>(
+        returnValue: _i7.Future<String>.value(_i12.dummyValue<String>(
           this,
           Invocation.method(
             #encryptText,
@@ -481,7 +481,7 @@ class MockLoginService extends _i1.Mock implements _i10.LoginService {
           #decryptText,
           [encryptedText],
         ),
-        returnValue: _i7.Future<String>.value(_i11.dummyValue<String>(
+        returnValue: _i7.Future<String>.value(_i12.dummyValue<String>(
           this,
           Invocation.method(
             #decryptText,
@@ -520,7 +520,7 @@ class MockLoginService extends _i1.Mock implements _i10.LoginService {
             #recipientPubkey: recipientPubkey,
           },
         ),
-        returnValue: _i7.Future<String>.value(_i11.dummyValue<String>(
+        returnValue: _i7.Future<String>.value(_i12.dummyValue<String>(
           this,
           Invocation.method(
             #encryptForRecipient,
@@ -547,7 +547,7 @@ class MockLoginService extends _i1.Mock implements _i10.LoginService {
             #senderPubkey: senderPubkey,
           },
         ),
-        returnValue: _i7.Future<String>.value(_i11.dummyValue<String>(
+        returnValue: _i7.Future<String>.value(_i12.dummyValue<String>(
           this,
           Invocation.method(
             #decryptFromSender,
@@ -564,16 +564,16 @@ class MockLoginService extends _i1.Mock implements _i10.LoginService {
 /// A class which mocks [VaultRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockVaultRepository extends _i1.Mock implements _i12.VaultRepository {
+class MockVaultRepository extends _i1.Mock implements _i13.VaultRepository {
   MockVaultRepository() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i7.Stream<List<_i13.Vault>> get vaultsStream => (super.noSuchMethod(
+  _i7.Stream<List<_i14.Vault>> get vaultsStream => (super.noSuchMethod(
         Invocation.getter(#vaultsStream),
-        returnValue: _i7.Stream<List<_i13.Vault>>.empty(),
-      ) as _i7.Stream<List<_i13.Vault>>);
+        returnValue: _i7.Stream<List<_i14.Vault>>.empty(),
+      ) as _i7.Stream<List<_i14.Vault>>);
 
   @override
   _i7.Future<void> initialize() => (super.noSuchMethod(
@@ -586,34 +586,34 @@ class MockVaultRepository extends _i1.Mock implements _i12.VaultRepository {
       ) as _i7.Future<void>);
 
   @override
-  _i7.Stream<_i13.Vault?> watchVault(String? id) => (super.noSuchMethod(
+  _i7.Stream<_i14.Vault?> watchVault(String? id) => (super.noSuchMethod(
         Invocation.method(
           #watchVault,
           [id],
         ),
-        returnValue: _i7.Stream<_i13.Vault?>.empty(),
-      ) as _i7.Stream<_i13.Vault?>);
+        returnValue: _i7.Stream<_i14.Vault?>.empty(),
+      ) as _i7.Stream<_i14.Vault?>);
 
   @override
-  _i7.Future<List<_i13.Vault>> getAllVaults() => (super.noSuchMethod(
+  _i7.Future<List<_i14.Vault>> getAllVaults() => (super.noSuchMethod(
         Invocation.method(
           #getAllVaults,
           [],
         ),
-        returnValue: _i7.Future<List<_i13.Vault>>.value(<_i13.Vault>[]),
-      ) as _i7.Future<List<_i13.Vault>>);
+        returnValue: _i7.Future<List<_i14.Vault>>.value(<_i14.Vault>[]),
+      ) as _i7.Future<List<_i14.Vault>>);
 
   @override
-  _i7.Future<_i13.Vault?> getVault(String? id) => (super.noSuchMethod(
+  _i7.Future<_i14.Vault?> getVault(String? id) => (super.noSuchMethod(
         Invocation.method(
           #getVault,
           [id],
         ),
-        returnValue: _i7.Future<_i13.Vault?>.value(),
-      ) as _i7.Future<_i13.Vault?>);
+        returnValue: _i7.Future<_i14.Vault?>.value(),
+      ) as _i7.Future<_i14.Vault?>);
 
   @override
-  _i7.Future<void> saveVault(_i13.Vault? vault) => (super.noSuchMethod(
+  _i7.Future<void> saveVault(_i14.Vault? vault) => (super.noSuchMethod(
         Invocation.method(
           #saveVault,
           [vault],
@@ -623,7 +623,7 @@ class MockVaultRepository extends _i1.Mock implements _i12.VaultRepository {
       ) as _i7.Future<void>);
 
   @override
-  _i7.Future<void> addVault(_i13.Vault? vault) => (super.noSuchMethod(
+  _i7.Future<void> addVault(_i14.Vault? vault) => (super.noSuchMethod(
         Invocation.method(
           #addVault,
           [vault],
@@ -728,7 +728,7 @@ class MockVaultRepository extends _i1.Mock implements _i12.VaultRepository {
   _i7.Future<void> updateStewardStatus({
     required String? vaultId,
     required String? pubkey,
-    _i14.StewardStatus? status,
+    _i15.StewardStatus? status,
     DateTime? acknowledgedAt,
     String? acknowledgmentEventId,
     int? acknowledgedDistributionVersion,
@@ -773,7 +773,7 @@ class MockVaultRepository extends _i1.Mock implements _i12.VaultRepository {
   @override
   _i7.Future<void> addShareToVault(
     String? vaultId,
-    _i8.Share? share,
+    _i9.Share? share,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -788,13 +788,13 @@ class MockVaultRepository extends _i1.Mock implements _i12.VaultRepository {
       ) as _i7.Future<void>);
 
   @override
-  _i7.Future<List<_i8.Share>> getSharesForVault(String? vaultId) => (super.noSuchMethod(
+  _i7.Future<List<_i9.Share>> getSharesForVault(String? vaultId) => (super.noSuchMethod(
         Invocation.method(
           #getSharesForVault,
           [vaultId],
         ),
-        returnValue: _i7.Future<List<_i8.Share>>.value(<_i8.Share>[]),
-      ) as _i7.Future<List<_i8.Share>>);
+        returnValue: _i7.Future<List<_i9.Share>>.value(<_i9.Share>[]),
+      ) as _i7.Future<List<_i9.Share>>);
 
   @override
   _i7.Future<int> maxHeldShareDistributionVersion(String? vaultId) => (super.noSuchMethod(
@@ -846,7 +846,7 @@ class MockVaultRepository extends _i1.Mock implements _i12.VaultRepository {
   @override
   _i7.Future<void> mergeVaultRowFromIncomingShare(
     String? vaultId,
-    _i8.Share? share,
+    _i9.Share? share,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -909,7 +909,7 @@ class MockVaultRepository extends _i1.Mock implements _i12.VaultRepository {
   @override
   _i7.Future<void> addRecoveryRequestToVault(
     String? vaultId,
-    _i15.RecoveryRequest? request,
+    _i16.RecoveryRequest? request,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -927,7 +927,7 @@ class MockVaultRepository extends _i1.Mock implements _i12.VaultRepository {
   _i7.Future<void> updateRecoveryRequestInVault(
     String? vaultId,
     String? requestId,
-    _i15.RecoveryRequest? updatedRequest,
+    _i16.RecoveryRequest? updatedRequest,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -989,33 +989,33 @@ class MockVaultRepository extends _i1.Mock implements _i12.VaultRepository {
       ) as _i7.Future<void>);
 
   @override
-  _i7.Future<List<_i15.RecoveryRequest>> getRecoveryRequestsForVault(String? vaultId) =>
+  _i7.Future<List<_i16.RecoveryRequest>> getRecoveryRequestsForVault(String? vaultId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRecoveryRequestsForVault,
           [vaultId],
         ),
-        returnValue: _i7.Future<List<_i15.RecoveryRequest>>.value(<_i15.RecoveryRequest>[]),
-      ) as _i7.Future<List<_i15.RecoveryRequest>>);
+        returnValue: _i7.Future<List<_i16.RecoveryRequest>>.value(<_i16.RecoveryRequest>[]),
+      ) as _i7.Future<List<_i16.RecoveryRequest>>);
 
   @override
-  _i7.Future<_i15.RecoveryRequest?> getActiveRecoveryRequest(String? vaultId) =>
+  _i7.Future<_i16.RecoveryRequest?> getActiveRecoveryRequest(String? vaultId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getActiveRecoveryRequest,
           [vaultId],
         ),
-        returnValue: _i7.Future<_i15.RecoveryRequest?>.value(),
-      ) as _i7.Future<_i15.RecoveryRequest?>);
+        returnValue: _i7.Future<_i16.RecoveryRequest?>.value(),
+      ) as _i7.Future<_i16.RecoveryRequest?>);
 
   @override
-  _i7.Future<List<_i15.RecoveryRequest>> getAllRecoveryRequests() => (super.noSuchMethod(
+  _i7.Future<List<_i16.RecoveryRequest>> getAllRecoveryRequests() => (super.noSuchMethod(
         Invocation.method(
           #getAllRecoveryRequests,
           [],
         ),
-        returnValue: _i7.Future<List<_i15.RecoveryRequest>>.value(<_i15.RecoveryRequest>[]),
-      ) as _i7.Future<List<_i15.RecoveryRequest>>);
+        returnValue: _i7.Future<List<_i16.RecoveryRequest>>.value(<_i16.RecoveryRequest>[]),
+      ) as _i7.Future<List<_i16.RecoveryRequest>>);
 
   @override
   void dispose() => super.noSuchMethod(
@@ -1030,7 +1030,7 @@ class MockVaultRepository extends _i1.Mock implements _i12.VaultRepository {
 /// A class which mocks [InvitationSendingService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockInvitationSendingService extends _i1.Mock implements _i16.InvitationSendingService {
+class MockInvitationSendingService extends _i1.Mock implements _i17.InvitationSendingService {
   MockInvitationSendingService() {
     _i1.throwOnMissingStub(this);
   }
@@ -1156,7 +1156,7 @@ class MockInvitationSendingService extends _i1.Mock implements _i16.InvitationSe
     required String? vaultId,
     required String? removedStewardPubkey,
     required List<String>? relayUrls,
-    _i17.KeyHolderRemovalReason? reason = _i17.KeyHolderRemovalReason.stewardRemoved,
+    _i18.KeyHolderRemovalReason? reason = _i18.KeyHolderRemovalReason.stewardRemoved,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1210,28 +1210,28 @@ class MockRelayScanService extends _i1.Mock implements _i5.RelayScanService {
       ) as _i7.Future<void>);
 
   @override
-  _i7.Future<List<_i18.RelayConfiguration>> getRelayConfigurations({bool? enabledOnly}) =>
+  _i7.Future<List<_i19.RelayConfiguration>> getRelayConfigurations({bool? enabledOnly}) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRelayConfigurations,
           [],
           {#enabledOnly: enabledOnly},
         ),
-        returnValue: _i7.Future<List<_i18.RelayConfiguration>>.value(<_i18.RelayConfiguration>[]),
-      ) as _i7.Future<List<_i18.RelayConfiguration>>);
+        returnValue: _i7.Future<List<_i19.RelayConfiguration>>.value(<_i19.RelayConfiguration>[]),
+      ) as _i7.Future<List<_i19.RelayConfiguration>>);
 
   @override
-  _i7.Future<_i18.RelayConfiguration?> getRelayConfiguration(String? relayId) =>
+  _i7.Future<_i19.RelayConfiguration?> getRelayConfiguration(String? relayId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRelayConfiguration,
           [relayId],
         ),
-        returnValue: _i7.Future<_i18.RelayConfiguration?>.value(),
-      ) as _i7.Future<_i18.RelayConfiguration?>);
+        returnValue: _i7.Future<_i19.RelayConfiguration?>.value(),
+      ) as _i7.Future<_i19.RelayConfiguration?>);
 
   @override
-  _i7.Future<void> addRelayConfiguration(_i18.RelayConfiguration? relay) => (super.noSuchMethod(
+  _i7.Future<void> addRelayConfiguration(_i19.RelayConfiguration? relay) => (super.noSuchMethod(
         Invocation.method(
           #addRelayConfiguration,
           [relay],
@@ -1241,7 +1241,7 @@ class MockRelayScanService extends _i1.Mock implements _i5.RelayScanService {
       ) as _i7.Future<void>);
 
   @override
-  _i7.Future<void> updateRelayConfiguration(_i18.RelayConfiguration? relay) => (super.noSuchMethod(
+  _i7.Future<void> updateRelayConfiguration(_i19.RelayConfiguration? relay) => (super.noSuchMethod(
         Invocation.method(
           #updateRelayConfiguration,
           [relay],
@@ -1359,7 +1359,7 @@ class MockRelayScanService extends _i1.Mock implements _i5.RelayScanService {
 /// A class which mocks [BackupService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockBackupService extends _i1.Mock implements _i19.BackupService {
+class MockBackupService extends _i1.Mock implements _i20.BackupService {
   MockBackupService() {
     _i1.throwOnMissingStub(this);
   }
@@ -1369,7 +1369,7 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
     required String? vaultId,
     required int? threshold,
     required int? totalKeys,
-    required List<_i20.Steward>? stewards,
+    required List<_i21.Steward>? stewards,
     required List<String>? relays,
     String? instructions,
   }) =>
@@ -1442,7 +1442,7 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
       ) as _i7.Future<void>);
 
   @override
-  _i7.Future<List<_i8.Share>> generateShamirShares({
+  _i7.Future<List<_i9.Share>> generateShamirShares({
     required String? content,
     required int? threshold,
     required int? totalShards,
@@ -1471,18 +1471,18 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
             #pushEnabled: pushEnabled,
           },
         ),
-        returnValue: _i7.Future<List<_i8.Share>>.value(<_i8.Share>[]),
-      ) as _i7.Future<List<_i8.Share>>);
+        returnValue: _i7.Future<List<_i9.Share>>.value(<_i9.Share>[]),
+      ) as _i7.Future<List<_i9.Share>>);
 
   @override
-  _i7.Future<String> reconstructFromShares({required List<_i8.Share>? shares}) =>
+  _i7.Future<String> reconstructFromShares({required List<_i9.Share>? shares}) =>
       (super.noSuchMethod(
         Invocation.method(
           #reconstructFromShares,
           [],
           {#shares: shares},
         ),
-        returnValue: _i7.Future<String>.value(_i11.dummyValue<String>(
+        returnValue: _i7.Future<String>.value(_i12.dummyValue<String>(
           this,
           Invocation.method(
             #reconstructFromShares,
@@ -1495,7 +1495,7 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
   @override
   _i7.Future<void> updateBackupStatus(
     String? vaultId,
-    _i21.BackupStatus? status,
+    _i22.BackupStatus? status,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1513,7 +1513,7 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
   _i7.Future<void> updateStewardStatus({
     required String? vaultId,
     required String? pubkey,
-    required _i14.StewardStatus? status,
+    required _i15.StewardStatus? status,
     DateTime? acknowledgedAt,
     String? acknowledgmentEventId,
     String? giftWrapEventId,
@@ -1548,7 +1548,7 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
   _i7.Future<_i6.BackupConfig> mergeBackupConfig({
     required String? vaultId,
     int? threshold,
-    List<_i20.Steward>? stewards,
+    List<_i21.Steward>? stewards,
     List<String>? relays,
     String? instructions,
   }) =>
@@ -1628,7 +1628,7 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
     required String? vaultId,
     required int? threshold,
     required int? totalKeys,
-    required List<_i20.Steward>? stewards,
+    required List<_i21.Steward>? stewards,
     required List<String>? relays,
     String? instructions,
   }) =>

--- a/test/services/invitation_sending_service_test.mocks.dart
+++ b/test/services/invitation_sending_service_test.mocks.dart
@@ -5,10 +5,11 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i4;
 
-import 'package:horcrux/models/nostr_kinds.dart' as _i6;
-import 'package:horcrux/models/share.dart' as _i5;
+import 'package:horcrux/models/nostr_kinds.dart' as _i7;
+import 'package:horcrux/models/share.dart' as _i6;
 import 'package:horcrux/services/ndk_service.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:ndk/entities.dart' as _i5;
 import 'package:ndk/ndk.dart' as _i2;
 
 // ignore_for_file: type=lint
@@ -91,7 +92,7 @@ class MockNdkService extends _i1.Mock implements _i3.NdkService {
 
   @override
   _i4.Future<void> processGiftWrapFromForegroundPush(
-    _i2.Nip01Event? event, {
+    _i5.Nip01Event? event, {
     bool? allowLocalNotification = true,
   }) =>
       (super.noSuchMethod(
@@ -105,7 +106,7 @@ class MockNdkService extends _i1.Mock implements _i3.NdkService {
       ) as _i4.Future<void>);
 
   @override
-  _i4.Future<_i2.Nip01Event?> fetchGiftWrapByIdForPush({
+  _i4.Future<_i5.Nip01Event?> fetchGiftWrapByIdForPush({
     required String? eventIdHex,
     List<String>? relayHints,
   }) =>
@@ -118,11 +119,11 @@ class MockNdkService extends _i1.Mock implements _i3.NdkService {
             #relayHints: relayHints,
           },
         ),
-        returnValue: _i4.Future<_i2.Nip01Event?>.value(),
-      ) as _i4.Future<_i2.Nip01Event?>);
+        returnValue: _i4.Future<_i5.Nip01Event?>.value(),
+      ) as _i4.Future<_i5.Nip01Event?>);
 
   @override
-  _i4.Future<_i5.Share?> loadShareDataFromPublishedDistributionGiftWrap({
+  _i4.Future<_i6.Share?> loadShareDataFromPublishedDistributionGiftWrap({
     required String? giftWrapEventId,
     required List<String>? relayHints,
   }) =>
@@ -135,11 +136,11 @@ class MockNdkService extends _i1.Mock implements _i3.NdkService {
             #relayHints: relayHints,
           },
         ),
-        returnValue: _i4.Future<_i5.Share?>.value(),
-      ) as _i4.Future<_i5.Share?>);
+        returnValue: _i4.Future<_i6.Share?>.value(),
+      ) as _i4.Future<_i6.Share?>);
 
   @override
-  _i4.Future<String?> resolveVaultIdForGiftWrap(_i2.Nip01Event? giftWrap) => (super.noSuchMethod(
+  _i4.Future<String?> resolveVaultIdForGiftWrap(_i5.Nip01Event? giftWrap) => (super.noSuchMethod(
         Invocation.method(
           #resolveVaultIdForGiftWrap,
           [giftWrap],
@@ -148,15 +149,15 @@ class MockNdkService extends _i1.Mock implements _i3.NdkService {
       ) as _i4.Future<String?>);
 
   @override
-  _i4.Future<({_i6.NostrKind kind, String recoveryRequestId})?> resolveRecoveryRequestIdForGiftWrap(
-          _i2.Nip01Event? giftWrap) =>
+  _i4.Future<({_i7.NostrKind kind, String recoveryRequestId})?> resolveRecoveryRequestIdForGiftWrap(
+          _i5.Nip01Event? giftWrap) =>
       (super.noSuchMethod(
         Invocation.method(
           #resolveRecoveryRequestIdForGiftWrap,
           [giftWrap],
         ),
-        returnValue: _i4.Future<({_i6.NostrKind kind, String recoveryRequestId})?>.value(),
-      ) as _i4.Future<({_i6.NostrKind kind, String recoveryRequestId})?>);
+        returnValue: _i4.Future<({_i7.NostrKind kind, String recoveryRequestId})?>.value(),
+      ) as _i4.Future<({_i7.NostrKind kind, String recoveryRequestId})?>);
 
   @override
   _i4.Future<void> closeSubscriptions() => (super.noSuchMethod(
@@ -199,7 +200,7 @@ class MockNdkService extends _i1.Mock implements _i3.NdkService {
       ) as _i4.Future<String?>);
 
   @override
-  _i4.Future<_i2.Nip01Event?> publishEncryptedEvent({
+  _i4.Future<_i5.Nip01Event?> publishEncryptedEvent({
     required String? content,
     required int? kind,
     required String? recipientPubkey,
@@ -224,11 +225,11 @@ class MockNdkService extends _i1.Mock implements _i3.NdkService {
             #nip40Expiration: nip40Expiration,
           },
         ),
-        returnValue: _i4.Future<_i2.Nip01Event?>.value(),
-      ) as _i4.Future<_i2.Nip01Event?>);
+        returnValue: _i4.Future<_i5.Nip01Event?>.value(),
+      ) as _i4.Future<_i5.Nip01Event?>);
 
   @override
-  _i4.Future<List<_i2.Nip01Event?>> publishEncryptedEventToMultiple({
+  _i4.Future<List<_i5.Nip01Event?>> publishEncryptedEventToMultiple({
     required String? content,
     required int? kind,
     required List<String>? recipientPubkeys,
@@ -253,8 +254,8 @@ class MockNdkService extends _i1.Mock implements _i3.NdkService {
             #nip40Expiration: nip40Expiration,
           },
         ),
-        returnValue: _i4.Future<List<_i2.Nip01Event?>>.value(<_i2.Nip01Event?>[]),
-      ) as _i4.Future<List<_i2.Nip01Event?>>);
+        returnValue: _i4.Future<List<_i5.Nip01Event?>>.value(<_i5.Nip01Event?>[]),
+      ) as _i4.Future<List<_i5.Nip01Event?>>);
 
   @override
   _i4.Future<_i2.Ndk> getNdk() => (super.noSuchMethod(

--- a/test/services/invitation_service_test.mocks.dart
+++ b/test/services/invitation_service_test.mocks.dart
@@ -6,23 +6,24 @@
 import 'dart:async' as _i7;
 
 import 'package:horcrux/models/backup_config.dart' as _i6;
-import 'package:horcrux/models/backup_status.dart' as _i21;
-import 'package:horcrux/models/key_holder_removal_reason.dart' as _i17;
-import 'package:horcrux/models/nostr_kinds.dart' as _i9;
-import 'package:horcrux/models/recovery_request.dart' as _i15;
-import 'package:horcrux/models/relay_configuration.dart' as _i18;
-import 'package:horcrux/models/share.dart' as _i8;
-import 'package:horcrux/models/steward.dart' as _i20;
-import 'package:horcrux/models/steward_status.dart' as _i14;
-import 'package:horcrux/models/vault.dart' as _i13;
-import 'package:horcrux/providers/vault_provider.dart' as _i12;
-import 'package:horcrux/services/backup_service.dart' as _i19;
-import 'package:horcrux/services/invitation_sending_service.dart' as _i16;
-import 'package:horcrux/services/login_service.dart' as _i10;
+import 'package:horcrux/models/backup_status.dart' as _i22;
+import 'package:horcrux/models/key_holder_removal_reason.dart' as _i18;
+import 'package:horcrux/models/nostr_kinds.dart' as _i10;
+import 'package:horcrux/models/recovery_request.dart' as _i16;
+import 'package:horcrux/models/relay_configuration.dart' as _i19;
+import 'package:horcrux/models/share.dart' as _i9;
+import 'package:horcrux/models/steward.dart' as _i21;
+import 'package:horcrux/models/steward_status.dart' as _i15;
+import 'package:horcrux/models/vault.dart' as _i14;
+import 'package:horcrux/providers/vault_provider.dart' as _i13;
+import 'package:horcrux/services/backup_service.dart' as _i20;
+import 'package:horcrux/services/invitation_sending_service.dart' as _i17;
+import 'package:horcrux/services/login_service.dart' as _i11;
 import 'package:horcrux/services/ndk_service.dart' as _i4;
 import 'package:horcrux/services/relay_scan_service.dart' as _i5;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i11;
+import 'package:mockito/src/dummies.dart' as _i12;
+import 'package:ndk/entities.dart' as _i8;
 import 'package:ndk/ndk.dart' as _i2;
 import 'package:ndk/shared/nips/nip01/key_pair.dart' as _i3;
 
@@ -146,7 +147,7 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
 
   @override
   _i7.Future<void> processGiftWrapFromForegroundPush(
-    _i2.Nip01Event? event, {
+    _i8.Nip01Event? event, {
     bool? allowLocalNotification = true,
   }) =>
       (super.noSuchMethod(
@@ -160,7 +161,7 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
       ) as _i7.Future<void>);
 
   @override
-  _i7.Future<_i2.Nip01Event?> fetchGiftWrapByIdForPush({
+  _i7.Future<_i8.Nip01Event?> fetchGiftWrapByIdForPush({
     required String? eventIdHex,
     List<String>? relayHints,
   }) =>
@@ -173,11 +174,11 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
             #relayHints: relayHints,
           },
         ),
-        returnValue: _i7.Future<_i2.Nip01Event?>.value(),
-      ) as _i7.Future<_i2.Nip01Event?>);
+        returnValue: _i7.Future<_i8.Nip01Event?>.value(),
+      ) as _i7.Future<_i8.Nip01Event?>);
 
   @override
-  _i7.Future<_i8.Share?> loadShareDataFromPublishedDistributionGiftWrap({
+  _i7.Future<_i9.Share?> loadShareDataFromPublishedDistributionGiftWrap({
     required String? giftWrapEventId,
     required List<String>? relayHints,
   }) =>
@@ -190,11 +191,11 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
             #relayHints: relayHints,
           },
         ),
-        returnValue: _i7.Future<_i8.Share?>.value(),
-      ) as _i7.Future<_i8.Share?>);
+        returnValue: _i7.Future<_i9.Share?>.value(),
+      ) as _i7.Future<_i9.Share?>);
 
   @override
-  _i7.Future<String?> resolveVaultIdForGiftWrap(_i2.Nip01Event? giftWrap) => (super.noSuchMethod(
+  _i7.Future<String?> resolveVaultIdForGiftWrap(_i8.Nip01Event? giftWrap) => (super.noSuchMethod(
         Invocation.method(
           #resolveVaultIdForGiftWrap,
           [giftWrap],
@@ -203,15 +204,14 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
       ) as _i7.Future<String?>);
 
   @override
-  _i7.Future<({_i9.NostrKind kind, String recoveryRequestId})?> resolveRecoveryRequestIdForGiftWrap(
-          _i2.Nip01Event? giftWrap) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #resolveRecoveryRequestIdForGiftWrap,
-          [giftWrap],
-        ),
-        returnValue: _i7.Future<({_i9.NostrKind kind, String recoveryRequestId})?>.value(),
-      ) as _i7.Future<({_i9.NostrKind kind, String recoveryRequestId})?>);
+  _i7.Future<({_i10.NostrKind kind, String recoveryRequestId})?>
+      resolveRecoveryRequestIdForGiftWrap(_i8.Nip01Event? giftWrap) => (super.noSuchMethod(
+            Invocation.method(
+              #resolveRecoveryRequestIdForGiftWrap,
+              [giftWrap],
+            ),
+            returnValue: _i7.Future<({_i10.NostrKind kind, String recoveryRequestId})?>.value(),
+          ) as _i7.Future<({_i10.NostrKind kind, String recoveryRequestId})?>);
 
   @override
   _i7.Future<void> closeSubscriptions() => (super.noSuchMethod(
@@ -254,7 +254,7 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
       ) as _i7.Future<String?>);
 
   @override
-  _i7.Future<_i2.Nip01Event?> publishEncryptedEvent({
+  _i7.Future<_i8.Nip01Event?> publishEncryptedEvent({
     required String? content,
     required int? kind,
     required String? recipientPubkey,
@@ -279,11 +279,11 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
             #nip40Expiration: nip40Expiration,
           },
         ),
-        returnValue: _i7.Future<_i2.Nip01Event?>.value(),
-      ) as _i7.Future<_i2.Nip01Event?>);
+        returnValue: _i7.Future<_i8.Nip01Event?>.value(),
+      ) as _i7.Future<_i8.Nip01Event?>);
 
   @override
-  _i7.Future<List<_i2.Nip01Event?>> publishEncryptedEventToMultiple({
+  _i7.Future<List<_i8.Nip01Event?>> publishEncryptedEventToMultiple({
     required String? content,
     required int? kind,
     required List<String>? recipientPubkeys,
@@ -308,8 +308,8 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
             #nip40Expiration: nip40Expiration,
           },
         ),
-        returnValue: _i7.Future<List<_i2.Nip01Event?>>.value(<_i2.Nip01Event?>[]),
-      ) as _i7.Future<List<_i2.Nip01Event?>>);
+        returnValue: _i7.Future<List<_i8.Nip01Event?>>.value(<_i8.Nip01Event?>[]),
+      ) as _i7.Future<List<_i8.Nip01Event?>>);
 
   @override
   _i7.Future<_i2.Ndk> getNdk() => (super.noSuchMethod(
@@ -358,7 +358,7 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
 /// A class which mocks [LoginService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockLoginService extends _i1.Mock implements _i10.LoginService {
+class MockLoginService extends _i1.Mock implements _i11.LoginService {
   MockLoginService() {
     _i1.throwOnMissingStub(this);
   }
@@ -466,7 +466,7 @@ class MockLoginService extends _i1.Mock implements _i10.LoginService {
           #encryptText,
           [plaintext],
         ),
-        returnValue: _i7.Future<String>.value(_i11.dummyValue<String>(
+        returnValue: _i7.Future<String>.value(_i12.dummyValue<String>(
           this,
           Invocation.method(
             #encryptText,
@@ -481,7 +481,7 @@ class MockLoginService extends _i1.Mock implements _i10.LoginService {
           #decryptText,
           [encryptedText],
         ),
-        returnValue: _i7.Future<String>.value(_i11.dummyValue<String>(
+        returnValue: _i7.Future<String>.value(_i12.dummyValue<String>(
           this,
           Invocation.method(
             #decryptText,
@@ -520,7 +520,7 @@ class MockLoginService extends _i1.Mock implements _i10.LoginService {
             #recipientPubkey: recipientPubkey,
           },
         ),
-        returnValue: _i7.Future<String>.value(_i11.dummyValue<String>(
+        returnValue: _i7.Future<String>.value(_i12.dummyValue<String>(
           this,
           Invocation.method(
             #encryptForRecipient,
@@ -547,7 +547,7 @@ class MockLoginService extends _i1.Mock implements _i10.LoginService {
             #senderPubkey: senderPubkey,
           },
         ),
-        returnValue: _i7.Future<String>.value(_i11.dummyValue<String>(
+        returnValue: _i7.Future<String>.value(_i12.dummyValue<String>(
           this,
           Invocation.method(
             #decryptFromSender,
@@ -564,16 +564,16 @@ class MockLoginService extends _i1.Mock implements _i10.LoginService {
 /// A class which mocks [VaultRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockVaultRepository extends _i1.Mock implements _i12.VaultRepository {
+class MockVaultRepository extends _i1.Mock implements _i13.VaultRepository {
   MockVaultRepository() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i7.Stream<List<_i13.Vault>> get vaultsStream => (super.noSuchMethod(
+  _i7.Stream<List<_i14.Vault>> get vaultsStream => (super.noSuchMethod(
         Invocation.getter(#vaultsStream),
-        returnValue: _i7.Stream<List<_i13.Vault>>.empty(),
-      ) as _i7.Stream<List<_i13.Vault>>);
+        returnValue: _i7.Stream<List<_i14.Vault>>.empty(),
+      ) as _i7.Stream<List<_i14.Vault>>);
 
   @override
   _i7.Future<void> initialize() => (super.noSuchMethod(
@@ -586,34 +586,34 @@ class MockVaultRepository extends _i1.Mock implements _i12.VaultRepository {
       ) as _i7.Future<void>);
 
   @override
-  _i7.Stream<_i13.Vault?> watchVault(String? id) => (super.noSuchMethod(
+  _i7.Stream<_i14.Vault?> watchVault(String? id) => (super.noSuchMethod(
         Invocation.method(
           #watchVault,
           [id],
         ),
-        returnValue: _i7.Stream<_i13.Vault?>.empty(),
-      ) as _i7.Stream<_i13.Vault?>);
+        returnValue: _i7.Stream<_i14.Vault?>.empty(),
+      ) as _i7.Stream<_i14.Vault?>);
 
   @override
-  _i7.Future<List<_i13.Vault>> getAllVaults() => (super.noSuchMethod(
+  _i7.Future<List<_i14.Vault>> getAllVaults() => (super.noSuchMethod(
         Invocation.method(
           #getAllVaults,
           [],
         ),
-        returnValue: _i7.Future<List<_i13.Vault>>.value(<_i13.Vault>[]),
-      ) as _i7.Future<List<_i13.Vault>>);
+        returnValue: _i7.Future<List<_i14.Vault>>.value(<_i14.Vault>[]),
+      ) as _i7.Future<List<_i14.Vault>>);
 
   @override
-  _i7.Future<_i13.Vault?> getVault(String? id) => (super.noSuchMethod(
+  _i7.Future<_i14.Vault?> getVault(String? id) => (super.noSuchMethod(
         Invocation.method(
           #getVault,
           [id],
         ),
-        returnValue: _i7.Future<_i13.Vault?>.value(),
-      ) as _i7.Future<_i13.Vault?>);
+        returnValue: _i7.Future<_i14.Vault?>.value(),
+      ) as _i7.Future<_i14.Vault?>);
 
   @override
-  _i7.Future<void> saveVault(_i13.Vault? vault) => (super.noSuchMethod(
+  _i7.Future<void> saveVault(_i14.Vault? vault) => (super.noSuchMethod(
         Invocation.method(
           #saveVault,
           [vault],
@@ -623,7 +623,7 @@ class MockVaultRepository extends _i1.Mock implements _i12.VaultRepository {
       ) as _i7.Future<void>);
 
   @override
-  _i7.Future<void> addVault(_i13.Vault? vault) => (super.noSuchMethod(
+  _i7.Future<void> addVault(_i14.Vault? vault) => (super.noSuchMethod(
         Invocation.method(
           #addVault,
           [vault],
@@ -728,7 +728,7 @@ class MockVaultRepository extends _i1.Mock implements _i12.VaultRepository {
   _i7.Future<void> updateStewardStatus({
     required String? vaultId,
     required String? pubkey,
-    _i14.StewardStatus? status,
+    _i15.StewardStatus? status,
     DateTime? acknowledgedAt,
     String? acknowledgmentEventId,
     int? acknowledgedDistributionVersion,
@@ -773,7 +773,7 @@ class MockVaultRepository extends _i1.Mock implements _i12.VaultRepository {
   @override
   _i7.Future<void> addShareToVault(
     String? vaultId,
-    _i8.Share? share,
+    _i9.Share? share,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -788,13 +788,13 @@ class MockVaultRepository extends _i1.Mock implements _i12.VaultRepository {
       ) as _i7.Future<void>);
 
   @override
-  _i7.Future<List<_i8.Share>> getSharesForVault(String? vaultId) => (super.noSuchMethod(
+  _i7.Future<List<_i9.Share>> getSharesForVault(String? vaultId) => (super.noSuchMethod(
         Invocation.method(
           #getSharesForVault,
           [vaultId],
         ),
-        returnValue: _i7.Future<List<_i8.Share>>.value(<_i8.Share>[]),
-      ) as _i7.Future<List<_i8.Share>>);
+        returnValue: _i7.Future<List<_i9.Share>>.value(<_i9.Share>[]),
+      ) as _i7.Future<List<_i9.Share>>);
 
   @override
   _i7.Future<int> maxHeldShareDistributionVersion(String? vaultId) => (super.noSuchMethod(
@@ -846,7 +846,7 @@ class MockVaultRepository extends _i1.Mock implements _i12.VaultRepository {
   @override
   _i7.Future<void> mergeVaultRowFromIncomingShare(
     String? vaultId,
-    _i8.Share? share,
+    _i9.Share? share,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -909,7 +909,7 @@ class MockVaultRepository extends _i1.Mock implements _i12.VaultRepository {
   @override
   _i7.Future<void> addRecoveryRequestToVault(
     String? vaultId,
-    _i15.RecoveryRequest? request,
+    _i16.RecoveryRequest? request,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -927,7 +927,7 @@ class MockVaultRepository extends _i1.Mock implements _i12.VaultRepository {
   _i7.Future<void> updateRecoveryRequestInVault(
     String? vaultId,
     String? requestId,
-    _i15.RecoveryRequest? updatedRequest,
+    _i16.RecoveryRequest? updatedRequest,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -989,33 +989,33 @@ class MockVaultRepository extends _i1.Mock implements _i12.VaultRepository {
       ) as _i7.Future<void>);
 
   @override
-  _i7.Future<List<_i15.RecoveryRequest>> getRecoveryRequestsForVault(String? vaultId) =>
+  _i7.Future<List<_i16.RecoveryRequest>> getRecoveryRequestsForVault(String? vaultId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRecoveryRequestsForVault,
           [vaultId],
         ),
-        returnValue: _i7.Future<List<_i15.RecoveryRequest>>.value(<_i15.RecoveryRequest>[]),
-      ) as _i7.Future<List<_i15.RecoveryRequest>>);
+        returnValue: _i7.Future<List<_i16.RecoveryRequest>>.value(<_i16.RecoveryRequest>[]),
+      ) as _i7.Future<List<_i16.RecoveryRequest>>);
 
   @override
-  _i7.Future<_i15.RecoveryRequest?> getActiveRecoveryRequest(String? vaultId) =>
+  _i7.Future<_i16.RecoveryRequest?> getActiveRecoveryRequest(String? vaultId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getActiveRecoveryRequest,
           [vaultId],
         ),
-        returnValue: _i7.Future<_i15.RecoveryRequest?>.value(),
-      ) as _i7.Future<_i15.RecoveryRequest?>);
+        returnValue: _i7.Future<_i16.RecoveryRequest?>.value(),
+      ) as _i7.Future<_i16.RecoveryRequest?>);
 
   @override
-  _i7.Future<List<_i15.RecoveryRequest>> getAllRecoveryRequests() => (super.noSuchMethod(
+  _i7.Future<List<_i16.RecoveryRequest>> getAllRecoveryRequests() => (super.noSuchMethod(
         Invocation.method(
           #getAllRecoveryRequests,
           [],
         ),
-        returnValue: _i7.Future<List<_i15.RecoveryRequest>>.value(<_i15.RecoveryRequest>[]),
-      ) as _i7.Future<List<_i15.RecoveryRequest>>);
+        returnValue: _i7.Future<List<_i16.RecoveryRequest>>.value(<_i16.RecoveryRequest>[]),
+      ) as _i7.Future<List<_i16.RecoveryRequest>>);
 
   @override
   void dispose() => super.noSuchMethod(
@@ -1030,7 +1030,7 @@ class MockVaultRepository extends _i1.Mock implements _i12.VaultRepository {
 /// A class which mocks [InvitationSendingService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockInvitationSendingService extends _i1.Mock implements _i16.InvitationSendingService {
+class MockInvitationSendingService extends _i1.Mock implements _i17.InvitationSendingService {
   MockInvitationSendingService() {
     _i1.throwOnMissingStub(this);
   }
@@ -1156,7 +1156,7 @@ class MockInvitationSendingService extends _i1.Mock implements _i16.InvitationSe
     required String? vaultId,
     required String? removedStewardPubkey,
     required List<String>? relayUrls,
-    _i17.KeyHolderRemovalReason? reason = _i17.KeyHolderRemovalReason.stewardRemoved,
+    _i18.KeyHolderRemovalReason? reason = _i18.KeyHolderRemovalReason.stewardRemoved,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1210,28 +1210,28 @@ class MockRelayScanService extends _i1.Mock implements _i5.RelayScanService {
       ) as _i7.Future<void>);
 
   @override
-  _i7.Future<List<_i18.RelayConfiguration>> getRelayConfigurations({bool? enabledOnly}) =>
+  _i7.Future<List<_i19.RelayConfiguration>> getRelayConfigurations({bool? enabledOnly}) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRelayConfigurations,
           [],
           {#enabledOnly: enabledOnly},
         ),
-        returnValue: _i7.Future<List<_i18.RelayConfiguration>>.value(<_i18.RelayConfiguration>[]),
-      ) as _i7.Future<List<_i18.RelayConfiguration>>);
+        returnValue: _i7.Future<List<_i19.RelayConfiguration>>.value(<_i19.RelayConfiguration>[]),
+      ) as _i7.Future<List<_i19.RelayConfiguration>>);
 
   @override
-  _i7.Future<_i18.RelayConfiguration?> getRelayConfiguration(String? relayId) =>
+  _i7.Future<_i19.RelayConfiguration?> getRelayConfiguration(String? relayId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRelayConfiguration,
           [relayId],
         ),
-        returnValue: _i7.Future<_i18.RelayConfiguration?>.value(),
-      ) as _i7.Future<_i18.RelayConfiguration?>);
+        returnValue: _i7.Future<_i19.RelayConfiguration?>.value(),
+      ) as _i7.Future<_i19.RelayConfiguration?>);
 
   @override
-  _i7.Future<void> addRelayConfiguration(_i18.RelayConfiguration? relay) => (super.noSuchMethod(
+  _i7.Future<void> addRelayConfiguration(_i19.RelayConfiguration? relay) => (super.noSuchMethod(
         Invocation.method(
           #addRelayConfiguration,
           [relay],
@@ -1241,7 +1241,7 @@ class MockRelayScanService extends _i1.Mock implements _i5.RelayScanService {
       ) as _i7.Future<void>);
 
   @override
-  _i7.Future<void> updateRelayConfiguration(_i18.RelayConfiguration? relay) => (super.noSuchMethod(
+  _i7.Future<void> updateRelayConfiguration(_i19.RelayConfiguration? relay) => (super.noSuchMethod(
         Invocation.method(
           #updateRelayConfiguration,
           [relay],
@@ -1359,7 +1359,7 @@ class MockRelayScanService extends _i1.Mock implements _i5.RelayScanService {
 /// A class which mocks [BackupService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockBackupService extends _i1.Mock implements _i19.BackupService {
+class MockBackupService extends _i1.Mock implements _i20.BackupService {
   MockBackupService() {
     _i1.throwOnMissingStub(this);
   }
@@ -1369,7 +1369,7 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
     required String? vaultId,
     required int? threshold,
     required int? totalKeys,
-    required List<_i20.Steward>? stewards,
+    required List<_i21.Steward>? stewards,
     required List<String>? relays,
     String? instructions,
   }) =>
@@ -1442,7 +1442,7 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
       ) as _i7.Future<void>);
 
   @override
-  _i7.Future<List<_i8.Share>> generateShamirShares({
+  _i7.Future<List<_i9.Share>> generateShamirShares({
     required String? content,
     required int? threshold,
     required int? totalShards,
@@ -1471,18 +1471,18 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
             #pushEnabled: pushEnabled,
           },
         ),
-        returnValue: _i7.Future<List<_i8.Share>>.value(<_i8.Share>[]),
-      ) as _i7.Future<List<_i8.Share>>);
+        returnValue: _i7.Future<List<_i9.Share>>.value(<_i9.Share>[]),
+      ) as _i7.Future<List<_i9.Share>>);
 
   @override
-  _i7.Future<String> reconstructFromShares({required List<_i8.Share>? shares}) =>
+  _i7.Future<String> reconstructFromShares({required List<_i9.Share>? shares}) =>
       (super.noSuchMethod(
         Invocation.method(
           #reconstructFromShares,
           [],
           {#shares: shares},
         ),
-        returnValue: _i7.Future<String>.value(_i11.dummyValue<String>(
+        returnValue: _i7.Future<String>.value(_i12.dummyValue<String>(
           this,
           Invocation.method(
             #reconstructFromShares,
@@ -1495,7 +1495,7 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
   @override
   _i7.Future<void> updateBackupStatus(
     String? vaultId,
-    _i21.BackupStatus? status,
+    _i22.BackupStatus? status,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1513,7 +1513,7 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
   _i7.Future<void> updateStewardStatus({
     required String? vaultId,
     required String? pubkey,
-    required _i14.StewardStatus? status,
+    required _i15.StewardStatus? status,
     DateTime? acknowledgedAt,
     String? acknowledgmentEventId,
     String? giftWrapEventId,
@@ -1548,7 +1548,7 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
   _i7.Future<_i6.BackupConfig> mergeBackupConfig({
     required String? vaultId,
     int? threshold,
-    List<_i20.Steward>? stewards,
+    List<_i21.Steward>? stewards,
     List<String>? relays,
     String? instructions,
   }) =>
@@ -1628,7 +1628,7 @@ class MockBackupService extends _i1.Mock implements _i19.BackupService {
     required String? vaultId,
     required int? threshold,
     required int? totalKeys,
-    required List<_i20.Steward>? stewards,
+    required List<_i21.Steward>? stewards,
     required List<String>? relays,
     String? instructions,
   }) =>

--- a/test/services/ndk_service_inbound_test.dart
+++ b/test/services/ndk_service_inbound_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:ndk/entities.dart' show GiftWrapUnwrapResult;
 import 'package:ndk/ndk.dart';
 import 'package:horcrux/models/share.dart';
+import 'package:horcrux/services/ndk_service.dart';
 
 import '../fixtures/test_keys.dart';
 
@@ -33,6 +35,50 @@ Nip01Event _makeEvent({
 }
 
 void main() {
+  group('gift wrap seal verification', () {
+    GiftWrapUnwrapResult makeResult({
+      required bool isSealSignatureValid,
+      String sealPubkey = TestHexPubkeys.alice,
+      String rumorPubkey = TestHexPubkeys.alice,
+    }) {
+      return GiftWrapUnwrapResult(
+        isSealSignatureValid: isSealSignatureValid,
+        seal: _makeEvent(kind: 13, pubKey: sealPubkey),
+        rumor: _makeEvent(kind: 713, pubKey: rumorPubkey),
+      );
+    }
+
+    test('accepts valid seal signature when seal and rumor pubkeys match', () {
+      expect(
+        isVerifiedGiftWrapUnwrapResult(
+          makeResult(isSealSignatureValid: true),
+        ),
+        isTrue,
+      );
+    });
+
+    test('rejects invalid seal signature', () {
+      expect(
+        isVerifiedGiftWrapUnwrapResult(
+          makeResult(isSealSignatureValid: false),
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects seal and rumor pubkey mismatch', () {
+      expect(
+        isVerifiedGiftWrapUnwrapResult(
+          makeResult(
+            isSealSignatureValid: true,
+            rumorPubkey: TestHexPubkeys.bob,
+          ),
+        ),
+        isFalse,
+      );
+    });
+  });
+
   group('resolveVaultIdFromTags', () {
     test('returns vault_id for kind 713 (shareData)', () {
       final event = _makeEvent(kind: 713, tags: [

--- a/test/services/push_notification_receiver_test.mocks.dart
+++ b/test/services/push_notification_receiver_test.mocks.dart
@@ -5,15 +5,16 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i4;
 
-import 'package:horcrux/models/nostr_kinds.dart' as _i6;
-import 'package:horcrux/models/recovery_request.dart' as _i8;
-import 'package:horcrux/models/share.dart' as _i5;
-import 'package:horcrux/models/vault.dart' as _i11;
-import 'package:horcrux/services/horcrux_notification_service.dart' as _i9;
-import 'package:horcrux/services/local_notification_service.dart' as _i7;
+import 'package:horcrux/models/nostr_kinds.dart' as _i7;
+import 'package:horcrux/models/recovery_request.dart' as _i9;
+import 'package:horcrux/models/share.dart' as _i6;
+import 'package:horcrux/models/vault.dart' as _i12;
+import 'package:horcrux/services/horcrux_notification_service.dart' as _i10;
+import 'package:horcrux/services/local_notification_service.dart' as _i8;
 import 'package:horcrux/services/ndk_service.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i10;
+import 'package:mockito/src/dummies.dart' as _i11;
+import 'package:ndk/entities.dart' as _i5;
 import 'package:ndk/ndk.dart' as _i2;
 
 // ignore_for_file: type=lint
@@ -96,7 +97,7 @@ class MockNdkService extends _i1.Mock implements _i3.NdkService {
 
   @override
   _i4.Future<void> processGiftWrapFromForegroundPush(
-    _i2.Nip01Event? event, {
+    _i5.Nip01Event? event, {
     bool? allowLocalNotification = true,
   }) =>
       (super.noSuchMethod(
@@ -110,7 +111,7 @@ class MockNdkService extends _i1.Mock implements _i3.NdkService {
       ) as _i4.Future<void>);
 
   @override
-  _i4.Future<_i2.Nip01Event?> fetchGiftWrapByIdForPush({
+  _i4.Future<_i5.Nip01Event?> fetchGiftWrapByIdForPush({
     required String? eventIdHex,
     List<String>? relayHints,
   }) =>
@@ -123,11 +124,11 @@ class MockNdkService extends _i1.Mock implements _i3.NdkService {
             #relayHints: relayHints,
           },
         ),
-        returnValue: _i4.Future<_i2.Nip01Event?>.value(),
-      ) as _i4.Future<_i2.Nip01Event?>);
+        returnValue: _i4.Future<_i5.Nip01Event?>.value(),
+      ) as _i4.Future<_i5.Nip01Event?>);
 
   @override
-  _i4.Future<_i5.Share?> loadShareDataFromPublishedDistributionGiftWrap({
+  _i4.Future<_i6.Share?> loadShareDataFromPublishedDistributionGiftWrap({
     required String? giftWrapEventId,
     required List<String>? relayHints,
   }) =>
@@ -140,11 +141,11 @@ class MockNdkService extends _i1.Mock implements _i3.NdkService {
             #relayHints: relayHints,
           },
         ),
-        returnValue: _i4.Future<_i5.Share?>.value(),
-      ) as _i4.Future<_i5.Share?>);
+        returnValue: _i4.Future<_i6.Share?>.value(),
+      ) as _i4.Future<_i6.Share?>);
 
   @override
-  _i4.Future<String?> resolveVaultIdForGiftWrap(_i2.Nip01Event? giftWrap) => (super.noSuchMethod(
+  _i4.Future<String?> resolveVaultIdForGiftWrap(_i5.Nip01Event? giftWrap) => (super.noSuchMethod(
         Invocation.method(
           #resolveVaultIdForGiftWrap,
           [giftWrap],
@@ -153,15 +154,15 @@ class MockNdkService extends _i1.Mock implements _i3.NdkService {
       ) as _i4.Future<String?>);
 
   @override
-  _i4.Future<({_i6.NostrKind kind, String recoveryRequestId})?> resolveRecoveryRequestIdForGiftWrap(
-          _i2.Nip01Event? giftWrap) =>
+  _i4.Future<({_i7.NostrKind kind, String recoveryRequestId})?> resolveRecoveryRequestIdForGiftWrap(
+          _i5.Nip01Event? giftWrap) =>
       (super.noSuchMethod(
         Invocation.method(
           #resolveRecoveryRequestIdForGiftWrap,
           [giftWrap],
         ),
-        returnValue: _i4.Future<({_i6.NostrKind kind, String recoveryRequestId})?>.value(),
-      ) as _i4.Future<({_i6.NostrKind kind, String recoveryRequestId})?>);
+        returnValue: _i4.Future<({_i7.NostrKind kind, String recoveryRequestId})?>.value(),
+      ) as _i4.Future<({_i7.NostrKind kind, String recoveryRequestId})?>);
 
   @override
   _i4.Future<void> closeSubscriptions() => (super.noSuchMethod(
@@ -204,7 +205,7 @@ class MockNdkService extends _i1.Mock implements _i3.NdkService {
       ) as _i4.Future<String?>);
 
   @override
-  _i4.Future<_i2.Nip01Event?> publishEncryptedEvent({
+  _i4.Future<_i5.Nip01Event?> publishEncryptedEvent({
     required String? content,
     required int? kind,
     required String? recipientPubkey,
@@ -229,11 +230,11 @@ class MockNdkService extends _i1.Mock implements _i3.NdkService {
             #nip40Expiration: nip40Expiration,
           },
         ),
-        returnValue: _i4.Future<_i2.Nip01Event?>.value(),
-      ) as _i4.Future<_i2.Nip01Event?>);
+        returnValue: _i4.Future<_i5.Nip01Event?>.value(),
+      ) as _i4.Future<_i5.Nip01Event?>);
 
   @override
-  _i4.Future<List<_i2.Nip01Event?>> publishEncryptedEventToMultiple({
+  _i4.Future<List<_i5.Nip01Event?>> publishEncryptedEventToMultiple({
     required String? content,
     required int? kind,
     required List<String>? recipientPubkeys,
@@ -258,8 +259,8 @@ class MockNdkService extends _i1.Mock implements _i3.NdkService {
             #nip40Expiration: nip40Expiration,
           },
         ),
-        returnValue: _i4.Future<List<_i2.Nip01Event?>>.value(<_i2.Nip01Event?>[]),
-      ) as _i4.Future<List<_i2.Nip01Event?>>);
+        returnValue: _i4.Future<List<_i5.Nip01Event?>>.value(<_i5.Nip01Event?>[]),
+      ) as _i4.Future<List<_i5.Nip01Event?>>);
 
   @override
   _i4.Future<_i2.Ndk> getNdk() => (super.noSuchMethod(
@@ -308,7 +309,7 @@ class MockNdkService extends _i1.Mock implements _i3.NdkService {
 /// A class which mocks [LocalNotificationService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockLocalNotificationService extends _i1.Mock implements _i7.LocalNotificationService {
+class MockLocalNotificationService extends _i1.Mock implements _i8.LocalNotificationService {
   MockLocalNotificationService() {
     _i1.throwOnMissingStub(this);
   }
@@ -324,7 +325,7 @@ class MockLocalNotificationService extends _i1.Mock implements _i7.LocalNotifica
       ) as _i4.Future<void>);
 
   @override
-  _i4.Future<void> notifyRecoveryRequestProcessed(_i8.RecoveryRequest? request) =>
+  _i4.Future<void> notifyRecoveryRequestProcessed(_i9.RecoveryRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #notifyRecoveryRequestProcessed,
@@ -347,8 +348,8 @@ class MockLocalNotificationService extends _i1.Mock implements _i7.LocalNotifica
 
   @override
   _i4.Future<void> notifyShareDataProcessed({
-    required _i2.Nip01Event? event,
-    required _i5.Share? share,
+    required _i5.Nip01Event? event,
+    required _i6.Share? share,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -365,7 +366,7 @@ class MockLocalNotificationService extends _i1.Mock implements _i7.LocalNotifica
 
   @override
   _i4.Future<void> notifyShareConfirmationProcessed({
-    required _i2.Nip01Event? event,
+    required _i5.Nip01Event? event,
     required String? vaultId,
   }) =>
       (super.noSuchMethod(
@@ -421,7 +422,7 @@ class MockLocalNotificationService extends _i1.Mock implements _i7.LocalNotifica
 
   @override
   _i4.Future<bool> navigateForKind(
-    _i6.NostrKind? kind,
+    _i7.NostrKind? kind,
     String? id, {
     String? vaultId,
   }) =>
@@ -460,7 +461,7 @@ class MockLocalNotificationService extends _i1.Mock implements _i7.LocalNotifica
 /// A class which mocks [HorcruxNotificationService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockHorcruxNotificationService extends _i1.Mock implements _i9.HorcruxNotificationService {
+class MockHorcruxNotificationService extends _i1.Mock implements _i10.HorcruxNotificationService {
   MockHorcruxNotificationService() {
     _i1.throwOnMissingStub(this);
   }
@@ -471,7 +472,7 @@ class MockHorcruxNotificationService extends _i1.Mock implements _i9.HorcruxNoti
           #getBaseUrl,
           [],
         ),
-        returnValue: _i4.Future<String>.value(_i10.dummyValue<String>(
+        returnValue: _i4.Future<String>.value(_i11.dummyValue<String>(
           this,
           Invocation.method(
             #getBaseUrl,
@@ -493,7 +494,7 @@ class MockHorcruxNotificationService extends _i1.Mock implements _i9.HorcruxNoti
   @override
   _i4.Future<void> register({
     required String? fcmToken,
-    required _i9.NotifierPlatform? platform,
+    required _i10.NotifierPlatform? platform,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -521,7 +522,7 @@ class MockHorcruxNotificationService extends _i1.Mock implements _i9.HorcruxNoti
   @override
   _i4.Future<void> updateToken({
     required String? newToken,
-    required _i9.NotifierPlatform? platform,
+    required _i10.NotifierPlatform? platform,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -549,7 +550,7 @@ class MockHorcruxNotificationService extends _i1.Mock implements _i9.HorcruxNoti
   @override
   List<String> computeConsentList({
     required String? currentUserPubkey,
-    required List<_i11.Vault>? vaults,
+    required List<_i12.Vault>? vaults,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -585,9 +586,9 @@ class MockHorcruxNotificationService extends _i1.Mock implements _i9.HorcruxNoti
 
   @override
   _i4.Future<void> tryPushForEvent({
-    required _i2.Nip01Event? event,
-    required _i6.NostrKind? kind,
-    required _i11.Vault? vault,
+    required _i5.Nip01Event? event,
+    required _i7.NostrKind? kind,
+    required _i12.Vault? vault,
     List<String>? relayHints,
     bool? recoveryApproved,
   }) =>

--- a/test/services/vault_share_service_test.dart
+++ b/test/services/vault_share_service_test.dart
@@ -253,12 +253,66 @@ void main() {
           relayUrls: ['wss://relay.example.com'],
           nostrEventId: 'process-vault-share-push-opt-in',
         );
-        await service.processVaultShare(vaultId, shard);
+        await service.processVaultShare(
+          vaultId,
+          shard,
+          verifiedSenderPubkey: ownerPubkey,
+        );
 
         verify(mockPushReceiver.isOptedIn()).called(1);
         verify(mockPushReceiver.optIn()).called(1);
       },
     );
+
+    test('rejects share when verified sender does not match claimed creator', () async {
+      final shard = buildShard(index: 0, distributionVersion: 1);
+
+      await service.processVaultShare(
+        vaultId,
+        shard,
+        verifiedSenderPubkey: TestHexPubkeys.bob,
+      );
+
+      expect(await repository.getVault(vaultId), isNull);
+    });
+
+    test('rejects share when claimed creator differs from existing vault owner', () async {
+      final existing = Vault(
+        id: vaultId,
+        name: 'Original Vault',
+        createdAt: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+        ownerPubkey: ownerPubkey,
+        ownerName: 'Alice',
+        pushEnabled: false,
+      );
+      await repository.addVault(existing);
+
+      final maliciousShard = createShare(
+        payload: 'abc123',
+        threshold: 2,
+        shareIndex: 0,
+        totalShares: 3,
+        scheme: null,
+        creatorPubkey: TestHexPubkeys.bob,
+        vaultId: vaultId,
+        vaultName: 'Forged Vault',
+        pushEnabled: true,
+        distributionVersion: 2,
+      );
+
+      await service.processVaultShare(
+        vaultId,
+        maliciousShard,
+        verifiedSenderPubkey: TestHexPubkeys.bob,
+      );
+
+      final stored = await repository.getVault(vaultId);
+      expect(stored, isNotNull);
+      expect(stored!.ownerPubkey, ownerPubkey);
+      expect(stored.name, 'Original Vault');
+      expect(stored.pushEnabled, isFalse);
+      expect(await repository.getSharesForVault(vaultId), isEmpty);
+    });
   });
 
   group('VaultShareService.sendShareConfirmationEvent wire tags', () {
@@ -823,7 +877,11 @@ void main() {
         nostrEventId: 'manifest-event-1',
       );
 
-      await service.processVaultShare(vaultId, manifest);
+      await service.processVaultShare(
+        vaultId,
+        manifest,
+        verifiedSenderPubkey: owner,
+      );
 
       final shares = await repository.getSharesForVault(vaultId);
       expect(shares, isEmpty);
@@ -896,6 +954,7 @@ void main() {
             vaultName: 'FromVThree',
             nostrEventId: 'manifest-v3-first',
           ),
+          verifiedSenderPubkey: owner,
         );
 
         await service.processVaultShare(
@@ -905,6 +964,7 @@ void main() {
             vaultName: 'FromVTwoStale',
             nostrEventId: 'manifest-v2-late',
           ),
+          verifiedSenderPubkey: owner,
         );
 
         final v = await repository.getVault(orderVaultId);
@@ -942,7 +1002,11 @@ void main() {
           nostrEventId: 'manifest-shell-a',
         );
 
-        await service.processVaultShare(shellVaultId, manifest);
+        await service.processVaultShare(
+          shellVaultId,
+          manifest,
+          verifiedSenderPubkey: owner,
+        );
         expect(await repository.isOwnedVault(shellVaultId), isTrue);
 
         await repository.deleteVaultContent(shellVaultId);
@@ -954,6 +1018,7 @@ void main() {
             instructions: 'Replay same dist',
             nostrEventId: 'manifest-shell-b',
           ),
+          verifiedSenderPubkey: owner,
         );
 
         expect(await repository.isOwnedVault(shellVaultId), isTrue);
@@ -968,6 +1033,71 @@ void main() {
         );
       },
     );
+
+    test('rejects manifest when verified sender does not match claimed creator', () async {
+      const manifest = Share(
+        payload: '',
+        threshold: 2,
+        shareIndex: -1,
+        totalShares: 2,
+        scheme: null,
+        creatorPubkey: owner,
+        createdAt: 1700000000,
+        vaultId: vaultId,
+        vaultName: 'Forged Manifest',
+        ownerName: 'Alice',
+        distributionVersion: 1,
+      );
+
+      await service.processVaultShare(
+        vaultId,
+        manifest,
+        verifiedSenderPubkey: TestHexPubkeys.bob,
+      );
+
+      expect(await repository.getVault(vaultId), isNull);
+    });
+
+    test('rejects manifest when claimed creator differs from existing vault owner', () async {
+      final existing = Vault(
+        id: vaultId,
+        name: 'Original Manifest Vault',
+        createdAt: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+        ownerPubkey: owner,
+        ownerName: 'Alice',
+        pushEnabled: false,
+      );
+      await repository.addVault(existing);
+
+      const manifest = Share(
+        payload: '',
+        threshold: 2,
+        shareIndex: -1,
+        totalShares: 2,
+        scheme: null,
+        creatorPubkey: TestHexPubkeys.bob,
+        createdAt: 1700000000,
+        vaultId: vaultId,
+        vaultName: 'Forged Manifest',
+        ownerName: 'Mallory',
+        pushEnabled: true,
+        distributionVersion: 2,
+      );
+
+      await service.processVaultShare(
+        vaultId,
+        manifest,
+        verifiedSenderPubkey: TestHexPubkeys.bob,
+      );
+
+      final stored = await repository.getVault(vaultId);
+      expect(stored, isNotNull);
+      expect(stored!.ownerPubkey, owner);
+      expect(stored.name, 'Original Manifest Vault');
+      expect(stored.ownerName, 'Alice');
+      expect(stored.pushEnabled, isFalse);
+      expect(stored.backupConfig, isNull);
+    });
   });
 
   group('processKeyHolderRemoval', () {
@@ -1180,7 +1310,11 @@ void main() {
         relayUrls: [relayUrl],
       );
 
-      await service.processVaultShare(vaultId, shard);
+      await service.processVaultShare(
+        vaultId,
+        shard,
+        verifiedSenderPubkey: ownerPubkey,
+      );
 
       verify(mockRelayScanService.syncRelaysFromUrls([relayUrl])).called(1);
     });
@@ -1198,7 +1332,11 @@ void main() {
         relayUrls: null,
       );
 
-      await service.processVaultShare(vaultId, shard);
+      await service.processVaultShare(
+        vaultId,
+        shard,
+        verifiedSenderPubkey: ownerPubkey,
+      );
 
       verifyNever(mockRelayScanService.syncRelaysFromUrls(any));
     });

--- a/test/services/vault_share_service_test.mocks.dart
+++ b/test/services/vault_share_service_test.mocks.dart
@@ -5,18 +5,19 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i7;
 
-import 'package:firebase_messaging/firebase_messaging.dart' as _i14;
-import 'package:horcrux/models/nostr_kinds.dart' as _i10;
-import 'package:horcrux/models/relay_configuration.dart' as _i15;
-import 'package:horcrux/models/share.dart' as _i9;
-import 'package:horcrux/models/vault.dart' as _i12;
-import 'package:horcrux/services/horcrux_notification_service.dart' as _i11;
+import 'package:firebase_messaging/firebase_messaging.dart' as _i15;
+import 'package:horcrux/models/nostr_kinds.dart' as _i11;
+import 'package:horcrux/models/relay_configuration.dart' as _i16;
+import 'package:horcrux/models/share.dart' as _i10;
+import 'package:horcrux/models/vault.dart' as _i13;
+import 'package:horcrux/services/horcrux_notification_service.dart' as _i12;
 import 'package:horcrux/services/login_service.dart' as _i6;
 import 'package:horcrux/services/ndk_service.dart' as _i4;
-import 'package:horcrux/services/push_notification_receiver.dart' as _i13;
+import 'package:horcrux/services/push_notification_receiver.dart' as _i14;
 import 'package:horcrux/services/relay_scan_service.dart' as _i5;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i8;
+import 'package:ndk/entities.dart' as _i9;
 import 'package:ndk/ndk.dart' as _i3;
 import 'package:ndk/shared/nips/nip01/key_pair.dart' as _i2;
 
@@ -336,7 +337,7 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
 
   @override
   _i7.Future<void> processGiftWrapFromForegroundPush(
-    _i3.Nip01Event? event, {
+    _i9.Nip01Event? event, {
     bool? allowLocalNotification = true,
   }) =>
       (super.noSuchMethod(
@@ -350,7 +351,7 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
       ) as _i7.Future<void>);
 
   @override
-  _i7.Future<_i3.Nip01Event?> fetchGiftWrapByIdForPush({
+  _i7.Future<_i9.Nip01Event?> fetchGiftWrapByIdForPush({
     required String? eventIdHex,
     List<String>? relayHints,
   }) =>
@@ -363,11 +364,11 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
             #relayHints: relayHints,
           },
         ),
-        returnValue: _i7.Future<_i3.Nip01Event?>.value(),
-      ) as _i7.Future<_i3.Nip01Event?>);
+        returnValue: _i7.Future<_i9.Nip01Event?>.value(),
+      ) as _i7.Future<_i9.Nip01Event?>);
 
   @override
-  _i7.Future<_i9.Share?> loadShareDataFromPublishedDistributionGiftWrap({
+  _i7.Future<_i10.Share?> loadShareDataFromPublishedDistributionGiftWrap({
     required String? giftWrapEventId,
     required List<String>? relayHints,
   }) =>
@@ -380,11 +381,11 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
             #relayHints: relayHints,
           },
         ),
-        returnValue: _i7.Future<_i9.Share?>.value(),
-      ) as _i7.Future<_i9.Share?>);
+        returnValue: _i7.Future<_i10.Share?>.value(),
+      ) as _i7.Future<_i10.Share?>);
 
   @override
-  _i7.Future<String?> resolveVaultIdForGiftWrap(_i3.Nip01Event? giftWrap) => (super.noSuchMethod(
+  _i7.Future<String?> resolveVaultIdForGiftWrap(_i9.Nip01Event? giftWrap) => (super.noSuchMethod(
         Invocation.method(
           #resolveVaultIdForGiftWrap,
           [giftWrap],
@@ -393,14 +394,14 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
       ) as _i7.Future<String?>);
 
   @override
-  _i7.Future<({_i10.NostrKind kind, String recoveryRequestId})?>
-      resolveRecoveryRequestIdForGiftWrap(_i3.Nip01Event? giftWrap) => (super.noSuchMethod(
+  _i7.Future<({_i11.NostrKind kind, String recoveryRequestId})?>
+      resolveRecoveryRequestIdForGiftWrap(_i9.Nip01Event? giftWrap) => (super.noSuchMethod(
             Invocation.method(
               #resolveRecoveryRequestIdForGiftWrap,
               [giftWrap],
             ),
-            returnValue: _i7.Future<({_i10.NostrKind kind, String recoveryRequestId})?>.value(),
-          ) as _i7.Future<({_i10.NostrKind kind, String recoveryRequestId})?>);
+            returnValue: _i7.Future<({_i11.NostrKind kind, String recoveryRequestId})?>.value(),
+          ) as _i7.Future<({_i11.NostrKind kind, String recoveryRequestId})?>);
 
   @override
   _i7.Future<void> closeSubscriptions() => (super.noSuchMethod(
@@ -443,7 +444,7 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
       ) as _i7.Future<String?>);
 
   @override
-  _i7.Future<_i3.Nip01Event?> publishEncryptedEvent({
+  _i7.Future<_i9.Nip01Event?> publishEncryptedEvent({
     required String? content,
     required int? kind,
     required String? recipientPubkey,
@@ -468,11 +469,11 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
             #nip40Expiration: nip40Expiration,
           },
         ),
-        returnValue: _i7.Future<_i3.Nip01Event?>.value(),
-      ) as _i7.Future<_i3.Nip01Event?>);
+        returnValue: _i7.Future<_i9.Nip01Event?>.value(),
+      ) as _i7.Future<_i9.Nip01Event?>);
 
   @override
-  _i7.Future<List<_i3.Nip01Event?>> publishEncryptedEventToMultiple({
+  _i7.Future<List<_i9.Nip01Event?>> publishEncryptedEventToMultiple({
     required String? content,
     required int? kind,
     required List<String>? recipientPubkeys,
@@ -497,8 +498,8 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
             #nip40Expiration: nip40Expiration,
           },
         ),
-        returnValue: _i7.Future<List<_i3.Nip01Event?>>.value(<_i3.Nip01Event?>[]),
-      ) as _i7.Future<List<_i3.Nip01Event?>>);
+        returnValue: _i7.Future<List<_i9.Nip01Event?>>.value(<_i9.Nip01Event?>[]),
+      ) as _i7.Future<List<_i9.Nip01Event?>>);
 
   @override
   _i7.Future<_i3.Ndk> getNdk() => (super.noSuchMethod(
@@ -547,7 +548,7 @@ class MockNdkService extends _i1.Mock implements _i4.NdkService {
 /// A class which mocks [HorcruxNotificationService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockHorcruxNotificationService extends _i1.Mock implements _i11.HorcruxNotificationService {
+class MockHorcruxNotificationService extends _i1.Mock implements _i12.HorcruxNotificationService {
   MockHorcruxNotificationService() {
     _i1.throwOnMissingStub(this);
   }
@@ -580,7 +581,7 @@ class MockHorcruxNotificationService extends _i1.Mock implements _i11.HorcruxNot
   @override
   _i7.Future<void> register({
     required String? fcmToken,
-    required _i11.NotifierPlatform? platform,
+    required _i12.NotifierPlatform? platform,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -608,7 +609,7 @@ class MockHorcruxNotificationService extends _i1.Mock implements _i11.HorcruxNot
   @override
   _i7.Future<void> updateToken({
     required String? newToken,
-    required _i11.NotifierPlatform? platform,
+    required _i12.NotifierPlatform? platform,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -636,7 +637,7 @@ class MockHorcruxNotificationService extends _i1.Mock implements _i11.HorcruxNot
   @override
   List<String> computeConsentList({
     required String? currentUserPubkey,
-    required List<_i12.Vault>? vaults,
+    required List<_i13.Vault>? vaults,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -672,9 +673,9 @@ class MockHorcruxNotificationService extends _i1.Mock implements _i11.HorcruxNot
 
   @override
   _i7.Future<void> tryPushForEvent({
-    required _i3.Nip01Event? event,
-    required _i10.NostrKind? kind,
-    required _i12.Vault? vault,
+    required _i9.Nip01Event? event,
+    required _i11.NostrKind? kind,
+    required _i13.Vault? vault,
     List<String>? relayHints,
     bool? recoveryApproved,
   }) =>
@@ -733,7 +734,7 @@ class MockHorcruxNotificationService extends _i1.Mock implements _i11.HorcruxNot
 /// A class which mocks [PushNotificationReceiver].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockPushNotificationReceiver extends _i1.Mock implements _i13.PushNotificationReceiver {
+class MockPushNotificationReceiver extends _i1.Mock implements _i14.PushNotificationReceiver {
   MockPushNotificationReceiver() {
     _i1.throwOnMissingStub(this);
   }
@@ -787,7 +788,7 @@ class MockPushNotificationReceiver extends _i1.Mock implements _i13.PushNotifica
       ) as _i7.Future<void>);
 
   @override
-  _i7.Future<void> handleNotificationTap(_i14.RemoteMessage? message) => (super.noSuchMethod(
+  _i7.Future<void> handleNotificationTap(_i15.RemoteMessage? message) => (super.noSuchMethod(
         Invocation.method(
           #handleNotificationTap,
           [message],
@@ -843,28 +844,28 @@ class MockRelayScanService extends _i1.Mock implements _i5.RelayScanService {
       ) as _i7.Future<void>);
 
   @override
-  _i7.Future<List<_i15.RelayConfiguration>> getRelayConfigurations({bool? enabledOnly}) =>
+  _i7.Future<List<_i16.RelayConfiguration>> getRelayConfigurations({bool? enabledOnly}) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRelayConfigurations,
           [],
           {#enabledOnly: enabledOnly},
         ),
-        returnValue: _i7.Future<List<_i15.RelayConfiguration>>.value(<_i15.RelayConfiguration>[]),
-      ) as _i7.Future<List<_i15.RelayConfiguration>>);
+        returnValue: _i7.Future<List<_i16.RelayConfiguration>>.value(<_i16.RelayConfiguration>[]),
+      ) as _i7.Future<List<_i16.RelayConfiguration>>);
 
   @override
-  _i7.Future<_i15.RelayConfiguration?> getRelayConfiguration(String? relayId) =>
+  _i7.Future<_i16.RelayConfiguration?> getRelayConfiguration(String? relayId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRelayConfiguration,
           [relayId],
         ),
-        returnValue: _i7.Future<_i15.RelayConfiguration?>.value(),
-      ) as _i7.Future<_i15.RelayConfiguration?>);
+        returnValue: _i7.Future<_i16.RelayConfiguration?>.value(),
+      ) as _i7.Future<_i16.RelayConfiguration?>);
 
   @override
-  _i7.Future<void> addRelayConfiguration(_i15.RelayConfiguration? relay) => (super.noSuchMethod(
+  _i7.Future<void> addRelayConfiguration(_i16.RelayConfiguration? relay) => (super.noSuchMethod(
         Invocation.method(
           #addRelayConfiguration,
           [relay],
@@ -874,7 +875,7 @@ class MockRelayScanService extends _i1.Mock implements _i5.RelayScanService {
       ) as _i7.Future<void>);
 
   @override
-  _i7.Future<void> updateRelayConfiguration(_i15.RelayConfiguration? relay) => (super.noSuchMethod(
+  _i7.Future<void> updateRelayConfiguration(_i16.RelayConfiguration? relay) => (super.noSuchMethod(
         Invocation.method(
           #updateRelayConfiguration,
           [relay],

--- a/test/utils/shamir_gf256/secret_scheme_test.dart
+++ b/test/utils/shamir_gf256/secret_scheme_test.dart
@@ -366,10 +366,8 @@ void main() {
       final poly = BytePolynomial(0); // degree-0
       poly.generateCoefficients(0x00, rng); // secret byte is 0
       expect(poly.isGenerated, isTrue);
-      expect(poly.coefficients[0], 0x00,
-          reason: 'degree-0 must preserve zero secret byte');
-      expect(poly.constantAtZero, 0x00,
-          reason: 'constantAtZero must return 0');
+      expect(poly.coefficients[0], 0x00, reason: 'degree-0 must preserve zero secret byte');
+      expect(poly.constantAtZero, 0x00, reason: 'constantAtZero must return 0');
     });
 
     test('degree-0 polynomial preserves non-zero secret byte', () {


### PR DESCRIPTION
## Beads
horcrux_app-uugm
horcrux_app-4own

## Summary
- Verify inbound gift-wrap seal signatures and seal/rumor pubkey matches before routing events.
- Thread the verified seal pubkey into Kind 1337 share handling.
- Reject vault share/manifests before upsert when the verified sender does not match the claimed creator, or when an existing vault owner differs from the claimed creator.

## Testing
- `dart format`
- `ReadLints` on edited files
- `flutter analyze`
- `flutter test test/services/vault_share_service_test.dart test/services/ndk_service_inbound_test.dart`
- `flutter test --exclude-tags=golden`

## Notes
Remaining per-kind authorization checks for 1338/1339/1340/1341/1342/1345 stay tracked in horcrux_app-uugm.

Made with [Cursor](https://cursor.com)