### PR TITLE
Onboarding: skip key-backup offer for users on the invitation flow

### DIFF
--- a/lib/screens/account_choice_screen.dart
+++ b/lib/screens/account_choice_screen.dart
@@ -5,6 +5,7 @@ import '../services/invitation_service.dart';
 import '../services/logger.dart';
 import '../utils/app_initialization.dart';
 import '../screens/account_created_screen.dart';
+import '../screens/consent_screen.dart';
 import '../screens/login_screen.dart';
 import '../widgets/horcrux_app_bar.dart';
 import '../widgets/horcrux_scaffold.dart';
@@ -70,7 +71,9 @@ class _AccountChoiceScreenState extends ConsumerState<AccountChoiceScreen> {
 
                   navigator.push(
                     MaterialPageRoute(
-                      builder: (context) => AccountCreatedScreen(nsec: keyPair.privateKeyBech32!),
+                      builder: (context) => ConsentScreen(
+                        nextScreen: AccountCreatedScreen(nsec: keyPair.privateKeyBech32!),
+                      ),
                     ),
                   );
                 },

--- a/lib/screens/account_choice_screen.dart
+++ b/lib/screens/account_choice_screen.dart
@@ -4,6 +4,7 @@ import '../providers/key_provider.dart';
 import '../services/invitation_service.dart';
 import '../services/logger.dart';
 import '../utils/app_initialization.dart';
+import '../utils/onboarding_navigation.dart';
 import '../screens/account_created_screen.dart';
 import '../screens/consent_screen.dart';
 import '../screens/login_screen.dart';
@@ -69,13 +70,30 @@ class _AccountChoiceScreenState extends ConsumerState<AccountChoiceScreen> {
                     'hasStagedInvitations=${ref.read(invitationServiceProvider).hasStagedInvitations}',
                   );
 
-                  navigator.push(
-                    MaterialPageRoute(
-                      builder: (context) => ConsentScreen(
-                        nextScreen: AccountCreatedScreen(nsec: keyPair.privateKeyBech32!),
+                  final hasStagedInvitation =
+                      ref.read(invitationServiceProvider).hasStagedInvitations;
+
+                  if (hasStagedInvitation) {
+                    // Invitation flow: skip the key-backup offer, go through
+                    // consent then to invitation acceptance or vault list.
+                    await navigator.push(
+                      MaterialPageRoute(
+                        builder: (context) => const ConsentScreen(),
                       ),
-                    ),
-                  );
+                    );
+                    if (context.mounted) {
+                      routeToVaultListOrStagedInvitation(context: context, ref: ref);
+                    }
+                  } else {
+                    navigator.push(
+                      MaterialPageRoute(
+                        builder: (context) => ConsentScreen(
+                          nextScreen:
+                              AccountCreatedScreen(nsec: keyPair.privateKeyBech32!),
+                        ),
+                      ),
+                    );
+                  }
                 },
               ),
               const SizedBox(height: 16),

--- a/lib/screens/account_created_screen.dart
+++ b/lib/screens/account_created_screen.dart
@@ -5,6 +5,7 @@ import '../widgets/row_button_stack.dart';
 import '../widgets/horcrux_app_bar.dart';
 import '../widgets/horcrux_scaffold.dart';
 import '../screens/vault_explainer_screen.dart';
+import '../services/invitation_service.dart';
 import '../services/logger.dart';
 import '../utils/onboarding_navigation.dart';
 import '../utils/snackbar_helper.dart';
@@ -26,6 +27,16 @@ class _AccountCreatedScreenState extends ConsumerState<AccountCreatedScreen> {
   void initState() {
     super.initState();
     Log.info('[onboarding] AccountCreatedScreen: shown');
+    // Check for staged invitation after first frame. Invitation-flow users
+    // should skip the key-backup offer entirely.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final invitationService = ref.read(invitationServiceProvider);
+      if (invitationService.hasStagedInvitations) {
+        Log.debug('[onboarding] AccountCreatedScreen: staged invitation found, skipping key-backup offer');
+        routeToVaultListOrStagedInvitation(context: context, ref: ref);
+      }
+    });
   }
 
   String _getRedactedNsec() {

--- a/lib/screens/account_created_screen.dart
+++ b/lib/screens/account_created_screen.dart
@@ -4,7 +4,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../widgets/row_button_stack.dart';
 import '../widgets/horcrux_app_bar.dart';
 import '../widgets/horcrux_scaffold.dart';
-import '../screens/consent_screen.dart';
 import '../screens/vault_explainer_screen.dart';
 import '../services/logger.dart';
 import '../utils/onboarding_navigation.dart';
@@ -53,16 +52,15 @@ class _AccountCreatedScreenState extends ConsumerState<AccountCreatedScreen> {
     });
 
     try {
-      // Navigate through consent screen first, then to vault explainer
+      // Navigate directly to vault explainer (consent is handled before
+      // reaching this screen — see AccountChoiceScreen).
       if (mounted) {
         await Navigator.of(context).pushAndRemoveUntil(
           MaterialPageRoute(
-            builder: (context) => ConsentScreen(
-              nextScreen: VaultExplainerScreen(
-                initialContent: widget.nsec,
-                initialName: 'Nostr Key Backup',
-                isOnboarding: true,
-              ),
+            builder: (context) => VaultExplainerScreen(
+              initialContent: widget.nsec,
+              initialName: 'Nostr Key Backup',
+              isOnboarding: true,
             ),
           ),
           (route) => false, // Clear all previous routes
@@ -88,14 +86,8 @@ class _AccountCreatedScreenState extends ConsumerState<AccountCreatedScreen> {
   Future<void> _skipBackup() async {
     Log.debug('[onboarding] AccountCreatedScreen: Skip for Now tapped');
     if (mounted) {
-      // Route through consent screen first.
-      await Navigator.of(context).push(
-        MaterialPageRoute(builder: (context) => const ConsentScreen()),
-      );
-
-      if (mounted) {
-        routeToVaultListOrStagedInvitation(context: context, ref: ref);
-      }
+      // Consent is handled before reaching this screen (see AccountChoiceScreen).
+      routeToVaultListOrStagedInvitation(context: context, ref: ref);
     }
   }
 

--- a/lib/screens/consent_screen.dart
+++ b/lib/screens/consent_screen.dart
@@ -303,7 +303,7 @@ class _ConsentScreenState extends ConsumerState<ConsentScreen> {
         RowButton(
           onPressed: _agreed ? _handleAccept : null,
           icon: Icons.check,
-          text: 'Agree & Continue',
+          text: 'Continue',
           addBottomSafeArea: true,
         ),
       ],

--- a/test/screens/login_relay_config_screen_test.dart
+++ b/test/screens/login_relay_config_screen_test.dart
@@ -90,8 +90,8 @@ void main() {
     await tester.tap(find.byType(Checkbox));
     await tester.pumpAndSettle();
 
-    // Tap 'Agree & Continue' to accept terms
-    await tester.tap(find.text('Agree & Continue'));
+    // Tap 'Continue' to accept terms
+    await tester.tap(find.text('Continue'));
     await tester.pumpAndSettle();
 
     // After accepting, ImportSuccessScreen should be shown
@@ -124,7 +124,7 @@ void main() {
     await tester.pump();
     await tester.pump();
 
-    await tester.tap(find.text('Agree & Continue'));
+    await tester.tap(find.text('Continue'));
     // Use pump() instead of pumpAndSettle() because VaultListScreen may have
     // infinite animations (timers, periodic refresh from vaultDetailListProvider).
     await tester.pump();


### PR DESCRIPTION
Users who enter onboarding via an invitation link (staged invitation detected) now skip the AccountCreatedScreen key-backup offer. After accepting ToS, they go directly to the invitation acceptance screen or vault list.

- AccountChoiceScreen: after account creation, checks for staged invitation
- If invitation exists → ConsentScreen() → routeToVaultListOrStagedInvitation
- If no invitation → ConsentScreen(nextScreen: AccountCreatedScreen) as before

Depends on jn0q (ToS reorder) — based on that branch.

Closes horcrux_app-h6y8