### PR TITLE
Change Travel Mode to Seal Vault

### DIFF
--- a/lib/providers/vault_provider.dart
+++ b/lib/providers/vault_provider.dart
@@ -597,7 +597,7 @@ class VaultRepository {
   /// [vaultDao.watchAll] / [vaultDao.watchById] re-emit and both
   /// [VaultRepository] and [VaultDetailRepository] reactive streams reflect
   /// the change immediately. Without this touch the streams only observe
-  /// changes to the `vaults` table, so Travel Mode and exitRecoveryMode would
+  /// changes to the `vaults` table, so Seal Vault and exitRecoveryMode would
   /// delete content but the UI would continue showing a stale
   /// [OwnedVaultDetail] until something else modified the vault row.
   Future<void> deleteVaultContent(String vaultId) async {

--- a/lib/widgets/vault_detail_button_stack.dart
+++ b/lib/widgets/vault_detail_button_stack.dart
@@ -156,9 +156,9 @@ class VaultDetailButtonStack extends ConsumerWidget {
                         backupConfig.hasBeenDistributed) {
                       buttons.add(
                         RowButtonConfig(
-                          onPressed: () => _showTravelModeDialog(context, ref, vault),
-                          icon: Icons.luggage,
-                          text: 'Travel Mode',
+                          onPressed: () => _showSealVaultDialog(context, ref, vault),
+                          icon: Icons.lock,
+                          text: 'Seal Vault',
                         ),
                       );
                     }
@@ -377,20 +377,21 @@ class VaultDetailButtonStack extends ConsumerWidget {
     }
   }
 
-  /// Confirm enabling Travel Mode: erase the local copy of the vault contents
+  /// Confirm sealing the vault: erase the local copy of the vault contents
   /// while keeping the recovery plan intact, so the owner can restore them
   /// later via their stewards.
-  Future<void> _showTravelModeDialog(BuildContext context, WidgetRef ref, VaultDetail vault) async {
+  Future<void> _showSealVaultDialog(BuildContext context, WidgetRef ref, VaultDetail vault) async {
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
-        title: const Text('Enable Travel Mode?'),
+        title: const Text('Seal Vault?'),
         content: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             const Text(
-              'Travel Mode wipes the vault contents from this device, so even if this device is compromised your vault will be safe.',
+              'Sealing this vault wipes its contents from this device. You '
+              "won't be able to view or edit them here until you recover the vault.",
               style: TextStyle(fontWeight: FontWeight.bold),
             ),
             const SizedBox(height: 12),
@@ -411,7 +412,7 @@ class VaultDetailButtonStack extends ConsumerWidget {
                   SizedBox(width: 8),
                   Expanded(
                     child: Text(
-                      "You'll need to initiate recovery and wait for stewards to approve before you can view this vault's contents again.",
+                      "To edit this vault again you'll need to import or recreate the contents.",
                       style: TextStyle(color: Colors.orange),
                     ),
                   ),
@@ -428,7 +429,7 @@ class VaultDetailButtonStack extends ConsumerWidget {
               backgroundColor: Colors.red,
               foregroundColor: Colors.white,
             ),
-            child: const Text('Enable Travel Mode'),
+            child: const Text('Seal Vault'),
           ),
         ],
       ),
@@ -441,7 +442,7 @@ class VaultDetailButtonStack extends ConsumerWidget {
 
         if (context.mounted) {
           context.showHorcruxSnackBar(
-            'Travel Mode enabled.',
+            'Vault sealed.',
             kind: HorcruxSnackKind.success,
           );
 
@@ -450,7 +451,7 @@ class VaultDetailButtonStack extends ConsumerWidget {
       } catch (e) {
         if (context.mounted) {
           context.showHorcruxSnackBar(
-            'Failed to enable Travel Mode: $e',
+            'Failed to seal vault: $e',
             kind: HorcruxSnackKind.error,
           );
         }

--- a/test/screens/vault_detail_screen_test.dart
+++ b/test/screens/vault_detail_screen_test.dart
@@ -100,8 +100,8 @@ void main() {
       container.dispose();
     });
 
-    testWidgets(
-      'shows Travel Mode button when owner has content and owner steward configured',
+  testWidgets(
+      'shows Seal Vault button when owner has content and owner steward configured',
       (tester) async {
         final ownerSteward = createOwnerSteward(pubkey: testPubkey);
         final otherSteward = createSteward(pubkey: otherPubkey, name: 'Alice');
@@ -145,13 +145,13 @@ void main() {
 
         await tester.pumpAndSettle();
 
-        expect(find.text('Travel Mode'), findsOneWidget);
+        expect(find.text('Seal Vault'), findsOneWidget);
 
         container.dispose();
       },
     );
 
-    testWidgets('shows Travel Mode after distribution even without owner steward', (
+    testWidgets('shows Seal Vault after distribution even without owner steward', (
       tester,
     ) async {
       final steward1 = createSteward(pubkey: otherPubkey, name: 'Alice');
@@ -195,7 +195,7 @@ void main() {
 
       await tester.pumpAndSettle();
 
-      expect(find.text('Travel Mode'), findsOneWidget);
+      expect(find.text('Seal Vault'), findsOneWidget);
 
       container.dispose();
     });

--- a/test/services/recovery_service_test.dart
+++ b/test/services/recovery_service_test.dart
@@ -958,7 +958,7 @@ void main() {
       'exitRecoveryMode preserves owner content when ending a practice recovery',
       () async {
         // Arrange: Set up owned vault content so the vault hydrates as
-        // OwnedVaultDetail (which gates the Travel Mode button).
+        // OwnedVaultDetail (which gates the Seal Vault button).
         await repository.saveOwnedVaultContent(testVaultId, 'ciphertext-AAA');
 
         // Initiate a practice recovery
@@ -973,7 +973,7 @@ void main() {
         // Act: Exit practice recovery mode
         await recoveryService.exitRecoveryMode(request.id);
 
-        // Assert: Vault content is still present (Travel Mode button stays visible)
+        // Assert: Vault content is still present (Seal Vault button stays visible)
         final ownedRow = await testDb.ownedVaultDao.getByVaultId(testVaultId);
         expect(
           ownedRow,


### PR DESCRIPTION
Renames 'Travel Mode' to 'Seal Vault' everywhere user-facing, with revised dialog copy per human feedback.

Changes:
- Button label, dialog title, body text, warning box, confirm button, snackbar messages
- Icon: Icons.luggage → Icons.lock
- Method: _showTravelModeDialog → _showSealVaultDialog
- Updated all test assertions and comments