### PR TITLE
Remove d tags from all canonical Nostr event formats

### DIFF
--- a/lib/services/invitation_sending_service.dart
+++ b/lib/services/invitation_sending_service.dart
@@ -171,7 +171,6 @@ class InvitationSendingService {
         recipientPubkey: ownerPubkey,
         relays: relayUrls,
         tags: [
-          ['d', 'share_error_${vaultId}_$shareIndex'],
           ['vault_id', vaultId],
           ['error', error],
         ],

--- a/lib/services/recovery_service.dart
+++ b/lib/services/recovery_service.dart
@@ -994,7 +994,6 @@ class RecoveryService {
         recipientPubkeys: recipients,
         relays: relays,
         tags: [
-          ['d', 'recovery_request_${request.id}'],
           ['vault_id', request.vaultId],
           ['recovery_request_id', request.id],
           ['is_practice', request.isPractice.toString()],
@@ -1066,7 +1065,6 @@ class RecoveryService {
 
       // Build tags: recovery_request_id, vault_id, is_practice, and share metadata
       final tags = <List<String>>[
-        ['d', 'recovery_response_${request.id}_$currentPubkey'],
         ['recovery_request_id', request.id],
         ['vault_id', request.vaultId],
       ];

--- a/lib/services/share_distribution_service.dart
+++ b/lib/services/share_distribution_service.dart
@@ -94,8 +94,6 @@ class ShareDistributionService {
           // New Nostr wire format: content is raw payload, tags from shareToNostrTags
           final nostrContent = shareToNostrContent(shareWithRelays);
           final nostrTags = shareToNostrTags(shareWithRelays);
-          // Add d tag for dedup (stable identifier for replaceable event)
-          nostrTags.insert(0, ['d', 'share_${config.vaultId}_$i']);
 
           Log.debug('recipient pubkey: ${keyHolder.pubkey}');
 

--- a/lib/services/share_distribution_service.dart
+++ b/lib/services/share_distribution_service.dart
@@ -254,7 +254,6 @@ class ShareDistributionService {
         // New Nostr wire format for manifest: empty content, tags from shareToNostrTags
         final manifestContent = shareToNostrContent(manifest);
         final manifestTags = shareToNostrTags(manifest);
-        manifestTags.insert(0, ['d', 'manifest_${config.vaultId}']);
         final publishedManifest = await _ndkService.publishEncryptedEvent(
           content: manifestContent,
           kind: NostrKind.shareData.value,

--- a/test/services/share_distribution_service_test.dart
+++ b/test/services/share_distribution_service_test.dart
@@ -436,9 +436,7 @@ void main() {
       expect(capturedTagLists, hasLength(3));
 
       final manifestTags = capturedTagLists.firstWhere(
-        (tags) => tags.any(
-          (t) => t.isNotEmpty && t[0] == 'd' && t.length > 1 && t[1].startsWith('manifest_'),
-        ),
+        (tags) => tags.any((t) => t[0] == 'blob'),
       );
       expect(
         manifestTags.any((t) => t[0] == 'blob' && t[1] == sampleBlob),


### PR DESCRIPTION
Removes 5 redundant d tag lines from outbound event builders on custom kinds 1337-1345 (not declared as replaceable, so d tags serve no purpose).

Removed:
- share_distribution_service.dart: share and manifest d tags + stale comment
- invitation_sending_service.dart: share_error d tag
- recovery_service.dart: recovery_request and recovery_response d tags

No inbound parser changes needed — none read the 'd' tag on these kinds.