### PR TITLE
Add ITSAppUsesNonExemptEncryption key to iOS Info.plist

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -63,5 +63,7 @@
 	</array>
 	<key>FirebaseAppDelegateProxyEnabled</key>
 	<true/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<true/>
 </dict>
 </plist>

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -39,5 +39,7 @@
 			</array>
 		</dict>
 	</array>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Adds the `ITSAppUsesNonExemptEncryption` key to `ios/Runner/Info.plist` for App Store submission.

Horcrux bundles non-OS encryption (pointycastle ChaCha20-Poly1305, SQLCipher, NIP-44 gift-wrapping), so the value is `true` (non-exempt encryption is used).

Qualifies for the mass-market / open-source exemption (MIT license, publicly available on GitHub).

Closes horcrux_app-leoo