### PR TITLE
Fail closed if SQLCipher is not the active library

### DIFF
--- a/lib/database/connection.dart
+++ b/lib/database/connection.dart
@@ -134,9 +134,11 @@ DatabaseConnection openSqlCipherConnection({DbKeyDerivation? keyDerivation}) {
 
 /// Throws a [StateError] unless the active SQLite library is SQLCipher.
 ///
-/// `PRAGMA cipher_version` returns a version string only under SQLCipher; a
-/// plain SQLite build returns an empty result set. Per the SQLCipher advisory
-/// (https://discuss.zetetic.net/t/important-advisory-sqlcipher-with-xcode-8-and-new-sdks/1688)
+/// `PRAGMA cipher_version` is a library capability check — it returns a
+/// version string on an unkeyed SQLCipher connection and an empty result set
+/// under plain SQLite. Call this **before** applying `PRAGMA key` so key
+/// material is never submitted to a non-encrypting SQLite. Per the SQLCipher
+/// advisory (https://discuss.zetetic.net/t/important-advisory-sqlcipher-with-xcode-8-and-new-sdks/1688)
 /// this is the recommended runtime failsafe: refuse to operate on a connection
 /// that is not actually encrypting, on every platform, rather than silently
 /// persisting plaintext.
@@ -155,11 +157,20 @@ void verifySqlCipherActive(Database rawDb) {
 /// Applies the SQLCipher key and the v1 pragma set to a raw [Database].
 /// Extracted so tests using a non-encrypted in-memory DB can skip it.
 ///
-/// The key PRAGMA is executed first; any failure is re-thrown as a
-/// [StateError] with a sanitised message so key material cannot propagate
-/// through exception messages into crash reporters or logs. After keying, the
-/// connection is verified to actually be SQLCipher via [verifySqlCipherActive].
+/// Verifies SQLCipher is active **before** applying the key so key material
+/// is never handed to a plain SQLite library (where `PRAGMA key` is a silent
+/// no-op but the key still enters the SQL API / statement text). Key PRAGMA
+/// failures are re-thrown as a [StateError] with a sanitised message so key
+/// material cannot propagate through exception messages into crash reporters
+/// or logs.
 void _applyKeyAndPragmas(Database rawDb, String pragmaKey) {
+  // Fail closed before keying. `PRAGMA cipher_version` is a library capability
+  // check (works on an unkeyed SQLCipher connection). Plain SQLite returns an
+  // empty result; refusing here avoids ever submitting the key to a
+  // non-encrypting SQLite. This also guards against the linking regression
+  // fixed in [configureSqlCipherOpen] ever recurring and silently writing an
+  // unencrypted database.
+  verifySqlCipherActive(rawDb);
   try {
     rawDb.execute("PRAGMA key = $pragmaKey;");
   } on Object catch (e) {
@@ -170,12 +181,6 @@ void _applyKeyAndPragmas(Database rawDb, String pragmaKey) {
       'This is a fatal configuration error.',
     );
   }
-  // Fail closed if the active SQLite library is not SQLCipher. `PRAGMA key`
-  // above is silently accepted by plain SQLite (it treats unknown pragmas as
-  // no-ops), so a successful key set is NOT proof of encryption. This guards
-  // against the linking regression fixed in [configureSqlCipherOpen] ever
-  // recurring and silently writing an unencrypted database.
-  verifySqlCipherActive(rawDb);
   rawDb.execute('PRAGMA cipher_page_size = 4096;');
   rawDb.execute("PRAGMA cipher_kdf_algorithm = 'PBKDF2_HMAC_SHA512';");
   rawDb.execute('PRAGMA cipher_use_hmac = ON;');

--- a/lib/database/connection.dart
+++ b/lib/database/connection.dart
@@ -132,12 +132,33 @@ DatabaseConnection openSqlCipherConnection({DbKeyDerivation? keyDerivation}) {
   return DatabaseConnection(lazy, closeStreamsSynchronously: true);
 }
 
+/// Throws a [StateError] unless the active SQLite library is SQLCipher.
+///
+/// `PRAGMA cipher_version` returns a version string only under SQLCipher; a
+/// plain SQLite build returns an empty result set. Per the SQLCipher advisory
+/// (https://discuss.zetetic.net/t/important-advisory-sqlcipher-with-xcode-8-and-new-sdks/1688)
+/// this is the recommended runtime failsafe: refuse to operate on a connection
+/// that is not actually encrypting, on every platform, rather than silently
+/// persisting plaintext.
+void verifySqlCipherActive(Database rawDb) {
+  final result = rawDb.select('PRAGMA cipher_version;');
+  final version = result.isEmpty ? null : result.first.values.first;
+  if (version == null || (version is String && version.trim().isEmpty)) {
+    throw StateError(
+      'SQLCipher is not the active SQLite library (PRAGMA cipher_version '
+      'returned no value). Refusing to open a database that would not be '
+      'encrypted. This is a fatal configuration error.',
+    );
+  }
+}
+
 /// Applies the SQLCipher key and the v1 pragma set to a raw [Database].
 /// Extracted so tests using a non-encrypted in-memory DB can skip it.
 ///
 /// The key PRAGMA is executed first; any failure is re-thrown as a
 /// [StateError] with a sanitised message so key material cannot propagate
-/// through exception messages into crash reporters or logs.
+/// through exception messages into crash reporters or logs. After keying, the
+/// connection is verified to actually be SQLCipher via [verifySqlCipherActive].
 void _applyKeyAndPragmas(Database rawDb, String pragmaKey) {
   try {
     rawDb.execute("PRAGMA key = $pragmaKey;");
@@ -149,6 +170,12 @@ void _applyKeyAndPragmas(Database rawDb, String pragmaKey) {
       'This is a fatal configuration error.',
     );
   }
+  // Fail closed if the active SQLite library is not SQLCipher. `PRAGMA key`
+  // above is silently accepted by plain SQLite (it treats unknown pragmas as
+  // no-ops), so a successful key set is NOT proof of encryption. This guards
+  // against the linking regression fixed in [configureSqlCipherOpen] ever
+  // recurring and silently writing an unencrypted database.
+  verifySqlCipherActive(rawDb);
   rawDb.execute('PRAGMA cipher_page_size = 4096;');
   rawDb.execute("PRAGMA cipher_kdf_algorithm = 'PBKDF2_HMAC_SHA512';");
   rawDb.execute('PRAGMA cipher_use_hmac = ON;');

--- a/test/database/verify_sqlcipher_active_test.dart
+++ b/test/database/verify_sqlcipher_active_test.dart
@@ -5,8 +5,9 @@ import 'package:sqlite3/sqlite3.dart';
 
 // Runs against the plain system SQLite that `flutter test` loads on the host
 // (no SQLCipher), so `PRAGMA cipher_version` is empty and the failsafe must
-// throw. This proves the connection setup fails closed instead of silently
-// operating on an unencrypted database.
+// throw — including on an unkeyed connection, matching production order
+// (verify before PRAGMA key). This proves the connection setup fails closed
+// instead of silently operating on an unencrypted database.
 void main() {
   test('verifySqlCipherActive throws when SQLCipher is not the active library', () {
     final db = sqlite3.openInMemory();

--- a/test/database/verify_sqlcipher_active_test.dart
+++ b/test/database/verify_sqlcipher_active_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:horcrux/database/connection.dart';
+// ignore: depend_on_referenced_packages
+import 'package:sqlite3/sqlite3.dart';
+
+// Runs against the plain system SQLite that `flutter test` loads on the host
+// (no SQLCipher), so `PRAGMA cipher_version` is empty and the failsafe must
+// throw. This proves the connection setup fails closed instead of silently
+// operating on an unencrypted database.
+void main() {
+  test('verifySqlCipherActive throws when SQLCipher is not the active library', () {
+    final db = sqlite3.openInMemory();
+    addTearDown(db.dispose);
+
+    expect(
+      () => verifySqlCipherActive(db),
+      throwsA(isA<StateError>()),
+    );
+  });
+}


### PR DESCRIPTION
## Bead
horcrux_app-3jo6

## Summary
Implements the HIGH runtime failsafe from `docs/security-audit-july-2026.md` §3.2. Plain SQLite silently accepts `PRAGMA key` (unknown pragmas are no-ops), so a successful key set is **not** proof the database is encrypted.

- Add `verifySqlCipherActive(Database)` in `lib/database/connection.dart`: runs `PRAGMA cipher_version` and throws a sanitized `StateError` on **every platform** if it returns no value.
- Call it from `_applyKeyAndPragmas` **before** applying `PRAGMA key`, so key material is never submitted to a non-encrypting SQLite and the connection fails closed instead of silently persisting plaintext.

This guards against the iOS/macOS linking regression fixed in #254 ever recurring.

> Stacked on #254 (`fix/sqlcipher-ios-linking`). Will retarget to `main` automatically once #254 merges.

## Out of scope (follow-up)
Zetetic advisory scenario tests and the dedicated macOS SQLCipher CI job live in **#257** (`test/sqlcipher-encryption-verification`, bead `horcrux_app-p8wf`), stacked on this PR.

## Behavior change / accepted fallout
Per maintainer direction this throws on **all** platforms with no per-platform gating. Linux/Windows desktop bundle only system SQLite (no SQLCipher), so after this change the desktop app will hit the failsafe and route to the initialization-error screen. That is accepted; making Linux run encrypted (build libsqlcipher + a Linux `open.overrideFor`) is a separate follow-up.

## Test plan
- [x] `flutter analyze` clean on connection + failsafe tests
- [x] `verifySqlCipherActive` throws against plain host SQLite (no cipher)
- [x] `configureSqlCipherOpen` idempotence test still passes
- [x] Existing in-memory DB tests unaffected (they bypass `_applyKeyAndPragmas`)

Made with [Cursor](https://cursor.com)