### PR TITLE
Update Horcrux branding and copyright metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Keydex
+Copyright (c) 2025 Single Origin Software LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lib/src/localization/app_en.arb
+++ b/lib/src/localization/app_en.arb
@@ -1,5 +1,5 @@
 {
-  "appTitle": "keydex",
+  "appTitle": "Horcrux",
   "@appTitle": {
     "description": "The title of the application"
   }

--- a/lib/src/localization/app_localizations.dart
+++ b/lib/src/localization/app_localizations.dart
@@ -95,7 +95,7 @@ abstract class AppLocalizations {
   /// The title of the application
   ///
   /// In en, this message translates to:
-  /// **'keydex'**
+  /// **'Horcrux'**
   String get appTitle;
 }
 

--- a/lib/src/localization/app_localizations_en.dart
+++ b/lib/src/localization/app_localizations_en.dart
@@ -9,5 +9,5 @@ class AppLocalizationsEn extends AppLocalizations {
   AppLocalizationsEn([String locale = 'en']) : super(locale);
 
   @override
-  String get appTitle => 'keydex';
+  String get appTitle => 'Horcrux';
 }

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -11,4 +11,4 @@ PRODUCT_NAME = Horcrux
 PRODUCT_BUNDLE_IDENTIFIER = com.singleoriginsoftware.horcrux
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2025 com.example. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2025 Single Origin Software LLC. All rights reserved.

--- a/specs/007-lost-device-recovery/spec.md
+++ b/specs/007-lost-device-recovery/spec.md
@@ -69,7 +69,7 @@ As a vault owner who has lost my device, I want to recover my vault from a fresh
 - **What if steward has no vaults for this owner?** Show message "You don't appear to be a steward for any vaults that match this request."
 - **What if owner's temp key expires or they lose the fresh device?** They must start over with a new temp key and link.
 - **What if relay URLs in link differ from original vault relays?** Requests use original relays (from shard data), responses use link's relays (where owner listens). Stewards should add the link's relay URLs to their vault config so future communication uses consistent relays.
-- **What relays does owner use on fresh device?** Default to keydex relay (configurable). These relays are embedded in the recovery initiation link and stewards add them to their vault config.
+- **What relays does owner use on fresh device?** Default to Horcrux relay (configurable). These relays are embedded in the recovery initiation link and stewards add them to their vault config.
 - **How does owner's fresh device know which vault to reconstruct?** When first recovery response (shard) arrives, automatically create a local vault stub using metadata from the shard (vault ID, vault name from shard data). Subsequent shards are added to this vault.
 
 ---
@@ -90,7 +90,7 @@ As a vault owner who has lost my device, I want to recover my vault from a fresh
 - **FR-007**: System MUST prompt owner to enter vault name they want to recover
 - **FR-008**: System MUST prompt owner to enter their name (for steward identification)
 - **FR-009**: System MUST generate recovery initiation link with format: `horcrux://horcrux.app/recover/{code}?owner={tempPubkey}&vault={name}&name={ownerName}&relays={urls}`
-- **FR-009a**: System MUST default to keydex relay URL, but allow owner to configure different relays
+- **FR-009a**: System MUST default to Horcrux relay URL, but allow owner to configure different relays
 - **FR-009b**: Stewards MUST add the relay URLs from recovery initiation link to their vault's relay config for consistent communication
 - **FR-010**: System MUST create `RecoveryInitiationLink` model to track the link
 - **FR-011**: System MUST allow owner to copy/share the link

--- a/specs/007-lost-device-recovery/tasks.md
+++ b/specs/007-lost-device-recovery/tasks.md
@@ -70,7 +70,7 @@
 
 - [ ] T015 Implement link generation in `OwnerRecoveryScreen`:
   - Validate vault name and owner name inputs
-  - Default to keydex relay URL (allow user to change)
+  - Default to Horcrux relay URL (allow user to change)
   - Create RecoveryInitiationLink
   - Generate shareable URL
   - Store link locally for tracking

--- a/web/index.html
+++ b/web/index.html
@@ -23,13 +23,13 @@
   <!-- iOS meta tags & icons -->
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="keydex">
+  <meta name="apple-mobile-web-app-title" content="Horcrux">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>keydex</title>
+  <title>Horcrux</title>
   <link rel="manifest" href="manifest.json">
 </head>
 <body>

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "keydex",
-    "short_name": "keydex",
+    "name": "Horcrux",
+    "short_name": "Horcrux",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#000000",

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Project-level configuration.
 cmake_minimum_required(VERSION 3.14)
-project(keydex LANGUAGES CXX)
+project(horcrux LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "keydex")
+set(BINARY_NAME "horcrux")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -89,13 +89,13 @@ BEGIN
     BEGIN
         BLOCK "040904e4"
         BEGIN
-            VALUE "CompanyName", "com.example" "\0"
-            VALUE "FileDescription", "keydex" "\0"
+            VALUE "CompanyName", "Single Origin Software LLC" "\0"
+            VALUE "FileDescription", "Horcrux" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
-            VALUE "InternalName", "keydex" "\0"
-            VALUE "LegalCopyright", "Copyright (C) 2025 com.example. All rights reserved." "\0"
-            VALUE "OriginalFilename", "keydex.exe" "\0"
-            VALUE "ProductName", "keydex" "\0"
+            VALUE "InternalName", "horcrux" "\0"
+            VALUE "LegalCopyright", "Copyright (C) 2025 Single Origin Software LLC. All rights reserved." "\0"
+            VALUE "OriginalFilename", "horcrux.exe" "\0"
+            VALUE "ProductName", "Horcrux" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"
         END
     END

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -27,7 +27,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   FlutterWindow window(project);
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(1280, 720);
-  if (!window.Create(L"keydex", origin, size)) {
+  if (!window.Create(L"Horcrux", origin, size)) {
     return EXIT_FAILURE;
   }
   window.SetQuitOnClose(true);


### PR DESCRIPTION
## Summary
- Bead: horcrux_app-0k7v
- Replace stale Keydex/keydex app metadata, localization title, and recovery spec references with Horcrux.
- Update license and platform copyright metadata to 2025 Single Origin Software LLC.

## Test plan
- [x] `fvm dart format lib/src/localization/app_localizations.dart lib/src/localization/app_localizations_en.dart`
- [x] `fvm flutter analyze`
- [x] `fvm flutter test --exclude-tags=golden`
- [x] `fvm flutter run -d macos --debug` launch smoke test reached normal Flutter run state


Made with [Cursor](https://cursor.com)