### PR TITLE
Fix invitation link parsing for non-ASCII vault/owner names

### DIFF
--- a/lib/services/deep_link_service.dart
+++ b/lib/services/deep_link_service.dart
@@ -344,11 +344,11 @@ class DeepLinkService {
       if (relayUrlsParam != null && relayUrlsParam.isNotEmpty) {
         final relayUrlStrings = relayUrlsParam.split(',');
         for (final relayUrlStr in relayUrlStrings) {
-          final decodedUrl = Uri.decodeComponent(relayUrlStr.trim());
-          if (isValidRelayUrl(decodedUrl)) {
-            relayUrls.add(decodedUrl);
+          final relayUrl = relayUrlStr.trim();
+          if (isValidRelayUrl(relayUrl)) {
+            relayUrls.add(relayUrl);
           } else {
-            Log.warning('Invalid relay URL: $decodedUrl');
+            Log.warning('Invalid relay URL: $relayUrl');
           }
         }
       }

--- a/lib/services/deep_link_service.dart
+++ b/lib/services/deep_link_service.dart
@@ -372,11 +372,9 @@ class DeepLinkService {
       return (
         inviteCode: inviteCode,
         vaultId: vaultId,
-        vaultName:
-            vaultName != null && vaultName.isNotEmpty ? Uri.decodeComponent(vaultName) : null,
+        vaultName: vaultName != null && vaultName.isNotEmpty ? vaultName : null,
         ownerPubkey: ownerPubkey,
-        ownerName:
-            ownerName != null && ownerName.isNotEmpty ? Uri.decodeComponent(ownerName) : null,
+        ownerName: ownerName != null && ownerName.isNotEmpty ? ownerName : null,
         relayUrls: relayUrls,
       );
     } on InvalidInvitationLinkException {

--- a/test/services/deep_link_service_parse_test.dart
+++ b/test/services/deep_link_service_parse_test.dart
@@ -138,6 +138,10 @@ void main() {
     });
 
     test('parses multiple relay URLs with non-ASCII characters', () {
+      // A comma-separated relay list is percent-encoded by toUrl() as
+      // wss%3A%2F%2Frelay1.example.com%2Cwss%3A%2F%2Fm%C3%BCnchen.example.com.
+      // queryParameters decodes the whole value before the split, so both
+      // relays must be parsed and the non-ASCII (IDN) host preserved.
       final url = Uri.parse(
         'https://horcruxbackup.com/invite/akEzcK5XMprOCTYy5ikiv6ZMeSHXnToekiSPd8DpJVU'
         '?vault=vaultId'
@@ -146,7 +150,14 @@ void main() {
         '&relays=wss%3A%2F%2Frelay1.example.com%2Cwss%3A%2F%2Fm%C3%BCnchen.example.com',
       );
 
-      expect(() => makeService().parseInvitationLink(url), returnsNormally);
+      final data = makeService().parseInvitationLink(url);
+
+      expect(data, isNotNull);
+      expect(data!.relayUrls, hasLength(2));
+      expect(data.relayUrls, [
+        'wss://relay1.example.com',
+        'wss://münchen.example.com',
+      ]);
     });
   });
 }

--- a/test/services/deep_link_service_parse_test.dart
+++ b/test/services/deep_link_service_parse_test.dart
@@ -116,5 +116,37 @@ void main() {
       expect(data!.ownerName, isNull);
       expect(data.vaultName, 'My Vault');
     });
+
+    test('parses a relay URL with a non-ASCII (IDN/punycode) host', () {
+      // A relay URL like wss://münchen.example.com is percent-encoded as
+      // wss://m%C3%BCnchen.example.com by toUrl(). queryParameters decodes
+      // this to the literal ü, so the parse must NOT call
+      // Uri.decodeComponent a second time (which would throw for code > 127).
+      final url = Uri.parse(
+        'https://horcruxbackup.com/invite/akEzcK5XMprOCTYy5ikiv6ZMeSHXnToekiSPd8DpJVU'
+        '?vault=vaultId'
+        '&name=My%20Vault'
+        '&owner=$ownerPubkey'
+        '&relays=wss%3A%2F%2Fm%C3%BCnchen.example.com',
+      );
+
+      final data = makeService().parseInvitationLink(url);
+
+      expect(data, isNotNull);
+      expect(data!.relayUrls, hasLength(1));
+      expect(data.relayUrls.first, 'wss://münchen.example.com');
+    });
+
+    test('parses multiple relay URLs with non-ASCII characters', () {
+      final url = Uri.parse(
+        'https://horcruxbackup.com/invite/akEzcK5XMprOCTYy5ikiv6ZMeSHXnToekiSPd8DpJVU'
+        '?vault=vaultId'
+        '&name=My%20Vault'
+        '&owner=$ownerPubkey'
+        '&relays=wss%3A%2F%2Frelay1.example.com%2Cwss%3A%2F%2Fm%C3%BCnchen.example.com',
+      );
+
+      expect(() => makeService().parseInvitationLink(url), returnsNormally);
+    });
   });
 }

--- a/test/services/deep_link_service_parse_test.dart
+++ b/test/services/deep_link_service_parse_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:horcrux/services/deep_link_service.dart';
+
+/// [DeepLinkService.parseInvitationLink] must correctly parse invitation
+/// links containing non-ASCII characters in the vault/owner name query
+/// params. Regression coverage for a bug where a vault name containing an
+/// iOS curly apostrophe (U+2019) caused parsing to throw
+/// "Illegal percent encoding in URI".
+///
+/// `Uri.queryParameters` already URL-decodes values, so the code must not
+/// call `Uri.decodeComponent` a second time on the name/ownerName params.
+void main() {
+  // A valid DeepLinkService. parseInvitationLink is synchronous and does not
+  // touch the injected InvitationService, so throwaway callbacks suffice.
+  DeepLinkService makeService() => DeepLinkService(
+        getInvitationService: () => throw UnimplementedError(),
+        getIsLoggedIn: () async => true,
+      );
+
+  const ownerPubkey = '704e34b4d4acd67c8f43ef8f0b0dc905b403bef96d8e94b88271355aef601d2d';
+
+  group('parseInvitationLink', () {
+    test('parses a vault name with an iOS curly apostrophe (U+2019)', () {
+      // Reported failing URL: name=Ben%E2%80%99s%20Super%20Secret%20Things
+      final url = Uri.parse(
+        'https://horcruxbackup.com/invite/akEzcK5XMprOCTYy5ikiv6ZMeSHXnToekiSPd8DpJVU'
+        '?vault=61_iV28zPv9UWnsMUDP8XfAepuZ9ipl5icDmOav786c'
+        '&name=Ben%E2%80%99s%20Super%20Secret%20Things'
+        '&owner=$ownerPubkey'
+        '&ownerName=Ben%20Moody'
+        '&relays=wss%3A%2F%2Frelay.horcruxbackup.com',
+      );
+
+      final data = makeService().parseInvitationLink(url);
+
+      expect(data, isNotNull);
+      // U+2019 is the expected decoded value of %E2%80%99 (iOS curly apostrophe)
+      expect(data!.vaultName, 'Ben’s Super Secret Things');
+      expect(data.ownerName, 'Ben Moody');
+    });
+
+    test('parses an ASCII apostrophe vault name', () {
+      final url = Uri.parse(
+        'https://horcruxbackup.com/invite/akEzcK5XMprOCTYy5ikiv6ZMeSHXnToekiSPd8DpJVU'
+        '?vault=vaultId'
+        '&name=Ben%27s%20Secret%20Things'
+        '&owner=$ownerPubkey'
+        '&relays=wss%3A%2F%2Frelay.horcruxbackup.com',
+      );
+
+      final data = makeService().parseInvitationLink(url);
+
+      expect(data, isNotNull);
+      expect(data!.vaultName, "Ben's Secret Things");
+    });
+
+    test('parses an empty vault name as null', () {
+      final url = Uri.parse(
+        'https://horcruxbackup.com/invite/akEzcK5XMprOCTYy5ikiv6ZMeSHXnToekiSPd8DpJVU'
+        '?vault=vaultId'
+        '&name='
+        '&owner=$ownerPubkey'
+        '&relays=wss%3A%2F%2Frelay.horcruxbackup.com',
+      );
+
+      final data = makeService().parseInvitationLink(url);
+
+      expect(data, isNotNull);
+      expect(data!.vaultName, isNull);
+    });
+
+    test('parses an accented owner name', () {
+      final url = Uri.parse(
+        'https://horcruxbackup.com/invite/akEzcK5XMprOCTYy5ikiv6ZMeSHXnToekiSPd8DpJVU'
+        '?vault=vaultId'
+        '&name=My%20Vault'
+        '&owner=$ownerPubkey'
+        '&ownerName=Ren%C3%A9e%20M%C3%BCller'
+        '&relays=wss%3A%2F%2Frelay.horcruxbackup.com',
+      );
+
+      final data = makeService().parseInvitationLink(url);
+
+      expect(data, isNotNull);
+      expect(data!.ownerName, 'Renée Müller');
+    });
+
+    test('parses an emoji vault name', () {
+      final url = Uri.parse(
+        'https://horcruxbackup.com/invite/akEzcK5XMprOCTYy5ikiv6ZMeSHXnToekiSPd8DpJVU'
+        '?vault=vaultId'
+        '&name=%F0%9F%94%90%20Vault'
+        '&owner=$ownerPubkey'
+        '&relays=wss%3A%2F%2Frelay.horcruxbackup.com',
+      );
+
+      final data = makeService().parseInvitationLink(url);
+
+      expect(data, isNotNull);
+      expect(data!.vaultName, '🔐 Vault');
+    });
+
+    test('falls back to null when owner name is absent', () {
+      final url = Uri.parse(
+        'https://horcruxbackup.com/invite/akEzcK5XMprOCTYy5ikiv6ZMeSHXnToekiSPd8DpJVU'
+        '?vault=vaultId'
+        '&name=My%20Vault'
+        '&owner=$ownerPubkey'
+        '&relays=wss%3A%2F%2Frelay.horcruxbackup.com',
+      );
+
+      final data = makeService().parseInvitationLink(url);
+
+      expect(data, isNotNull);
+      expect(data!.ownerName, isNull);
+      expect(data.vaultName, 'My Vault');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes horcrux_app-kzxw — invitation links failed to parse (`Illegal percent encoding in URI`) when the vault or owner name contained a non-ASCII character (e.g. iOS curly apostrophe U+2019, accents, emoji).

## Root cause

`DeepLinkService.parseInvitationLink` double-percent-decoded the `name`, `ownerName`, and `relays` query params. `uri.queryParameters` already returns URL-decoded values; calling `Uri.decodeComponent` a second time throws on any code point > 127.

## Fix

Removed the redundant `Uri.decodeComponent` calls on `vaultName`, `ownerName`, and relay URLs in `lib/services/deep_link_service.dart`. `isValidRelayUrl` validation is unchanged.

## Tests

New `test/services/deep_link_service_parse_test.dart` with 8 cases:
- Exact reported failing URL (curly apostrophe vault name)
- ASCII apostrophe, accented owner name (Renée Müller), emoji vault name
- Empty/null name fallbacks
- Relay URLs with non-ASCII (IDN) hosts, single and multiple

Full suite: 859 passed, 4 skipped. Analyze + format clean.