### PR TITLE
Fix run-app-in-docker.sh on x86_64 hosts: detect Flutter arch

### DIFF
--- a/scripts/run-app-in-docker.sh
+++ b/scripts/run-app-in-docker.sh
@@ -143,10 +143,16 @@ cd /workspace
     echo 'Building Flutter app (incremental)...' >> /tmp/flutter_run.log
     flutter build linux --debug >> /tmp/flutter_run.log 2>&1 || { echo 'Build failed!' >> /tmp/flutter_run.log; exit 1; }
     
-    # Ensure bundle directory exists with executable
-    BUNDLE_DIR="build/linux/arm64/debug/bundle"
-    INTERMEDIATE_DIR="build/linux/arm64/debug/intermediates_do_not_run"
-    BUILD_DIR="build/linux/arm64/debug"
+    # Ensure bundle directory exists with executable.
+    # Flutter's linux build dir is arch-specific: x64 on x86_64, arm64 on aarch64.
+    case "$(uname -m)" in
+        x86_64)        FLUTTER_ARCH=x64 ;;
+        aarch64|arm64) FLUTTER_ARCH=arm64 ;;
+        *) echo "ERROR: unsupported arch: $(uname -m)" >> /tmp/flutter_run.log; exit 1 ;;
+    esac
+    BUNDLE_DIR="build/linux/$FLUTTER_ARCH/debug/bundle"
+    INTERMEDIATE_DIR="build/linux/$FLUTTER_ARCH/debug/intermediates_do_not_run"
+    BUILD_DIR="build/linux/$FLUTTER_ARCH/debug"
     
     # Run cmake install to create bundle with correct prefix
     echo 'Running cmake install to create bundle...' >> /tmp/flutter_run.log


### PR DESCRIPTION
## Problem

`scripts/run-app-in-docker.sh` generates a build script that hardcodes `build/linux/arm64/debug` bundle paths. On x86_64 hosts Flutter outputs to `build/linux/x64/debug`, so the build succeeds (`✓ Built build/linux/x64/debug/bundle/horcrux`) but the script then aborts:

```
ERROR: Bundle executable not found or not executable
```

This made the Docker QA testing workflow unusable on x86_64 Linux hosts (it was presumably written on an arm64 Mac).

## Fix

Derive `FLUTTER_ARCH` from `uname -m` inside the generated build script (`x86_64` → `x64`, `aarch64`/`arm64` → `arm64`) and use it for all three build-dir variables. Errors out explicitly on unknown arches instead of silently looking in the wrong directory.

## Testing

- Hit the failure on the gascity x86_64 host while testing #287, applied this fix in the worktree, and the full Docker workflow then ran end-to-end: build → bundle → D-Bus/gnome-keyring → app launch → Marionette VM Service URI.
- `bash -n` syntax check passes.
- No behavior change on arm64 hosts (same paths as before).

Note: the port-9100 conflict mentioned in the bead is already fixed on main (`9101:9100` remap), so this PR is just the arch fix.

Bead: horcrux_app-kbxw