### PR TITLE
Enable eager NIP-42 auth so the app works on auth-enabled relays

### DIFF
--- a/lib/services/ndk_service.dart
+++ b/lib/services/ndk_service.dart
@@ -155,6 +155,12 @@ class NdkService {
           cache: MemCacheManager(),
           eventVerifier: Bip340EventVerifier(),
           engine: NdkEngine.JIT,
+          // Respond to relay AUTH challenges (NIP-42) as soon as they are
+          // issued on connect. nostr-rs-relay silently drops gated reads
+          // (DMs/gift-wraps) instead of sending CLOSED "auth-required", so
+          // lazy (reactive) auth never fires and no events would arrive on
+          // auth-enabled relays.
+          eagerAuth: true,
         ),
       );
 


### PR DESCRIPTION
## Summary

Set `eagerAuth: true` on the `NdkConfig` in `NdkService.initialize()`. The app now answers relay NIP-42 AUTH challenges immediately on connect.

## Why

nostr-rs-relay (v0.10.0) sends a proactive `["AUTH", <challenge>]` on connect but never emits `CLOSED ... auth-required` for gated reads — it silently drops DMs/gift-wraps (kinds 4/44/1059) for unauthenticated connections. With ndk's default lazy/reactive auth (`eagerAuth: false`), the app gets no trigger to authenticate and receives no gift-wrap events on auth-enabled relays.

Verified behavior on `wss://dev.horcruxbackup.com`: `nak --fpa` (preemptive) returns events; `nak --auth` (lazy) returns none.

## Verification

- `fvm flutter analyze lib/services/ndk_service.dart` — clean
- `fvm flutter test test/services/ndk_service_inbound_test.dart` — all pass

## Tracking

Bead: horcrux_app-ip9g