### PR TITLE
Centralize event authorization policies

### DIFF
--- a/lib/services/event_authorizer.dart
+++ b/lib/services/event_authorizer.dart
@@ -1,0 +1,152 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:ndk/ndk.dart';
+
+import '../database/app_database.dart';
+import '../database/app_database_provider.dart';
+import '../models/nostr_kinds.dart';
+import '../models/share.dart';
+import '../models/vault.dart';
+import '../providers/vault_provider.dart';
+
+final eventAuthorizerProvider = Provider<EventAuthorizer>((ref) {
+  return EventAuthorizer(
+    ref.read(vaultRepositoryProvider),
+    ref.watch(appDatabaseProvider),
+  );
+});
+
+enum AuthDecision { allow, deny }
+
+/// Authorizes unwrapped Horcrux Nostr events before they reach service handlers.
+///
+/// Each routed kind is listed explicitly. Unknown or unrouted kinds deny by
+/// default so newly introduced handlers must add a reviewed policy first.
+class EventAuthorizer {
+  EventAuthorizer(this._vaultRepository, this._db);
+
+  final VaultRepository _vaultRepository;
+  final AppDatabase _db;
+
+  Future<AuthDecision> authorize({
+    required Nip01Event rumor,
+    required String verifiedSenderPubkey,
+  }) async {
+    final kind = NostrKind.fromValue(rumor.kind);
+    switch (kind) {
+      case NostrKind.shareData:
+        return _authorizeShareData(rumor, verifiedSenderPubkey);
+      case NostrKind.invitationAcceptance:
+        return _authorizeInvitation(rumor, verifiedSenderPubkey);
+      case NostrKind.invitationDenial:
+        return _authorizeInvitation(rumor, verifiedSenderPubkey);
+      case NostrKind.recoveryRequest:
+        return _authorizeStewardOrOwner(rumor, verifiedSenderPubkey);
+      case NostrKind.recoveryResponse:
+        return _authorizeRecoveryResponder(rumor, verifiedSenderPubkey);
+      case NostrKind.shareConfirmation:
+        return _authorizeKnownSteward(rumor, verifiedSenderPubkey);
+      case NostrKind.keyHolderRemoved:
+        return _authorizeOwnerOnly(rumor, verifiedSenderPubkey);
+
+      // deny all kinds without handlers in NdkService.
+      case NostrKind.seal:
+      case NostrKind.giftWrap:
+      case NostrKind.httpAuth:
+      case NostrKind.shareError:
+      case NostrKind.invitationInvalid:
+      case null:
+        return AuthDecision.deny;
+    }
+  }
+
+  Future<AuthDecision> _authorizeShareData(Nip01Event rumor, String verifiedSenderPubkey) async {
+    final share = shareFromNostr(rumor);
+    final vaultId = share.vaultId;
+    if (vaultId == null || vaultId.isEmpty) return AuthDecision.deny;
+    if (verifiedSenderPubkey != share.creatorPubkey) return AuthDecision.deny;
+
+    final existingVault = await _vaultRepository.getVault(vaultId);
+    if (existingVault != null && share.creatorPubkey != existingVault.ownerPubkey) {
+      return AuthDecision.deny;
+    }
+    return AuthDecision.allow;
+  }
+
+  Future<AuthDecision> _authorizeInvitation(
+    Nip01Event rumor,
+    String verifiedSenderPubkey,
+  ) async {
+    final inviteCode = _firstTagValue(rumor.tags, 'invite_code');
+    if (inviteCode == null) return AuthDecision.deny;
+
+    final invitation = await _db.invitationDao.getByCode(inviteCode);
+    if (invitation == null) return AuthDecision.deny;
+    final redeemedBy = invitation.acceptedByPubkey;
+    if (redeemedBy != null && redeemedBy != verifiedSenderPubkey) {
+      return AuthDecision.deny;
+    }
+    return AuthDecision.allow;
+  }
+
+  Future<AuthDecision> _authorizeOwnerOnly(Nip01Event rumor, String verifiedSenderPubkey) async {
+    final vault = await _vaultFromEvent(rumor);
+    if (vault == null) return AuthDecision.deny;
+    return vault.ownerPubkey == verifiedSenderPubkey ? AuthDecision.allow : AuthDecision.deny;
+  }
+
+  Future<AuthDecision> _authorizeKnownSteward(Nip01Event rumor, String verifiedSenderPubkey) async {
+    final vault = await _vaultFromEvent(rumor);
+    if (vault == null) return AuthDecision.deny;
+    return _isKnownSteward(vault, verifiedSenderPubkey) ? AuthDecision.allow : AuthDecision.deny;
+  }
+
+  Future<AuthDecision> _authorizeStewardOrOwner(
+    Nip01Event rumor,
+    String verifiedSenderPubkey,
+  ) async {
+    final vault = await _vaultFromEvent(rumor);
+    if (vault == null) return AuthDecision.deny;
+    final isMember =
+        vault.ownerPubkey == verifiedSenderPubkey || _isKnownSteward(vault, verifiedSenderPubkey);
+    return isMember ? AuthDecision.allow : AuthDecision.deny;
+  }
+
+  Future<AuthDecision> _authorizeRecoveryResponder(
+    Nip01Event rumor,
+    String verifiedSenderPubkey,
+  ) async {
+    final vaultId = _firstTagValue(rumor.tags, 'vault_id');
+    final recoveryRequestId = _firstTagValue(rumor.tags, 'recovery_request_id');
+    if (vaultId == null || recoveryRequestId == null) return AuthDecision.deny;
+
+    final requests = await _vaultRepository.getRecoveryRequestsForVault(vaultId);
+    for (final request in requests) {
+      if (request.id == recoveryRequestId &&
+          request.stewardPubkeys.contains(verifiedSenderPubkey)) {
+        return AuthDecision.allow;
+      }
+    }
+    return AuthDecision.deny;
+  }
+
+  Future<Vault?> _vaultFromEvent(Nip01Event rumor) async {
+    final vaultId = _firstTagValue(rumor.tags, 'vault_id');
+    if (vaultId == null) return null;
+    return _vaultRepository.getVault(vaultId);
+  }
+
+  bool _isKnownSteward(Vault vault, String verifiedSenderPubkey) {
+    final stewards = vault.backupConfig?.stewards ?? const [];
+    return stewards.any((steward) => steward.pubkey == verifiedSenderPubkey);
+  }
+
+  String? _firstTagValue(List<List<String>> tags, String name) {
+    for (final tag in tags) {
+      if (tag.length >= 2 && tag[0] == name) {
+        final value = tag[1];
+        return value.isEmpty ? null : value;
+      }
+    }
+    return null;
+  }
+}

--- a/lib/services/event_authorizer.dart
+++ b/lib/services/event_authorizer.dart
@@ -78,9 +78,12 @@ class EventAuthorizer {
   ) async {
     final inviteCode = _firstTagValue(rumor.tags, 'invite_code');
     if (inviteCode == null) return AuthDecision.deny;
+    final vaultId = _firstTagValue(rumor.tags, 'vault_id');
+    if (vaultId == null) return AuthDecision.deny;
 
     final invitation = await _db.invitationDao.getByCode(inviteCode);
     if (invitation == null) return AuthDecision.deny;
+    if (invitation.vaultId != vaultId) return AuthDecision.deny;
     final redeemedBy = invitation.acceptedByPubkey;
     if (redeemedBy != null && redeemedBy != verifiedSenderPubkey) {
       return AuthDecision.deny;

--- a/lib/services/invitation_sending_service.dart
+++ b/lib/services/invitation_sending_service.dart
@@ -73,6 +73,7 @@ class InvitationSendingService {
   /// Returns event ID, or null if publishing fails.
   Future<String?> sendDenialEvent({
     required String inviteCode,
+    required String vaultId,
     required String ownerPubkey, // Hex format
     required List<String> relayUrls,
   }) async {
@@ -89,6 +90,7 @@ class InvitationSendingService {
         relays: relayUrls,
         tags: [
           ['invite_code', inviteCode],
+          ['vault_id', vaultId],
         ],
       );
       return event?.id;

--- a/lib/services/invitation_service.dart
+++ b/lib/services/invitation_service.dart
@@ -851,6 +851,14 @@ class InvitationService {
       return; // Silently ignore if invitation not found
     }
 
+    if (invitation.redeemedBy != null && invitation.redeemedBy != inviteePubkey) {
+      Log.warning(
+        'Ignoring denial event for invitation $inviteCode from $inviteePubkey: '
+        'already redeemed by ${invitation.redeemedBy}',
+      );
+      return;
+    }
+
     // Update invitation status to denied
     final deniedInvitation = invitation.updateStatus(InvitationStatus.denied);
     await _saveInvitation(deniedInvitation);

--- a/lib/services/invitation_service.dart
+++ b/lib/services/invitation_service.dart
@@ -515,6 +515,7 @@ class InvitationService {
     try {
       await invitationSendingService.sendDenialEvent(
         inviteCode: inviteCode,
+        vaultId: invitation.vaultId,
         ownerPubkey: invitation.ownerPubkey,
         relayUrls: invitation.relayUrls,
       );

--- a/lib/services/ndk_service.dart
+++ b/lib/services/ndk_service.dart
@@ -15,6 +15,7 @@ import 'login_service.dart';
 import 'recovery_service.dart';
 import 'vault_share_service.dart';
 import 'invitation_service.dart';
+import 'event_authorizer.dart';
 import 'share_distribution_service.dart';
 import 'logger.dart';
 import 'processed_nostr_event_store.dart';
@@ -555,6 +556,20 @@ class NdkService {
       Log.debug('Gift wrap event tags: ${event.tags}');
       Log.debug('Unwrapped event tags: ${unwrappedEvent.tags}');
 
+      final authDecision = await _ref.read(eventAuthorizerProvider).authorize(
+            rumor: unwrappedEvent,
+            verifiedSenderPubkey: verifiedSenderPubkey,
+          );
+      if (authDecision == AuthDecision.deny) {
+        Log.warning(
+          'Rejecting unauthorized gift wrap ${event.id}: '
+          'innerKind=${unwrappedEvent.kind}, sender=$verifiedSenderPubkey',
+        );
+        await _processedEventStore.recordProcessed(event.id);
+        await _processedEventStore.recordLastSeen(relayUrl, event.createdAt);
+        return;
+      }
+
       if (unwrappedEvent.kind == NostrKind.shareData.value) {
         await _handleShare(
           unwrappedEvent,
@@ -617,11 +632,12 @@ class NdkService {
     }
 
     final vaultShareService = _ref.read(vaultShareServiceProvider);
-    await vaultShareService.processVaultShare(
+    final wasAccepted = await vaultShareService.processVaultShare(
       vaultId,
       shardData,
       verifiedSenderPubkey: verifiedSenderPubkey,
     );
+    if (!wasAccepted) return;
 
     if (allowLocalNotification) {
       await _ref

--- a/lib/services/vault_share_service.dart
+++ b/lib/services/vault_share_service.dart
@@ -138,7 +138,7 @@ class VaultShareService {
   /// manifests or held shares), a **stale** manifest (lower or equal
   /// [Share.distributionVersion]) is ignored so relays cannot roll back
   /// metadata.
-  Future<void> processVaultShare(
+  Future<bool> processVaultShare(
     String vaultId,
     Share shardData, {
     required String verifiedSenderPubkey,
@@ -151,14 +151,14 @@ class VaultShareService {
         'processVaultShare: rejected share for vault $vaultId because verified '
         'sender does not match creatorPubkey',
       );
-      return;
+      return false;
     }
     if (existingVault != null && shardData.creatorPubkey != existingVault.ownerPubkey) {
       Log.warning(
         'processVaultShare: rejected share for vault $vaultId because creator '
         'does not match existing vault owner',
       );
-      return;
+      return false;
     }
 
     // Dedup by nostrEventId. If the vault doesn't exist yet, skip the check
@@ -174,7 +174,7 @@ class VaultShareService {
             'processVaultShare: share ${shardData.nostrEventId} already stored '
             'for vault $vaultId — skipping',
           );
-          return;
+          return false;
         }
       } on ArgumentError {
         // Vault not found — first time seeing this vault; proceed to create it.
@@ -200,7 +200,7 @@ class VaultShareService {
           if (pkStale != null && pkStale == shardData.creatorPubkey) {
             await repository.ensureOwnedVaultShell(vaultId);
           }
-          return;
+          return false;
         }
       }
 
@@ -220,7 +220,7 @@ class VaultShareService {
         await _getRelayScanService().syncRelaysFromUrls(shardData.relayUrls!);
       }
 
-      return;
+      return true;
     }
 
     await addVaultShare(vaultId, shardData);
@@ -269,6 +269,7 @@ class VaultShareService {
         e,
       );
     }
+    return true;
   }
 
   /// Creates and publishes a share confirmation event (kind 718).

--- a/test/services/event_authorizer_test.dart
+++ b/test/services/event_authorizer_test.dart
@@ -1,0 +1,417 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ndk/ndk.dart';
+
+import 'package:horcrux/database/app_database.dart';
+import 'package:horcrux/models/backup_config.dart';
+import 'package:horcrux/models/invitation_link.dart';
+import 'package:horcrux/models/invitation_status.dart';
+import 'package:horcrux/models/nostr_kinds.dart';
+import 'package:horcrux/models/recovery_request.dart';
+import 'package:horcrux/models/steward.dart';
+import 'package:horcrux/models/vault.dart';
+import 'package:horcrux/providers/vault_provider.dart';
+import 'package:horcrux/services/event_authorizer.dart';
+import 'package:horcrux/services/login_service.dart';
+
+import '../fixtures/test_keys.dart';
+import '../helpers/test_database.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const vaultId = 'auth-vault';
+  const recoveryRequestId = 'auth-recovery-request';
+
+  late AppDatabase db;
+  late VaultRepository repository;
+  late EventAuthorizer authorizer;
+
+  Nip01Event event({
+    required NostrKind kind,
+    String pubKey = TestHexPubkeys.alice,
+    List<List<String>> tags = const [],
+  }) {
+    return Nip01Event(
+      pubKey: pubKey,
+      kind: kind.value,
+      tags: tags,
+      content: '',
+      createdAt: 1759759657,
+    );
+  }
+
+  Nip01Event shareDataEvent({
+    String vaultId = vaultId,
+    String pubKey = TestHexPubkeys.alice,
+  }) {
+    return event(
+      kind: NostrKind.shareData,
+      pubKey: pubKey,
+      tags: [
+        ['vault_id', vaultId],
+        ['share_index', '0'],
+        ['total_shares', '2'],
+        ['threshold', '1'],
+      ],
+    );
+  }
+
+  Future<void> seedVault() async {
+    final config = createBackupConfig(
+      vaultId: vaultId,
+      threshold: 1,
+      totalKeys: 2,
+      stewards: [
+        createOwnerSteward(
+          id: 'owner-steward',
+          pubkey: TestHexPubkeys.alice,
+          name: 'Alice',
+        ),
+        createSteward(
+          id: 'bob-steward',
+          pubkey: TestHexPubkeys.bob,
+          name: 'Bob',
+        ),
+      ],
+      relays: ['wss://relay.example.com'],
+    );
+
+    await repository.addVault(
+      Vault(
+        id: vaultId,
+        name: 'Authorization Vault',
+        createdAt: DateTime.utc(2026),
+        ownerPubkey: TestHexPubkeys.alice,
+        backupConfig: config,
+      ),
+    );
+  }
+
+  Future<void> seedInvitation({
+    required String inviteCode,
+    String? redeemedBy,
+  }) async {
+    final link = createInvitationLink(
+      inviteCode: inviteCode,
+      vaultId: vaultId,
+      ownerPubkey: TestHexPubkeys.alice,
+      relayUrls: ['wss://relay.example.com'],
+      inviteeName: 'Bob',
+    ).updateStatus(
+      redeemedBy == null ? InvitationStatus.pending : InvitationStatus.redeemed,
+      redeemedBy: redeemedBy,
+      redeemedAt: redeemedBy == null ? null : DateTime.utc(2026),
+    );
+
+    await db.invitationDao.upsert(
+      InvitationsCompanion.insert(
+        code: inviteCode,
+        vaultId: vaultId,
+        payload: jsonEncode(invitationLinkToJson(link)),
+        createdAt: DateTime.utc(2026).millisecondsSinceEpoch,
+        acceptedAt: Value(link.redeemedAt?.millisecondsSinceEpoch),
+        acceptedByPubkey: Value(redeemedBy),
+      ),
+    );
+  }
+
+  setUp(() async {
+    db = newTestDatabase();
+    repository = VaultRepository(LoginService(), db: db);
+    authorizer = EventAuthorizer(repository, db);
+    await seedVault();
+  });
+
+  tearDown(() async {
+    repository.dispose();
+    await db.close();
+  });
+
+  group('EventAuthorizer', () {
+    test('denies unknown and unrouted kinds by default', () async {
+      final unknown = Nip01Event(
+        pubKey: TestHexPubkeys.alice,
+        kind: 999,
+        tags: [
+          ['vault_id', vaultId],
+        ],
+        content: '',
+        createdAt: 1759759657,
+      );
+
+      expect(
+        await authorizer.authorize(
+          rumor: unknown,
+          verifiedSenderPubkey: TestHexPubkeys.alice,
+        ),
+        AuthDecision.deny,
+      );
+
+      expect(
+        await authorizer.authorize(
+          rumor: event(
+            kind: NostrKind.shareError,
+            tags: [
+              ['vault_id', vaultId],
+            ],
+          ),
+          verifiedSenderPubkey: TestHexPubkeys.alice,
+        ),
+        AuthDecision.deny,
+      );
+    });
+
+    test('authorizes shareData from the verified creator', () async {
+      expect(
+        await authorizer.authorize(
+          rumor: shareDataEvent(),
+          verifiedSenderPubkey: TestHexPubkeys.alice,
+        ),
+        AuthDecision.allow,
+      );
+
+      expect(
+        await authorizer.authorize(
+          rumor: shareDataEvent(vaultId: 'new-inbound-vault'),
+          verifiedSenderPubkey: TestHexPubkeys.alice,
+        ),
+        AuthDecision.allow,
+      );
+    });
+
+    test('denies shareData from a forged creator or wrong existing owner', () async {
+      expect(
+        await authorizer.authorize(
+          rumor: shareDataEvent(),
+          verifiedSenderPubkey: TestHexPubkeys.bob,
+        ),
+        AuthDecision.deny,
+      );
+
+      expect(
+        await authorizer.authorize(
+          rumor: shareDataEvent(pubKey: TestHexPubkeys.bob),
+          verifiedSenderPubkey: TestHexPubkeys.bob,
+        ),
+        AuthDecision.deny,
+      );
+    });
+
+    test('authorizes invitations by invite code and redeemed pubkey', () async {
+      const pendingInviteCode = 'pending-invite';
+      const redeemedInviteCode = 'redeemed-invite';
+      await seedInvitation(inviteCode: pendingInviteCode);
+      await seedInvitation(
+        inviteCode: redeemedInviteCode,
+        redeemedBy: TestHexPubkeys.bob,
+      );
+
+      for (final kind in [
+        NostrKind.invitationAcceptance,
+        NostrKind.invitationDenial,
+      ]) {
+        expect(
+          await authorizer.authorize(
+            rumor: event(
+              kind: kind,
+              pubKey: TestHexPubkeys.bob,
+              tags: [
+                ['invite_code', pendingInviteCode],
+              ],
+            ),
+            verifiedSenderPubkey: TestHexPubkeys.bob,
+          ),
+          AuthDecision.allow,
+        );
+        expect(
+          await authorizer.authorize(
+            rumor: event(
+              kind: kind,
+              pubKey: TestHexPubkeys.bob,
+              tags: [
+                ['invite_code', redeemedInviteCode],
+              ],
+            ),
+            verifiedSenderPubkey: TestHexPubkeys.bob,
+          ),
+          AuthDecision.allow,
+        );
+        expect(
+          await authorizer.authorize(
+            rumor: event(
+              kind: kind,
+              pubKey: TestHexPubkeys.charlie,
+              tags: [
+                ['invite_code', redeemedInviteCode],
+              ],
+            ),
+            verifiedSenderPubkey: TestHexPubkeys.charlie,
+          ),
+          AuthDecision.deny,
+        );
+      }
+    });
+
+    test('denies invitations with missing or unknown invite codes', () async {
+      expect(
+        await authorizer.authorize(
+          rumor: event(kind: NostrKind.invitationAcceptance),
+          verifiedSenderPubkey: TestHexPubkeys.bob,
+        ),
+        AuthDecision.deny,
+      );
+      expect(
+        await authorizer.authorize(
+          rumor: event(
+            kind: NostrKind.invitationDenial,
+            tags: [
+              ['invite_code', 'unknown-invite'],
+            ],
+          ),
+          verifiedSenderPubkey: TestHexPubkeys.bob,
+        ),
+        AuthDecision.deny,
+      );
+    });
+
+    test('authorizes keyHolderRemoved only from the vault owner', () async {
+      final rumor = event(
+        kind: NostrKind.keyHolderRemoved,
+        tags: [
+          ['vault_id', vaultId],
+        ],
+      );
+
+      expect(
+        await authorizer.authorize(
+          rumor: rumor,
+          verifiedSenderPubkey: TestHexPubkeys.alice,
+        ),
+        AuthDecision.allow,
+      );
+      expect(
+        await authorizer.authorize(
+          rumor: rumor,
+          verifiedSenderPubkey: TestHexPubkeys.bob,
+        ),
+        AuthDecision.deny,
+      );
+    });
+
+    test('authorizes shareConfirmation only from known stewards', () async {
+      final rumor = event(
+        kind: NostrKind.shareConfirmation,
+        tags: [
+          ['vault_id', vaultId],
+        ],
+      );
+
+      expect(
+        await authorizer.authorize(
+          rumor: rumor,
+          verifiedSenderPubkey: TestHexPubkeys.bob,
+        ),
+        AuthDecision.allow,
+      );
+      expect(
+        await authorizer.authorize(
+          rumor: rumor,
+          verifiedSenderPubkey: TestHexPubkeys.charlie,
+        ),
+        AuthDecision.deny,
+      );
+    });
+
+    test('authorizes recoveryRequest from owner or known steward', () async {
+      final rumor = event(
+        kind: NostrKind.recoveryRequest,
+        tags: [
+          ['vault_id', vaultId],
+          ['recovery_request_id', recoveryRequestId],
+        ],
+      );
+
+      expect(
+        await authorizer.authorize(
+          rumor: rumor,
+          verifiedSenderPubkey: TestHexPubkeys.alice,
+        ),
+        AuthDecision.allow,
+      );
+      expect(
+        await authorizer.authorize(
+          rumor: rumor,
+          verifiedSenderPubkey: TestHexPubkeys.bob,
+        ),
+        AuthDecision.allow,
+      );
+      expect(
+        await authorizer.authorize(
+          rumor: rumor,
+          verifiedSenderPubkey: TestHexPubkeys.charlie,
+        ),
+        AuthDecision.deny,
+      );
+    });
+
+    test(
+      'authorizes recoveryResponse only from request participants',
+      () async {
+        await repository.addRecoveryRequestToVault(
+          vaultId,
+          RecoveryRequest.makeFromParticipants(
+            id: recoveryRequestId,
+            vaultId: vaultId,
+            initiatorPubkey: TestHexPubkeys.alice,
+            requestedAt: DateTime.utc(2026),
+            status: RecoveryRequestStatus.inProgress,
+            threshold: 1,
+            stewardPubkeys: const [TestHexPubkeys.bob],
+          ),
+        );
+        final rumor = event(
+          kind: NostrKind.recoveryResponse,
+          tags: [
+            ['vault_id', vaultId],
+            ['recovery_request_id', recoveryRequestId],
+          ],
+        );
+
+        expect(
+          await authorizer.authorize(
+            rumor: rumor,
+            verifiedSenderPubkey: TestHexPubkeys.bob,
+          ),
+          AuthDecision.allow,
+        );
+        expect(
+          await authorizer.authorize(
+            rumor: rumor,
+            verifiedSenderPubkey: TestHexPubkeys.charlie,
+          ),
+          AuthDecision.deny,
+        );
+      },
+    );
+
+    test('denies enforcing kinds when required tags are absent', () async {
+      for (final kind in [
+        NostrKind.recoveryRequest,
+        NostrKind.recoveryResponse,
+        NostrKind.shareConfirmation,
+        NostrKind.keyHolderRemoved,
+      ]) {
+        expect(
+          await authorizer.authorize(
+            rumor: event(kind: kind),
+            verifiedSenderPubkey: TestHexPubkeys.alice,
+          ),
+          AuthDecision.deny,
+        );
+      }
+    });
+  });
+}

--- a/test/services/event_authorizer_test.dart
+++ b/test/services/event_authorizer_test.dart
@@ -220,6 +220,7 @@ void main() {
               pubKey: TestHexPubkeys.bob,
               tags: [
                 ['invite_code', pendingInviteCode],
+                ['vault_id', vaultId],
               ],
             ),
             verifiedSenderPubkey: TestHexPubkeys.bob,
@@ -233,6 +234,7 @@ void main() {
               pubKey: TestHexPubkeys.bob,
               tags: [
                 ['invite_code', redeemedInviteCode],
+                ['vault_id', vaultId],
               ],
             ),
             verifiedSenderPubkey: TestHexPubkeys.bob,
@@ -246,6 +248,7 @@ void main() {
               pubKey: TestHexPubkeys.charlie,
               tags: [
                 ['invite_code', redeemedInviteCode],
+                ['vault_id', vaultId],
               ],
             ),
             verifiedSenderPubkey: TestHexPubkeys.charlie,
@@ -263,18 +266,55 @@ void main() {
         ),
         AuthDecision.deny,
       );
+      await seedInvitation(inviteCode: 'known-invite');
       expect(
         await authorizer.authorize(
           rumor: event(
-            kind: NostrKind.invitationDenial,
+            kind: NostrKind.invitationAcceptance,
             tags: [
-              ['invite_code', 'unknown-invite'],
+              ['invite_code', 'known-invite'],
             ],
           ),
           verifiedSenderPubkey: TestHexPubkeys.bob,
         ),
         AuthDecision.deny,
       );
+      expect(
+        await authorizer.authorize(
+          rumor: event(
+            kind: NostrKind.invitationDenial,
+            tags: [
+              ['invite_code', 'unknown-invite'],
+              ['vault_id', vaultId],
+            ],
+          ),
+          verifiedSenderPubkey: TestHexPubkeys.bob,
+        ),
+        AuthDecision.deny,
+      );
+    });
+
+    test('denies invitations whose vault_id does not match stored invitation', () async {
+      await seedInvitation(inviteCode: 'vault-mismatch-invite');
+
+      for (final kind in [
+        NostrKind.invitationAcceptance,
+        NostrKind.invitationDenial,
+      ]) {
+        expect(
+          await authorizer.authorize(
+            rumor: event(
+              kind: kind,
+              tags: [
+                ['invite_code', 'vault-mismatch-invite'],
+                ['vault_id', 'different-vault'],
+              ],
+            ),
+            verifiedSenderPubkey: TestHexPubkeys.bob,
+          ),
+          AuthDecision.deny,
+        );
+      }
     });
 
     test('authorizes keyHolderRemoved only from the vault owner', () async {

--- a/test/services/invitation_acceptance_format_test.mocks.dart
+++ b/test/services/invitation_acceptance_format_test.mocks.dart
@@ -1068,6 +1068,7 @@ class MockInvitationSendingService extends _i1.Mock implements _i17.InvitationSe
   @override
   _i7.Future<String?> sendDenialEvent({
     required String? inviteCode,
+    required String? vaultId,
     required String? ownerPubkey,
     required List<String>? relayUrls,
   }) =>
@@ -1077,6 +1078,7 @@ class MockInvitationSendingService extends _i1.Mock implements _i17.InvitationSe
           [],
           {
             #inviteCode: inviteCode,
+            #vaultId: vaultId,
             #ownerPubkey: ownerPubkey,
             #relayUrls: relayUrls,
           },

--- a/test/services/invitation_sending_service_test.dart
+++ b/test/services/invitation_sending_service_test.dart
@@ -98,12 +98,14 @@ void main() {
 
       await service.sendDenialEvent(
         inviteCode: 'invite-123',
+        vaultId: 'vault-abc',
         ownerPubkey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
         relayUrls: ['wss://relay.example.com'],
       );
 
       expect(capturedContent, isEmpty);
       expect(_hasTag(capturedTags, 'invite_code', 'invite-123'), isTrue);
+      expect(_hasTag(capturedTags, 'vault_id', 'vault-abc'), isTrue);
     });
 
     // ── sendShareConfirmationEvent (kind 718) ──

--- a/test/services/invitation_service_test.dart
+++ b/test/services/invitation_service_test.dart
@@ -9,6 +9,7 @@ import 'package:horcrux/services/relay_scan_service.dart';
 import 'package:horcrux/services/backup_service.dart';
 import 'package:horcrux/services/invitation_sending_service.dart';
 import 'package:horcrux/models/backup_config.dart';
+import 'package:horcrux/models/invitation_status.dart';
 import 'package:horcrux/models/steward.dart';
 import 'package:horcrux/models/steward_status.dart';
 import 'package:horcrux/models/nostr_kinds.dart';
@@ -521,6 +522,87 @@ void main() {
         expect(config, isNotNull);
         expect(config!.stewards.any((s) => s.pubkey == deviceCPubkey), isFalse,
             reason: 'Device C should not be in the backup config');
+      },
+    );
+
+    test(
+      'denial from a different pubkey does not overwrite an already redeemed invitation',
+      () async {
+        const vaultId = 'test-vault-denial-mismatch';
+        const ownerPubkey = TestHexPubkeys.alice;
+        const redeemedPubkey = TestHexPubkeys.bob;
+        const attackerPubkey = TestHexPubkeys.charlie;
+
+        when(mockLoginService.getCurrentPublicKey()).thenAnswer((_) async => ownerPubkey);
+        when(mockLoginService.encryptText(any))
+            .thenAnswer((invocation) async => invocation.positionalArguments[0] as String);
+        when(mockLoginService.decryptText(any))
+            .thenAnswer((invocation) async => invocation.positionalArguments[0] as String);
+        when(mockBackupService.distributeKeysIfNecessary(any)).thenAnswer((_) async {});
+
+        await realRepository.addVault(
+          Vault(
+            id: vaultId,
+            name: 'Denial Mismatch Vault',
+            createdAt: DateTime.now(),
+            ownerPubkey: ownerPubkey,
+          ),
+        );
+        await realRepository.updateBackupConfig(
+          vaultId,
+          createBackupConfig(
+            vaultId: vaultId,
+            threshold: 1,
+            totalKeys: 1,
+            stewards: [
+              createInvitedSteward(
+                id: 'invited-steward',
+                name: 'Invited Device',
+                inviteCode: 'placeholder-invite-code',
+              ),
+            ],
+            relays: ['wss://relay.example.com'],
+          ),
+        );
+
+        await invitationService.generateInvitationLink(
+          vaultId: vaultId,
+          inviteeName: 'Invited Device',
+          relayUrls: ['wss://relay.example.com'],
+        );
+        final invitation = (await invitationService.getPendingInvitations(vaultId)).first;
+        final inviteCode = invitation.inviteCode;
+
+        await invitationService.processInvitationAcceptanceEvent(
+          event: Nip01Event(
+            kind: NostrKind.invitationAcceptance.value,
+            pubKey: redeemedPubkey,
+            tags: [
+              ['invite_code', inviteCode],
+              ['vault_id', vaultId],
+            ],
+            createdAt: secondsSinceEpoch(),
+            content: '',
+          ),
+        );
+
+        await invitationService.processDenialEvent(
+          event: Nip01Event(
+            kind: NostrKind.invitationDenial.value,
+            pubKey: attackerPubkey,
+            tags: [
+              ['invite_code', inviteCode],
+              ['vault_id', vaultId],
+            ],
+            createdAt: secondsSinceEpoch(),
+            content: '',
+          ),
+        );
+
+        final storedInvitation = await invitationService.lookupInvitationByCode(inviteCode);
+        expect(storedInvitation, isNotNull);
+        expect(storedInvitation!.status, InvitationStatus.redeemed);
+        expect(storedInvitation.redeemedBy, redeemedPubkey);
       },
     );
   });

--- a/test/services/invitation_service_test.mocks.dart
+++ b/test/services/invitation_service_test.mocks.dart
@@ -1068,6 +1068,7 @@ class MockInvitationSendingService extends _i1.Mock implements _i17.InvitationSe
   @override
   _i7.Future<String?> sendDenialEvent({
     required String? inviteCode,
+    required String? vaultId,
     required String? ownerPubkey,
     required List<String>? relayUrls,
   }) =>
@@ -1077,6 +1078,7 @@ class MockInvitationSendingService extends _i1.Mock implements _i17.InvitationSe
           [],
           {
             #inviteCode: inviteCode,
+            #vaultId: vaultId,
             #ownerPubkey: ownerPubkey,
             #relayUrls: relayUrls,
           },

--- a/test/services/vault_share_service_test.dart
+++ b/test/services/vault_share_service_test.dart
@@ -1049,12 +1049,13 @@ void main() {
         distributionVersion: 1,
       );
 
-      await service.processVaultShare(
+      final wasAccepted = await service.processVaultShare(
         vaultId,
         manifest,
         verifiedSenderPubkey: TestHexPubkeys.bob,
       );
 
+      expect(wasAccepted, isFalse);
       expect(await repository.getVault(vaultId), isNull);
     });
 
@@ -1084,12 +1085,13 @@ void main() {
         distributionVersion: 2,
       );
 
-      await service.processVaultShare(
+      final wasAccepted = await service.processVaultShare(
         vaultId,
         manifest,
         verifiedSenderPubkey: TestHexPubkeys.bob,
       );
 
+      expect(wasAccepted, isFalse);
       final stored = await repository.getVault(vaultId);
       expect(stored, isNotNull);
       expect(stored!.ownerPubkey, owner);


### PR DESCRIPTION
## Bead
horcrux_app-uugm

## Summary
- Add a centralized `EventAuthorizer` gate for verified unwrapped gift-wrap events before NDK dispatch.
- Enforce share, recovery, invitation, share confirmation, and key-holder removal authorization policies with deny-by-default behavior.
- Prevent rejected share events from posting processed notifications and cover the new policies with service tests.

## Test plan
- `fvm flutter pub run build_runner build --delete-conflicting-outputs`
- `fvm dart format lib/services/event_authorizer.dart lib/services/ndk_service.dart lib/services/invitation_service.dart lib/services/vault_share_service.dart test/services/event_authorizer_test.dart test/services/invitation_service_test.dart test/services/vault_share_service_test.dart`
- `ReadLints` on changed files
- `fvm flutter test test/services/event_authorizer_test.dart test/services/invitation_service_test.dart test/services/vault_share_service_test.dart`
- `fvm flutter analyze`
- `fvm flutter test --exclude-tags=golden`
- Marionette smoke test on macOS: connected to the running app, verified the vault list rendered and interactive elements were available. Marionette log retrieval is not configured in the app, so logs were checked from the Flutter run output instead.


Made with [Cursor](https://cursor.com)