### PR TITLE
Owner without self-steward shard can initiate recovery on a sealed vault

### DIFF
--- a/lib/services/recovery_service.dart
+++ b/lib/services/recovery_service.dart
@@ -340,49 +340,79 @@ class RecoveryService {
     } else {
       // Real recovery: use held share data from the database.
       final shares = await repository.getSharesForVault(vaultId);
-      if (shares.isEmpty) {
-        throw StateError(
-          'Cannot recover: you don\'t have a key to this vault.',
-        );
-      }
 
-      final selectedShard = latestShare(shares)!;
+      // Owner without self-steward shard: derive from backupConfig (mirror
+      // the practice path), since they hold no local share to recover from.
+      if (shares.isEmpty && vault.isVaultOwner(initiatorPubkey)) {
+        final backupConfig = vault.backupConfig;
+        if (backupConfig == null || backupConfig.stewards.isEmpty) {
+          throw StateError('No recovery plan configured for this vault');
+        }
 
-      Log.debug(
-        'Selected shard with distributionVersion ${selectedShard.distributionVersion} for recovery',
-      );
+        stewardPubkeys = backupConfig.stewards
+            .where(
+              (s) => s.pubkey != null && s.status == StewardStatus.holdingKey,
+            )
+            .map((s) => s.pubkey!)
+            .toList();
 
-      final backupConfig = vault.backupConfig;
-      if (backupConfig == null) {
-        throw StateError(
-          'No steward metadata available for recovery. '
-          'Please refresh share metadata from a recent distribution.',
-        );
-      }
+        if (stewardPubkeys.isEmpty) {
+          throw StateError(
+            'No stewards available for recovery. Make sure stewards have received and confirmed their keys.',
+          );
+        }
 
-      // Use normalized stewards from the DB-backed backup config.
-      stewardPubkeys = backupConfig.stewards
-          .where((s) => s.pubkey != null && s.status != StewardStatus.invited)
-          .map((s) => s.pubkey!)
-          .toSet()
-          .toList();
-
-      if (stewardPubkeys.isEmpty) {
-        throw StateError('No stewards available for recovery');
-      }
-
-      threshold = backupConfig.threshold;
-
-      // Use normalized relay configuration first; fall back to legacy shard
-      // relay hints for older vault rows.
-      if (backupConfig.relays.isNotEmpty) {
+        threshold = backupConfig.threshold;
         relayUrls = backupConfig.relays;
-      } else if (selectedShard.relayUrls != null && selectedShard.relayUrls!.isNotEmpty) {
-        relayUrls = selectedShard.relayUrls!;
+
+        if (relayUrls.isEmpty) {
+          throw StateError('No relays configured in recovery plan');
+        }
       } else {
-        throw StateError(
-          'No relays configured for recovery. Please configure relays in the recovery plan.',
+        if (shares.isEmpty) {
+          throw StateError(
+            'Cannot recover: you don\'t have a key to this vault.',
+          );
+        }
+
+        final selectedShard = latestShare(shares)!;
+
+        Log.debug(
+          'Selected shard with distributionVersion ${selectedShard.distributionVersion} for recovery',
         );
+
+        final backupConfig = vault.backupConfig;
+        if (backupConfig == null) {
+          throw StateError(
+            'No steward metadata available for recovery. '
+            'Please refresh share metadata from a recent distribution.',
+          );
+        }
+
+        // Use normalized stewards from the DB-backed backup config.
+        stewardPubkeys = backupConfig.stewards
+            .where((s) => s.pubkey != null && s.status != StewardStatus.invited)
+            .map((s) => s.pubkey!)
+            .toSet()
+            .toList();
+
+        if (stewardPubkeys.isEmpty) {
+          throw StateError('No stewards available for recovery');
+        }
+
+        threshold = backupConfig.threshold;
+
+        // Use normalized relay configuration first; fall back to legacy shard
+        // relay hints for older vault rows.
+        if (backupConfig.relays.isNotEmpty) {
+          relayUrls = backupConfig.relays;
+        } else if (selectedShard.relayUrls != null && selectedShard.relayUrls!.isNotEmpty) {
+          relayUrls = selectedShard.relayUrls!;
+        } else {
+          throw StateError(
+            'No relays configured for recovery. Please configure relays in the recovery plan.',
+          );
+        }
       }
     }
 

--- a/lib/services/recovery_service.dart
+++ b/lib/services/recovery_service.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../database/app_database.dart';
 import '../database/app_database_provider.dart';
+import '../models/backup_config.dart';
 import '../models/nostr_kinds.dart';
 import '../models/recovery_request.dart';
 import '../models/recovery_status.dart';
@@ -17,6 +18,23 @@ import 'ndk_service.dart';
 import 'notification_recency.dart';
 import 'processed_nostr_event_store.dart';
 import 'logger.dart';
+
+/// Steward pubkeys that hold a confirmed key share and can participate in
+/// recovery. Only [StewardStatus.holdingKey] stewards are included — they are
+/// the only ones with a usable share to respond with. This is the single
+/// authoritative filter for both the practice and real recovery paths so the
+/// recovery roster is identical regardless of whether the initiator holds a
+/// shard themselves.
+///
+/// Duplicate pubkeys are de-duplicated with `.toSet()`; stewards without a
+/// pubkey are excluded.
+List<String> recoveryStewardPubkeys(BackupConfig backupConfig) {
+  return backupConfig.stewards
+      .where((s) => s.pubkey != null && s.status == StewardStatus.holdingKey)
+      .map((s) => s.pubkey!)
+      .toSet()
+      .toList();
+}
 
 /// Provider for RecoveryService
 /// This service depends on VaultRepository for recovery operations.
@@ -318,12 +336,7 @@ class RecoveryService {
       }
 
       // Get steward pubkeys from backup config (owners only - stewards cannot practice recovery)
-      stewardPubkeys = backupConfig.stewards
-          .where(
-            (s) => s.pubkey != null && s.status == StewardStatus.holdingKey,
-          )
-          .map((s) => s.pubkey!)
-          .toList();
+      stewardPubkeys = recoveryStewardPubkeys(backupConfig);
 
       if (stewardPubkeys.isEmpty) {
         throw StateError(
@@ -349,12 +362,7 @@ class RecoveryService {
           throw StateError('No recovery plan configured for this vault');
         }
 
-        stewardPubkeys = backupConfig.stewards
-            .where(
-              (s) => s.pubkey != null && s.status == StewardStatus.holdingKey,
-            )
-            .map((s) => s.pubkey!)
-            .toList();
+        stewardPubkeys = recoveryStewardPubkeys(backupConfig);
 
         if (stewardPubkeys.isEmpty) {
           throw StateError(
@@ -389,12 +397,13 @@ class RecoveryService {
           );
         }
 
-        // Use normalized stewards from the DB-backed backup config.
-        stewardPubkeys = backupConfig.stewards
-            .where((s) => s.pubkey != null && s.status != StewardStatus.invited)
-            .map((s) => s.pubkey!)
-            .toSet()
-            .toList();
+        // Use normalized stewards from the DB-backed backup config. Only
+        // holding-key stewards are included — they are the only ones with a
+        // confirmed share that can respond to the recovery request. This is
+        // intentionally aligned with the no-shard owner branch and the
+        // practice path above; awaiting/inactive/error/revoked stewards hold
+        // no usable share and would never be able to contribute.
+        stewardPubkeys = recoveryStewardPubkeys(backupConfig);
 
         if (stewardPubkeys.isEmpty) {
           throw StateError('No stewards available for recovery');

--- a/lib/widgets/vault_detail_button_stack.dart
+++ b/lib/widgets/vault_detail_button_stack.dart
@@ -251,11 +251,15 @@ class VaultDetailButtonStack extends ConsumerWidget {
                 // Owner without a self-steward shard who sealed the vault can
                 // still initiate real recovery — the request is built from the
                 // backup plan instead of a held shard.
+                // Require at least one holding-key steward so the button does
+                // not appear when the service would immediately throw a
+                // "No stewards available for recovery" StateError.
                 final canInitiateRecoveryWithoutShard =
                     isVaultOwner &&
                     vault is StewardedVaultDetail &&
                     vault.latestShare == null &&
-                    (vault.backupConfig?.isValidForDistribution == true);
+                    vault.backupConfig?.isValidForDistribution == true &&
+                    vault.backupConfig!.acknowledgedStewardsCount >= 1;
                 final showInitiateRealRecovery =
                     (isOwnerSteward || canInitiateRecoveryWithoutShard) &&
                     !hasMyInFlightRecovery &&

--- a/lib/widgets/vault_detail_button_stack.dart
+++ b/lib/widgets/vault_detail_button_stack.dart
@@ -248,8 +248,18 @@ class VaultDetailButtonStack extends ConsumerWidget {
                 final ownerHasOwnedContent = vault is OwnedVaultDetail;
                 final isOwnerSteward =
                     isVaultOwner && vault is StewardedVaultDetail && vault.latestShare != null;
+                // Owner without a self-steward shard who sealed the vault can
+                // still initiate real recovery — the request is built from the
+                // backup plan instead of a held shard.
+                final canInitiateRecoveryWithoutShard =
+                    isVaultOwner &&
+                    vault is StewardedVaultDetail &&
+                    vault.latestShare == null &&
+                    (vault.backupConfig?.isValidForDistribution == true);
                 final showInitiateRealRecovery =
-                    isOwnerSteward && !hasMyInFlightRecovery && !ownerHasOwnedContent;
+                    (isOwnerSteward || canInitiateRecoveryWithoutShard) &&
+                    !hasMyInFlightRecovery &&
+                    !ownerHasOwnedContent;
 
                 if (showInitiateRealRecovery) {
                   buttons.add(

--- a/test/screens/vault_detail_screen_test.dart
+++ b/test/screens/vault_detail_screen_test.dart
@@ -5,6 +5,7 @@ import 'package:horcrux/models/backup_config.dart';
 import 'package:horcrux/models/steward.dart';
 import 'package:horcrux/models/share.dart';
 import 'package:horcrux/models/recovery_request.dart';
+import 'package:horcrux/models/steward_status.dart';
 import 'package:horcrux/models/vault_detail.dart';
 import 'package:horcrux/providers/vault_provider.dart';
 import 'package:horcrux/providers/key_provider.dart';
@@ -199,6 +200,114 @@ void main() {
 
       container.dispose();
     });
+
+    testWidgets(
+      'shows Initiate Recovery for owner without self-steward shard on a sealed vault',
+      (tester) async {
+        // Owner is NOT a self-steward (no share), vault is sealed
+        // (no owned_vaults row → StewardedVaultDetail with latestShare null).
+        final steward1 = createSteward(pubkey: otherPubkey, name: 'Alice')
+            .copyWith(status: StewardStatus.holdingKey);
+        final steward2 = createSteward(pubkey: 'c' * 64, name: 'Bob')
+            .copyWith(status: StewardStatus.holdingKey);
+
+        final backupConfig = createBackupConfig(
+          vaultId: 'test-vault',
+          threshold: 2,
+          totalKeys: 2,
+          stewards: [steward1, steward2],
+          relays: ['wss://relay.example.com'],
+        ).copyWith(distributionVersion: 1);
+
+        final vaultDetail = StewardedVaultDetail(
+          id: 'test-vault',
+          name: 'Test Vault',
+          ownerPubkey: testPubkey,
+          ownerName: null,
+          threshold: 2,
+          totalShares: 2,
+          stewards: const [],
+          recoveryRequests: const [],
+          pushEnabled: false,
+          createdAt: DateTime(2024, 1, 1),
+          archivedAt: null,
+          archivedReason: null,
+          backupConfig: backupConfig,
+          latestShare: null,
+        );
+
+        final container = ProviderContainer(
+          overrides: baseOverrides(vault: vaultDetail, currentPubkey: testPubkey),
+        );
+
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: const MaterialApp(home: VaultDetailScreen(vaultId: 'test-vault')),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        expect(find.text('Initiate Recovery'), findsOneWidget);
+
+        container.dispose();
+      },
+    );
+
+    testWidgets(
+      'does not show Initiate Recovery for owner without shard when no steward holds a key',
+      (tester) async {
+        // Valid-for-distribution plan (2 stewards, threshold 2) but neither
+        // steward has acknowledged → acknowledgedStewardsCount == 0, so the
+        // service would throw "No stewards available for recovery" — the
+        // button must not be shown.
+        final steward1 = createSteward(pubkey: otherPubkey, name: 'Alice');
+        final steward2 = createSteward(pubkey: 'c' * 64, name: 'Bob');
+
+        final backupConfig = createBackupConfig(
+          vaultId: 'test-vault',
+          threshold: 2,
+          totalKeys: 2,
+          stewards: [steward1, steward2],
+          relays: ['wss://relay.example.com'],
+        ).copyWith(distributionVersion: 1);
+
+        final vaultDetail = StewardedVaultDetail(
+          id: 'test-vault',
+          name: 'Test Vault',
+          ownerPubkey: testPubkey,
+          ownerName: null,
+          threshold: 2,
+          totalShares: 2,
+          stewards: const [],
+          recoveryRequests: const [],
+          pushEnabled: false,
+          createdAt: DateTime(2024, 1, 1),
+          archivedAt: null,
+          archivedReason: null,
+          backupConfig: backupConfig,
+          latestShare: null,
+        );
+
+        final container = ProviderContainer(
+          overrides: baseOverrides(vault: vaultDetail, currentPubkey: testPubkey),
+        );
+
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: const MaterialApp(home: VaultDetailScreen(vaultId: 'test-vault')),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        expect(find.text('Initiate Recovery'), findsNothing);
+
+        container.dispose();
+      },
+    );
   });
 
   group('Steward vault detail buttons with concurrent multi-initiator recoveries', () {

--- a/test/services/recovery_service_test.dart
+++ b/test/services/recovery_service_test.dart
@@ -996,6 +996,150 @@ void main() {
     );
   });
 
+  group('initiateAndSendRecovery - owner without self-steward shard', () {
+    late String testOwnerPubkey;
+    late LoginService loginService;
+    late VaultRepository repository;
+    late BackupService backupService;
+    late NdkService ndkService;
+    late RecoveryService recoveryService;
+    late AppDatabase testDb;
+    const testVaultId = 'vault-non-self-steward';
+    const testKeyHolder1 = 'fedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321';
+    const testKeyHolder2 = 'abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdef1234';
+
+    setUp(() async {
+      secureStorageMock.clear();
+      loginService = LoginService();
+      await loginService.clearStoredKeys();
+      LoginService.resetCache();
+
+      final keyPair = await loginService.generateAndStoreNostrKey();
+      testOwnerPubkey = keyPair.publicKey;
+
+      testDb = newTestDatabase();
+      repository = VaultRepository(loginService, db: testDb);
+
+      final mockBackupService = MockBackupService();
+      final mockNdkService = MockNdkService();
+      when(mockNdkService.getCurrentPubkey()).thenAnswer((_) async => testOwnerPubkey);
+      when(
+        mockNdkService.publishEncryptedEventToMultiple(
+          content: anyNamed('content'),
+          kind: anyNamed('kind'),
+          recipientPubkeys: anyNamed('recipientPubkeys'),
+          relays: anyNamed('relays'),
+          tags: anyNamed('tags'),
+          customPubkey: anyNamed('customPubkey'),
+          vaultId: anyNamed('vaultId'),
+        ),
+      ).thenAnswer((_) async => <Nip01Event?>[]);
+
+      final mockHorcruxNotificationService = MockHorcruxNotificationService();
+      when(
+        mockHorcruxNotificationService.tryPushForEvent(
+          event: anyNamed('event'),
+          kind: anyNamed('kind'),
+          vault: anyNamed('vault'),
+          relayHints: anyNamed('relayHints'),
+          recoveryApproved: anyNamed('recoveryApproved'),
+        ),
+      ).thenAnswer((_) async {});
+
+      backupService = mockBackupService;
+      ndkService = mockNdkService;
+      recoveryService = RecoveryService(
+        repository,
+        backupService,
+        ndkService,
+        ProcessedNostrEventStore(),
+        MockLocalNotificationService(),
+        mockHorcruxNotificationService,
+        testDb,
+      );
+      await recoveryService.clearAll();
+      await repository.clearAll();
+
+      // Create a vault with a valid backup config (≥2 holdingKey stewards,
+      // threshold ≥2) — the owner has NO shares (no self-steward).
+      final testVault = Vault(
+        id: testVaultId,
+        name: 'Test Vault',
+        createdAt: DateTime.now(),
+        ownerPubkey: testOwnerPubkey,
+      );
+      await repository.addVault(testVault);
+
+      final relayPlan = createBackupConfig(
+        vaultId: testVaultId,
+        threshold: 2,
+        totalKeys: 2,
+        stewards: [
+          createSteward(pubkey: testKeyHolder1).copyWith(status: StewardStatus.holdingKey),
+          createSteward(pubkey: testKeyHolder2).copyWith(status: StewardStatus.holdingKey),
+        ],
+        relays: ['wss://relay.example.com'],
+      );
+      await repository.updateBackupConfig(testVaultId, relayPlan);
+    });
+
+    tearDown(() async {
+      await repository.clearAll();
+      await loginService.clearStoredKeys();
+      LoginService.resetCache();
+      await testDb.close();
+    });
+
+    test('owner without self-steward shard can initiate recovery from backup config', () async {
+      // Verify no shares exist (owner is not a self-steward)
+      final shares = await repository.getSharesForVault(testVaultId);
+      expect(shares, isEmpty, reason: 'Owner should have no shares');
+
+      // Act: initiate real recovery
+      final request = await recoveryService.initiateAndSendRecovery(
+        testVaultId,
+        isPractice: false,
+      );
+
+      // Assert: recovery request was created with data from backup config
+      expect(request, isNotNull);
+      expect(request.vaultId, testVaultId);
+      expect(request.initiatorPubkey, testOwnerPubkey);
+      expect(request.isPractice, isFalse);
+      expect(request.stewardPubkeys, containsAll([testKeyHolder1, testKeyHolder2]));
+      expect(request.threshold, 2);
+    });
+
+    test('owner with shares still uses the existing share-based path', () async {
+      // Add a share (simulating self-steward owner)
+      await repository.addShareToVault(
+        testVaultId,
+        Share(
+          payload: 'test-share',
+          threshold: 2,
+          totalShares: 2,
+          shareIndex: 0,
+          creatorPubkey: testOwnerPubkey,
+          createdAt: DateTime.now().millisecondsSinceEpoch,
+          relayUrls: ['wss://relay.example.com'],
+        ),
+      );
+
+      final shares = await repository.getSharesForVault(testVaultId);
+      expect(shares, isNotEmpty, reason: 'Owner should have a share');
+
+      // Act: initiate real recovery
+      final request = await recoveryService.initiateAndSendRecovery(
+        testVaultId,
+        isPractice: false,
+      );
+
+      // Assert: recovery request was created
+      expect(request, isNotNull);
+      expect(request.vaultId, testVaultId);
+    });
+  });
+
   group('processRecoveryResponse dedup', () {
     late String testCreatorPubkey;
     late LoginService loginService;


### PR DESCRIPTION
## Summary

Closes horcrux_app-9xrc.

An owner who did not add themselves as a self-steward holds zero shards for their own vault. Previously, both the UI gate (`latestShare != null`) and the service (`shares.isEmpty` → StateError) blocked them from initiating real recovery — even after sealing the vault (Travel Mode). This is a real recovery-path gap for the common deployment where the owner trusts their stewards entirely.

## Changes

- **`lib/services/recovery_service.dart`**: In `initiateAndSendRecovery` (non-practice branch), when the initiator is the vault owner and holds no share, derive stewards (holdingKey), threshold, and relays from `vault.backupConfig` — mirroring the practice-recovery path — instead of throwing. The "no stewards / no relays" StateErrors are preserved. Non-owners with no shares still throw the original error.
- **`lib/widgets/vault_detail_button_stack.dart`**: New `canInitiateRecoveryWithoutShard` gate shows "Initiate Recovery" for an owner with no `latestShare` when the vault is sealed and `backupConfig.isValidForDistribution` (from PR #295). The `!hasMyInFlightRecovery` and `!ownerHasOwnedContent` gates are unchanged.
- **Tests**: 2 new tests — owner without shard initiates from backup config; owner with shares still uses the existing share-based path.

## Verification

- Self-steward owners and pure stewards: existing paths untouched (new branch gated on `shares.isEmpty && isVaultOwner`).
- Non-self-steward owner with local content still only sees Practice Recovery.
- 853 tests pass, `flutter analyze` clean (per coder).
- Tester: interactive verification blocked by environment (gnome-keyring/marionette); verified via automated tests covering the new path.