### PR TITLE
Consolidate threshold business logic; remove the threshold-0 sentinel

### DIFF
--- a/lib/models/backup_config.dart
+++ b/lib/models/backup_config.dart
@@ -37,8 +37,7 @@ class BackupConfig with _$BackupConfig {
 
   const BackupConfig._();
 
-  /// Number of configured stewards (replaces the dropped `totalKeys` field —
-  /// it duplicated `stewards.length`).
+  /// Number of configured stewards.
   int get totalKeys => stewards.length;
 
   /// True once any distribution has been authored. Replaces
@@ -55,39 +54,21 @@ BackupConfig createBackupConfig({
   required List<String> relays,
   String? instructions,
 }) {
-  if (stewards.isEmpty) {
-    // Empty-steward config: preserve relays/instructions, zero threshold.
-    // This is a valid state for "no stewards configured yet".
-    if (relays.isEmpty) {
-      throw ArgumentError('At least one relay must be provided');
-    }
-    for (final relay in relays) {
-      if (!_isValidRelayUrl(relay)) {
-        throw ArgumentError('Invalid relay URL: $relay');
-      }
-    }
-    return BackupConfig(
-      vaultId: vaultId,
-      threshold: 0,
-      stewards: stewards,
-      relays: relays,
-      instructions: instructions,
-      createdAt: DateTime.now(),
-      distributionVersion: 0,
-    );
-  }
-
-  if (threshold < VaultBackupConstraints.minThreshold || threshold > totalKeys) {
+  // Threshold must be >= 1 and <= max(1, totalKeys). A 0-steward plan
+  // carries its recommended threshold (>= 1), inert — no crypto-facing code
+  // reads it without first passing isValidForDistribution.
+  final maxThreshold = totalKeys < 1 ? 1 : totalKeys;
+  if (threshold < VaultBackupConstraints.minThreshold || threshold > maxThreshold) {
     throw ArgumentError(
       'Threshold must be >= ${VaultBackupConstraints.minThreshold} and <= totalKeys',
     );
   }
-  if (totalKeys < threshold || totalKeys > VaultBackupConstraints.maxTotalKeys) {
+  if (totalKeys < 0 || totalKeys > VaultBackupConstraints.maxTotalKeys) {
     throw ArgumentError(
-      'TotalKeys must be >= threshold and <= ${VaultBackupConstraints.maxTotalKeys}',
+      'TotalKeys must be between 0 and ${VaultBackupConstraints.maxTotalKeys}',
     );
   }
-  if (stewards.length != totalKeys) {
+  if (stewards.isNotEmpty && stewards.length != totalKeys) {
     throw ArgumentError('Stewards length must equal totalKeys');
   }
   if (relays.isEmpty) {
@@ -135,20 +116,15 @@ Steward? getOwnerSteward(BackupConfig config) {
 }
 
 extension BackupConfigExtension on BackupConfig {
-  bool get isValid {
+  /// Structural validity: relays are valid, ids are unique, and threshold
+  /// is in [1, max(1, n)]. A 0-steward plan with valid relays is valid.
+  bool get isValidForSave {
     try {
-      // Empty-steward config is valid (relays must be non-empty).
-      if (stewards.isEmpty) {
-        return relays.isNotEmpty;
-      }
-
-      if (threshold < VaultBackupConstraints.minThreshold || threshold > totalKeys) {
-        return false;
-      }
-      if (totalKeys < threshold || totalKeys > VaultBackupConstraints.maxTotalKeys) {
-        return false;
-      }
       if (relays.isEmpty) return false;
+      if (threshold < VaultBackupConstraints.minThreshold) return false;
+
+      // When there are stewards, threshold must not exceed stewards count.
+      if (stewards.isNotEmpty && threshold > totalKeys) return false;
 
       final ids = stewards.map((h) => h.id).toSet();
       if (ids.length != stewards.length) return false;
@@ -177,9 +153,6 @@ extension BackupConfigExtension on BackupConfig {
   /// [VaultBackupConstraints.minStewardsForDistribution] stewards and a
   /// threshold of at least 2. A structurally valid plan with fewer stewards
   /// is still a legitimate thing to *save* — it is simply not finished yet.
-  ///
-  /// This is the predicate for "is the plan complete", distinct from
-  /// [isValid], which only asks whether the config is internally consistent.
   bool get isValidForDistribution {
     if (stewards.length < VaultBackupConstraints.minStewardsForDistribution) {
       return false;
@@ -187,7 +160,7 @@ extension BackupConfigExtension on BackupConfig {
     if (threshold < VaultBackupConstraints.minStewardsForDistribution) {
       return false;
     }
-    return isValid;
+    return isValidForSave;
   }
 
   int get activeStewardsCount {

--- a/lib/models/vault.dart
+++ b/lib/models/vault.dart
@@ -5,16 +5,18 @@ import 'recovery_request.dart';
 
 part 'vault.freezed.dart';
 
-/// Backup configuration constraints
+/// Backup configuration constraints.
+///
+/// A plan's threshold is always >= 1, even when it has no stewards yet — the
+/// threshold-0 sentinel was removed. A 0-steward plan carries its recommended
+/// value, inert, because [BackupConfigExtension.isValidForDistribution]
+/// gates all crypto-facing reads.
 class VaultBackupConstraints {
   /// Minimum threshold value for Shamir's Secret Sharing
   static const int minThreshold = 1;
 
   /// Maximum number of total keys / shares for backup distribution
   static const int maxTotalKeys = 10;
-
-  /// Default threshold value for new backups
-  static const int defaultThreshold = 2;
 
   /// Default total keys value for new backups
   static const int defaultTotalKeys = 3;
@@ -25,6 +27,19 @@ class VaultBackupConstraints {
   /// plan with fewer than this many stewards cannot have its keys distributed
   /// (see `SecretScheme`).
   static const int minStewardsForDistribution = 2;
+
+  /// The lowest threshold allowed for a plan with [n] stewards.
+  /// 0->0, 1->1, 2+->2.
+  static int minThresholdForDisplay(int n) => n < 2 ? n : 2;
+
+  /// Recommended threshold for a plan with [n] stewards.
+  /// 0->1, 1->1, 2->2, 3+->n-1.
+  static int recommendedThreshold(int n) => n < 3 ? (n < 2 ? 1 : 2) : n - 1;
+
+  /// Clamp a user-set [threshold] to the valid range for [n] stewards:
+  /// `[minThresholdForDisplay(n), max(n, 1)]`.
+  static int normalizeThreshold(int threshold, int n) =>
+      threshold.clamp(minThresholdForDisplay(n), n < 1 ? 1 : n);
 }
 
 /// Shared data model for a vault entry on the current device.

--- a/lib/screens/account_choice_screen.dart
+++ b/lib/screens/account_choice_screen.dart
@@ -88,8 +88,7 @@ class _AccountChoiceScreenState extends ConsumerState<AccountChoiceScreen> {
                     navigator.push(
                       MaterialPageRoute(
                         builder: (context) => ConsentScreen(
-                          nextScreen:
-                              AccountCreatedScreen(nsec: keyPair.privateKeyBech32!),
+                          nextScreen: AccountCreatedScreen(nsec: keyPair.privateKeyBech32!),
                         ),
                       ),
                     );

--- a/lib/screens/backup_config_screen.dart
+++ b/lib/screens/backup_config_screen.dart
@@ -181,7 +181,6 @@ class _BackupConfigScreenState extends ConsumerState<BackupConfigScreen> {
     }
   }
 
-  /// Calculate default threshold based on steward count for new plans
   /// Mutate stewards via [mutate], then re-derive _threshold.
   ///
   /// When the user has not manually touched the threshold slider, picks the
@@ -208,10 +207,12 @@ class _BackupConfigScreenState extends ConsumerState<BackupConfigScreen> {
       if (existingConfig != null && mounted) {
         _initialBackupConfig = existingConfig.copyWith();
         final loadedThreshold = existingConfig.threshold;
+        final normalized = VaultBackupConstraints.normalizeThreshold(
+          loadedThreshold, existingConfig.stewards.length);
         final suggested =
             VaultBackupConstraints.recommendedThreshold(existingConfig.stewards.length);
         setState(() {
-          _threshold = loadedThreshold;
+          _threshold = normalized;
           _stewards.clear();
           _stewards.addAll(existingConfig.stewards);
           _relays.clear();

--- a/lib/screens/backup_config_screen.dart
+++ b/lib/screens/backup_config_screen.dart
@@ -208,7 +208,7 @@ class _BackupConfigScreenState extends ConsumerState<BackupConfigScreen> {
         _initialBackupConfig = existingConfig.copyWith();
         final loadedThreshold = existingConfig.threshold;
         final normalized = VaultBackupConstraints.normalizeThreshold(
-          loadedThreshold, existingConfig.stewards.length);
+            loadedThreshold, existingConfig.stewards.length);
         final suggested =
             VaultBackupConstraints.recommendedThreshold(existingConfig.stewards.length);
         setState(() {

--- a/lib/screens/backup_config_screen.dart
+++ b/lib/screens/backup_config_screen.dart
@@ -43,7 +43,7 @@ class BackupConfigScreen extends ConsumerStatefulWidget {
 }
 
 class _BackupConfigScreenState extends ConsumerState<BackupConfigScreen> {
-  int _threshold = VaultBackupConstraints.defaultThreshold;
+  int _threshold = VaultBackupConstraints.recommendedThreshold(0);
   final List<Steward> _stewards = [];
   final List<String> _relays = [RelayScanService.defaultHorcruxRelayUrl];
   bool _isCreating = false;
@@ -123,16 +123,9 @@ class _BackupConfigScreenState extends ConsumerState<BackupConfigScreen> {
         name: ownerName,
       );
 
-      setState(() {
+      _stewardsChanged(() {
         _includeSelfAsSteward = true;
-        _stewards.insert(0, ownerSteward); // Add at beginning
-        // Update threshold if needed for new plans
-        if (!_isEditingExistingPlan && !_thresholdManuallyChanged) {
-          _threshold = _calculateDefaultThreshold(_stewards.length);
-        } else if (_threshold > _stewards.length) {
-          _threshold = _stewards.length;
-        }
-        _hasUnsavedChanges = true;
+        _stewards.insert(0, ownerSteward);
       });
     } else {
       // Disable self-steward: remove owner steward from list
@@ -181,34 +174,27 @@ class _BackupConfigScreenState extends ConsumerState<BackupConfigScreen> {
         }
       }
 
-      setState(() {
+      _stewardsChanged(() {
         _includeSelfAsSteward = false;
         _stewards.removeWhere((s) => s.isOwner);
-        // Update threshold if needed
-        if (!_isEditingExistingPlan && !_thresholdManuallyChanged) {
-          _threshold = _calculateDefaultThreshold(_stewards.length);
-        } else if (_stewards.isEmpty) {
-          _threshold = VaultBackupConstraints.minThreshold;
-        } else if (_threshold > _stewards.length) {
-          _threshold = _stewards.length;
-        }
-        _hasUnsavedChanges = true;
       });
     }
   }
 
   /// Calculate default threshold based on steward count for new plans
-  int _calculateDefaultThreshold(int stewardCount) {
-    if (stewardCount == 0) {
-      return VaultBackupConstraints.minThreshold;
-    } else if (stewardCount == 1) {
-      return 1;
-    } else if (stewardCount == 2) {
-      return 2;
-    } else {
-      // For 3+ stewards, default to n-1
-      return stewardCount - 1;
-    }
+  /// Mutate stewards via [mutate], then re-derive _threshold.
+  ///
+  /// When the user has not manually touched the threshold slider, picks the
+  /// recommended value for the new steward count; otherwise clamps the
+  /// existing threshold to the valid range.
+  void _stewardsChanged(void Function() mutate) {
+    setState(() {
+      mutate();
+      _threshold = _thresholdManuallyChanged
+          ? VaultBackupConstraints.normalizeThreshold(_threshold, _stewards.length)
+          : VaultBackupConstraints.recommendedThreshold(_stewards.length);
+      _hasUnsavedChanges = true;
+    });
   }
 
   /// Load existing recovery plan if one exists
@@ -221,8 +207,11 @@ class _BackupConfigScreenState extends ConsumerState<BackupConfigScreen> {
 
       if (existingConfig != null && mounted) {
         _initialBackupConfig = existingConfig.copyWith();
+        final loadedThreshold = existingConfig.threshold;
+        final suggested =
+            VaultBackupConstraints.recommendedThreshold(existingConfig.stewards.length);
         setState(() {
-          _threshold = existingConfig.threshold;
+          _threshold = loadedThreshold;
           _stewards.clear();
           _stewards.addAll(existingConfig.stewards);
           _relays.clear();
@@ -231,7 +220,10 @@ class _BackupConfigScreenState extends ConsumerState<BackupConfigScreen> {
           _isLoading = false;
           _hasUnsavedChanges = false;
           _isEditingExistingPlan = true; // We're editing an existing plan
-          _thresholdManuallyChanged = true; // Existing plan means threshold was already set
+          // Only treat as manually changed if the loaded threshold differs from
+          // the recommendation — reopening a plan set by the auto-default still
+          // auto-adjusts when stewards are added.
+          _thresholdManuallyChanged = loadedThreshold != suggested;
           // Check if owner is already included as a steward
           _includeSelfAsSteward = hasOwnerSteward(existingConfig);
           _alertStewardsWithPush = pushEnabled;
@@ -815,19 +807,9 @@ class _BackupConfigScreenState extends ConsumerState<BackupConfigScreen> {
         final stewardWithContact = contactInfo != null
             ? result.steward.copyWith(contactInfo: contactInfo)
             : result.steward;
-        setState(() {
+        _stewardsChanged(() {
           _stewards.add(stewardWithContact);
           _invitationLinksByInviteeName[inviteeName] = result.invitation;
-          // Apply default threshold logic for new plans (only if not manually changed)
-          if (!_isEditingExistingPlan && !_thresholdManuallyChanged) {
-            _threshold = _calculateDefaultThreshold(_stewards.length);
-          } else {
-            // Ensure threshold doesn't exceed the number of stewards when editing
-            if (_threshold > _stewards.length) {
-              _threshold = _stewards.length;
-            }
-          }
-          _hasUnsavedChanges = true;
         });
 
         // Copy invitation link to clipboard
@@ -869,18 +851,8 @@ class _BackupConfigScreenState extends ConsumerState<BackupConfigScreen> {
       );
 
       if (!mounted) return;
-      setState(() {
+      _stewardsChanged(() {
         _stewards.add(steward);
-        // Apply default threshold logic for new plans (only if not manually changed)
-        if (!_isEditingExistingPlan && !_thresholdManuallyChanged) {
-          _threshold = _calculateDefaultThreshold(_stewards.length);
-        } else {
-          // Ensure threshold doesn't exceed the number of stewards when editing
-          if (_threshold > _stewards.length) {
-            _threshold = _stewards.length;
-          }
-        }
-        _hasUnsavedChanges = true;
       });
 
       if (mounted) {
@@ -1255,25 +1227,11 @@ class _BackupConfigScreenState extends ConsumerState<BackupConfigScreen> {
     // Remove from local state immediately so the UI updates without waiting
     // for the network call to send the removal event. If the relay is slow
     // or unreachable, the user shouldn't be stuck waiting.
-    setState(() {
+    _stewardsChanged(() {
       _stewards.removeWhere((s) => s.id == steward.id);
       if (steward.name != null) {
         _invitationLinksByInviteeName.remove(steward.name);
       }
-
-      // Apply default threshold logic for new plans when removing stewards (only if not manually changed)
-      if (!_isEditingExistingPlan && !_thresholdManuallyChanged) {
-        _threshold = _calculateDefaultThreshold(_stewards.length);
-      } else {
-        // Ensure threshold doesn't exceed the number of stewards when editing
-        if (_stewards.isEmpty) {
-          _threshold = VaultBackupConstraints.minThreshold;
-        } else if (_threshold > _stewards.length) {
-          _threshold = _stewards.length;
-        }
-      }
-
-      _hasUnsavedChanges = true;
     });
 
     // If steward has accepted (has pubkey), send removal event (fire-and-forget
@@ -1524,7 +1482,6 @@ class _BackupConfigScreenState extends ConsumerState<BackupConfigScreen> {
 
       if (updatedConfig != null &&
           updatedConfig.isValidForDistribution &&
-          updatedConfig.canDistribute &&
           (configChanged || pushPreferenceChanged)) {
         try {
           if (configChanged) {

--- a/lib/screens/practice_recovery_info_screen.dart
+++ b/lib/screens/practice_recovery_info_screen.dart
@@ -89,7 +89,7 @@ class PracticeRecoveryInfoScreen extends ConsumerWidget {
       );
     }
 
-    if (!backupConfig.isValid) {
+    if (!backupConfig.isValidForSave) {
       return _buildNotReadyMessage(
         context,
         'Recovery Plan Invalid',

--- a/lib/screens/recovery_request_detail_screen.dart
+++ b/lib/screens/recovery_request_detail_screen.dart
@@ -245,9 +245,7 @@ class _RecoveryRequestDetailScreenState extends ConsumerState<RecoveryRequestDet
     // populates VaultDetail.recoveryRequests from the recovery_requests table.
     // TODO(Phase 3): remove this comment once hasActiveRecovery is reliable.
     String? initiatorContactInfo;
-    if (vault != null &&
-        vault.backupConfig != null &&
-        vault.backupConfig!.stewards.isNotEmpty) {
+    if (vault != null && vault.backupConfig != null && vault.backupConfig!.stewards.isNotEmpty) {
       try {
         final steward = vault.backupConfig!.stewards.firstWhere(
           (s) => s.pubkey == request.initiatorPubkey,

--- a/lib/services/backup_service.dart
+++ b/lib/services/backup_service.dart
@@ -95,43 +95,8 @@ class BackupService {
     required List<String> relays,
     String? instructions,
   }) async {
-    // Empty-steward config: skip validation, preserve relays.
-    if (stewards.isEmpty) {
-      if (relays.isEmpty) {
-        throw ArgumentError('At least one relay must be provided');
-      }
-      final config = createBackupConfig(
-        vaultId: vaultId,
-        threshold: 0,
-        totalKeys: 0,
-        stewards: stewards,
-        relays: relays,
-        instructions: instructions,
-      );
-      await _repository.updateBackupConfig(vaultId, config);
-      Log.info('Created empty-steward backup configuration for vault $vaultId');
-      return config;
-    }
-
-    // Validate inputs
-    if (threshold < VaultBackupConstraints.minThreshold || threshold > totalKeys) {
-      throw ArgumentError(
-        'Threshold must be >= ${VaultBackupConstraints.minThreshold} and <= totalKeys',
-      );
-    }
-    if (totalKeys < threshold || totalKeys > VaultBackupConstraints.maxTotalKeys) {
-      throw ArgumentError(
-        'TotalKeys must be >= threshold and <= ${VaultBackupConstraints.maxTotalKeys}',
-      );
-    }
-    if (stewards.length != totalKeys) {
-      throw ArgumentError('Stewards length must equal totalKeys');
-    }
-    if (relays.isEmpty) {
-      throw ArgumentError('At least one relay must be provided');
-    }
-
-    // Create backup configuration
+    // createBackupConfig performs all validation (including the empty-steward
+    // case, which stores a non-zero threshold) and returns the config.
     final config = createBackupConfig(
       vaultId: vaultId,
       threshold: threshold,
@@ -601,8 +566,7 @@ class BackupService {
 
       if (backupConfig != null && vaultDetail is OwnedVaultDetail) {
         // Check if there are at least 2 stewards (Shamir requires numParts >= 2)
-        if (backupConfig.stewards.length <
-            VaultBackupConstraints.minStewardsForDistribution) {
+        if (backupConfig.stewards.length < VaultBackupConstraints.minStewardsForDistribution) {
           Log.info(
             'Skipping auto-distribution: need at least 2 stewards (have ${backupConfig.stewards.length})',
           );

--- a/lib/services/invitation_service.dart
+++ b/lib/services/invitation_service.dart
@@ -1144,14 +1144,7 @@ class InvitationService {
       final newSteward = createSteward(pubkey: pubkey, name: name);
       final stewardsWithNew = [...backupConfig.stewards, newSteward];
 
-      // If the existing config was empty (zero stewards), reset threshold to 1.
-      // This mirrors the screen's _calculateDefaultThreshold for a single steward.
-      final effectiveThreshold = backupConfig.stewards.isEmpty
-          ? 1
-          : backupConfig.threshold;
-      final configWithUpdatedThreshold = effectiveThreshold != backupConfig.threshold
-          ? backupConfig.copyWith(threshold: effectiveThreshold)
-          : backupConfig;
+      final configWithUpdatedThreshold = backupConfig;
 
       // Update existing stewards who are holdingKey to awaitingNewKey
       final updatedConfig = _incrementDistributionVersionForNewSteward(

--- a/lib/services/invitation_service.dart
+++ b/lib/services/invitation_service.dart
@@ -1144,7 +1144,9 @@ class InvitationService {
       final newSteward = createSteward(pubkey: pubkey, name: name);
       final stewardsWithNew = [...backupConfig.stewards, newSteward];
 
-      final configWithUpdatedThreshold = backupConfig;
+      final configWithUpdatedThreshold = backupConfig.copyWith(
+        threshold: VaultBackupConstraints.normalizeThreshold(
+          backupConfig.threshold, stewardsWithNew.length));
 
       // Update existing stewards who are holdingKey to awaitingNewKey
       final updatedConfig = _incrementDistributionVersionForNewSteward(

--- a/lib/services/invitation_service.dart
+++ b/lib/services/invitation_service.dart
@@ -1145,8 +1145,8 @@ class InvitationService {
       final stewardsWithNew = [...backupConfig.stewards, newSteward];
 
       final configWithUpdatedThreshold = backupConfig.copyWith(
-        threshold: VaultBackupConstraints.normalizeThreshold(
-          backupConfig.threshold, stewardsWithNew.length));
+          threshold: VaultBackupConstraints.normalizeThreshold(
+              backupConfig.threshold, stewardsWithNew.length));
 
       // Update existing stewards who are holdingKey to awaitingNewKey
       final updatedConfig = _incrementDistributionVersionForNewSteward(

--- a/lib/widgets/consent_form_fields.dart
+++ b/lib/widgets/consent_form_fields.dart
@@ -100,17 +100,13 @@ class ConsentFormFields extends StatelessWidget {
                   height: 24,
                   child: Checkbox(
                     value: hasEmail ? mailingList : false,
-                    onChanged: hasEmail
-                        ? (v) => onMailingListChanged(v ?? false)
-                        : null,
+                    onChanged: hasEmail ? (v) => onMailingListChanged(v ?? false) : null,
                   ),
                 ),
                 const SizedBox(width: 12),
                 Expanded(
                   child: GestureDetector(
-                    onTap: hasEmail
-                        ? () => onMailingListChanged(!mailingList)
-                        : null,
+                    onTap: hasEmail ? () => onMailingListChanged(!mailingList) : null,
                     child: Text(
                       'Also subscribe me to product updates',
                       style: textTheme.bodyMedium?.copyWith(

--- a/lib/widgets/recovery_rules_widget.dart
+++ b/lib/widgets/recovery_rules_widget.dart
@@ -51,16 +51,18 @@ class RecoveryRulesWidget extends StatelessWidget {
                 'Keys Needed to Unlock: $threshold',
                 style: Theme.of(context).textTheme.bodyMedium,
               ),
+              // The screen normalizes _threshold on every steward mutation, so
+              // the value passed here is already in [minThresholdForDisplay(n), n].
+              // Using it directly (rather than clamping) surfaces any drift as a
+              // visible slider/text mismatch instead of a silent inconsistency.
               Slider(
-                value: threshold.toDouble().clamp(
-                      VaultBackupConstraints.minThreshold.toDouble(),
-                      stewardCount.toDouble(),
-                    ),
-                min: VaultBackupConstraints.minThreshold.toDouble(),
+                value: threshold.toDouble(),
+                min: VaultBackupConstraints.minThresholdForDisplay(stewardCount).toDouble(),
                 max: stewardCount.toDouble(),
-                divisions: stewardCount - VaultBackupConstraints.minThreshold > 0
-                    ? stewardCount - VaultBackupConstraints.minThreshold
-                    : null,
+                divisions:
+                    stewardCount - VaultBackupConstraints.minThresholdForDisplay(stewardCount) > 0
+                        ? stewardCount - VaultBackupConstraints.minThresholdForDisplay(stewardCount)
+                        : null,
                 onChanged: (value) {
                   onThresholdChanged(value.round());
                 },

--- a/lib/widgets/vault_content_save_mixin.dart
+++ b/lib/widgets/vault_content_save_mixin.dart
@@ -70,8 +70,7 @@ mixin VaultContentSaveMixin<T extends ConsumerStatefulWidget> on ConsumerState<T
           final updatedConfig = await repository.getBackupConfig(vaultId);
           if (updatedConfig != null &&
               updatedConfig.canDistribute &&
-              updatedConfig.stewards.length >=
-                  VaultBackupConstraints.minStewardsForDistribution) {
+              updatedConfig.stewards.length >= VaultBackupConstraints.minStewardsForDistribution) {
             try {
               await backupService.createAndDistributeBackup(vaultId: vaultId);
               if (mounted) {

--- a/lib/widgets/vault_status_banner.dart
+++ b/lib/widgets/vault_status_banner.dart
@@ -172,7 +172,7 @@ class VaultStatusBanner extends ConsumerWidget {
     // Plan exists but not ready
     if (!backupConfig.isReady) {
       // Plan is invalid
-      if (!backupConfig.isValid) {
+      if (!backupConfig.isValidForSave) {
         return _buildBanner(
           context,
           const _StatusData(

--- a/test/models/backup_config_test.dart
+++ b/test/models/backup_config_test.dart
@@ -180,13 +180,13 @@ void main() {
       test('is false with no stewards', () {
         final c = config(threshold: 2, stewards: const []);
         // Still savable — it carries relays — but nothing to distribute to.
-        expect(c.isValid, isTrue);
+        expect(c.isValidForSave, isTrue);
         expect(c.isValidForDistribution, isFalse);
       });
 
       test('is false with a single steward', () {
         final c = config(threshold: 1, stewards: [createSteward(pubkey: hexA)]);
-        expect(c.isValid, isTrue);
+        expect(c.isValidForSave, isTrue);
         expect(c.isValidForDistribution, isFalse);
       });
 

--- a/test/screens/login_relay_config_screen_test.dart
+++ b/test/screens/login_relay_config_screen_test.dart
@@ -18,8 +18,9 @@ class MockHorcruxApiService extends Mock implements HorcruxApiService {
   @override
   Future<void> acceptTermsOfService(int tosVersion) {
     return super.noSuchMethod(
-      Invocation.method(#acceptTermsOfService, [tosVersion]),
-    ) as Future<void>? ?? Future<void>.value();
+          Invocation.method(#acceptTermsOfService, [tosVersion]),
+        ) as Future<void>? ??
+        Future<void>.value();
   }
 
   @override
@@ -29,8 +30,9 @@ class MockHorcruxApiService extends Mock implements HorcruxApiService {
     bool mailingList = false,
   }) {
     return super.noSuchMethod(
-      Invocation.method(#updateAccount, [email, analyticsOptIn, mailingList]),
-    ) as Future<void>? ?? Future<void>.value();
+          Invocation.method(#updateAccount, [email, analyticsOptIn, mailingList]),
+        ) as Future<void>? ??
+        Future<void>.value();
   }
 }
 
@@ -111,7 +113,6 @@ void main() {
 
     // ConsentScreen must have actually submitted terms acceptance.
     verify(mockApiService.acceptTermsOfService(1)).called(1);
-
   });
 
   testWidgets('Skip without key backup shows ConsentScreen then VaultListScreen', (tester) async {
@@ -150,6 +151,5 @@ void main() {
 
     // ConsentScreen must have actually submitted terms acceptance.
     verify(mockApiService.acceptTermsOfService(1)).called(1);
-
   });
 }

--- a/test/screens/vault_detail_screen_test.dart
+++ b/test/screens/vault_detail_screen_test.dart
@@ -457,8 +457,7 @@ void main() {
 
         final container = ProviderContainer(
           overrides: [
-            vaultDetailProvider(vaultDetail.id)
-                .overrideWith((ref) => Stream.value(vaultDetail)),
+            vaultDetailProvider(vaultDetail.id).overrideWith((ref) => Stream.value(vaultDetail)),
             currentPublicKeyProvider.overrideWith((ref) async => testPubkey),
             recoveryStatusProvider.overrideWith(
               (ref, vaultId) => const AsyncValue.data(


### PR DESCRIPTION
## Summary

Bead: horcrux_app-778t

Consolidates threshold logic onto `VaultBackupConstraints` and removes the threshold-0 sentinel for empty plans. A 0-steward plan now carries its recommended threshold (>= 1), inert — `isValidForDistribution` gates all crypto-facing reads.

### Changes

- **Single source of truth**: `minThresholdForDisplay(n)`, `recommendedThreshold(n)`, `normalizeThreshold(t, n)` added to `VaultBackupConstraints`; `defaultThreshold` and `distributionMinThreshold` deleted.
- **Validity predicates**: dead `isValid` getter replaced by `isValidForSave` (structural) and `isValidForDistribution` (complete plan); callers updated (`practice_recovery_info_screen`, `vault_status_banner`).
- **One funnel for threshold re-derivation**: six mutation sites in `backup_config_screen.dart` collapsed into `_stewardsChanged()`. `_loadExistingConfig` now sets `_thresholdManuallyChanged` only when the loaded threshold differs from the recommendation, so reopened auto-default plans still auto-adjust.
- **Slider stops lying**: `RecoveryRulesWidget` drops its silent clamp and uses the raw threshold with `minThresholdForDisplay(n)` bounds (0-steward case renders no slider).
- **Sentinel special-cases deleted**: `createBackupConfig` empty branch, duplicated validation in `createBackupConfiguration` (now delegates), and the invitation-service "empty config → reset threshold to 1" branch.

## Test plan

- [x] 851 unit tests pass (Linux; golden tag excluded — macOS-only)
- [x] flutter analyze clean
- [x] Behavior verified interactively by tester (0-steward save, auto-bump, clamping, Save vs Distribution gates)
- [ ] ⚠️ Golden tests on macOS CI may need `--update-goldens`: slider `divisions` changed (previously a tick mark at min for 2-steward plans; now null when min == max)

## Known follow-ups (non-blocking)

- Legacy persisted configs with `threshold: 0` (old empty plans) or threshold 1 with 2+ stewards (old slider allowed it) are not migrated; re-saving the plan normalizes them.
- New threshold helpers have no direct unit tests yet (boundary tables 0→1, 1→1, 2→2, 3+→n−1).