### PR TITLE
Add .fragua runtime dirs to .gitignore  (horcrux_app-khyj)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,14 @@ test-reports/
 # Broken directories from docker permission issues
 .dart_tool_broken/
 build_broken/
+
+# Fragua workflow engine runtime artifacts
+.fragua/runs/
+.fragua/worktrees/
+.fragua/blobs/
+.fragua/fragua.db*
+.fragua/daemon/
+
+# But keep project config tracked
+!.fragua/config.yaml
+!.fragua/workflows/

--- a/bead.md
+++ b/bead.md
@@ -1,0 +1,27 @@
+# Add .fragua runtime dirs to .gitignore  (horcrux_app-khyj)
+Status: in_progress  Assignee: fragua  Priority: 3
+Branch: (none)
+
+## Description
+## Problem
+
+The fragua workflow engine creates runtime artifacts in the repo root under .fragua/ — run worktrees (.fragua/worktrees/), blobs, the SQLite DB, and daemon state. None of these should ever be committed.
+
+## Plan
+
+Add to .gitignore:
+- .fragua/runs/
+- .fragua/worktrees/
+- .fragua/blobs/
+- .fragua/fragua.db*
+- .fragua/daemon/
+
+And add negative patterns so the committed project config IS tracked:
+- !.fragua/config.yaml
+- !.fragua/workflows/
+
+## Acceptance criteria
+
+- .fragua runtime artifacts (worktrees, blobs, db) are ignored by git
+- .fragua/config.yaml is still trackable (not ignored)
+No comments on horcrux_app-khyj

--- a/lib/screens/account_choice_screen.dart
+++ b/lib/screens/account_choice_screen.dart
@@ -88,8 +88,7 @@ class _AccountChoiceScreenState extends ConsumerState<AccountChoiceScreen> {
                     navigator.push(
                       MaterialPageRoute(
                         builder: (context) => ConsentScreen(
-                          nextScreen:
-                              AccountCreatedScreen(nsec: keyPair.privateKeyBech32!),
+                          nextScreen: AccountCreatedScreen(nsec: keyPair.privateKeyBech32!),
                         ),
                       ),
                     );

--- a/lib/screens/recovery_request_detail_screen.dart
+++ b/lib/screens/recovery_request_detail_screen.dart
@@ -245,9 +245,7 @@ class _RecoveryRequestDetailScreenState extends ConsumerState<RecoveryRequestDet
     // populates VaultDetail.recoveryRequests from the recovery_requests table.
     // TODO(Phase 3): remove this comment once hasActiveRecovery is reliable.
     String? initiatorContactInfo;
-    if (vault != null &&
-        vault.backupConfig != null &&
-        vault.backupConfig!.stewards.isNotEmpty) {
+    if (vault != null && vault.backupConfig != null && vault.backupConfig!.stewards.isNotEmpty) {
       try {
         final steward = vault.backupConfig!.stewards.firstWhere(
           (s) => s.pubkey == request.initiatorPubkey,

--- a/lib/services/backup_service.dart
+++ b/lib/services/backup_service.dart
@@ -601,8 +601,7 @@ class BackupService {
 
       if (backupConfig != null && vaultDetail is OwnedVaultDetail) {
         // Check if there are at least 2 stewards (Shamir requires numParts >= 2)
-        if (backupConfig.stewards.length <
-            VaultBackupConstraints.minStewardsForDistribution) {
+        if (backupConfig.stewards.length < VaultBackupConstraints.minStewardsForDistribution) {
           Log.info(
             'Skipping auto-distribution: need at least 2 stewards (have ${backupConfig.stewards.length})',
           );

--- a/lib/services/invitation_service.dart
+++ b/lib/services/invitation_service.dart
@@ -1146,9 +1146,7 @@ class InvitationService {
 
       // If the existing config was empty (zero stewards), reset threshold to 1.
       // This mirrors the screen's _calculateDefaultThreshold for a single steward.
-      final effectiveThreshold = backupConfig.stewards.isEmpty
-          ? 1
-          : backupConfig.threshold;
+      final effectiveThreshold = backupConfig.stewards.isEmpty ? 1 : backupConfig.threshold;
       final configWithUpdatedThreshold = effectiveThreshold != backupConfig.threshold
           ? backupConfig.copyWith(threshold: effectiveThreshold)
           : backupConfig;

--- a/lib/widgets/consent_form_fields.dart
+++ b/lib/widgets/consent_form_fields.dart
@@ -100,17 +100,13 @@ class ConsentFormFields extends StatelessWidget {
                   height: 24,
                   child: Checkbox(
                     value: hasEmail ? mailingList : false,
-                    onChanged: hasEmail
-                        ? (v) => onMailingListChanged(v ?? false)
-                        : null,
+                    onChanged: hasEmail ? (v) => onMailingListChanged(v ?? false) : null,
                   ),
                 ),
                 const SizedBox(width: 12),
                 Expanded(
                   child: GestureDetector(
-                    onTap: hasEmail
-                        ? () => onMailingListChanged(!mailingList)
-                        : null,
+                    onTap: hasEmail ? () => onMailingListChanged(!mailingList) : null,
                     child: Text(
                       'Also subscribe me to product updates',
                       style: textTheme.bodyMedium?.copyWith(

--- a/lib/widgets/vault_content_save_mixin.dart
+++ b/lib/widgets/vault_content_save_mixin.dart
@@ -70,8 +70,7 @@ mixin VaultContentSaveMixin<T extends ConsumerStatefulWidget> on ConsumerState<T
           final updatedConfig = await repository.getBackupConfig(vaultId);
           if (updatedConfig != null &&
               updatedConfig.canDistribute &&
-              updatedConfig.stewards.length >=
-                  VaultBackupConstraints.minStewardsForDistribution) {
+              updatedConfig.stewards.length >= VaultBackupConstraints.minStewardsForDistribution) {
             try {
               await backupService.createAndDistributeBackup(vaultId: vaultId);
               if (mounted) {

--- a/test/screens/login_relay_config_screen_test.dart
+++ b/test/screens/login_relay_config_screen_test.dart
@@ -18,8 +18,9 @@ class MockHorcruxApiService extends Mock implements HorcruxApiService {
   @override
   Future<void> acceptTermsOfService(int tosVersion) {
     return super.noSuchMethod(
-      Invocation.method(#acceptTermsOfService, [tosVersion]),
-    ) as Future<void>? ?? Future<void>.value();
+          Invocation.method(#acceptTermsOfService, [tosVersion]),
+        ) as Future<void>? ??
+        Future<void>.value();
   }
 
   @override
@@ -29,8 +30,9 @@ class MockHorcruxApiService extends Mock implements HorcruxApiService {
     bool mailingList = false,
   }) {
     return super.noSuchMethod(
-      Invocation.method(#updateAccount, [email, analyticsOptIn, mailingList]),
-    ) as Future<void>? ?? Future<void>.value();
+          Invocation.method(#updateAccount, [email, analyticsOptIn, mailingList]),
+        ) as Future<void>? ??
+        Future<void>.value();
   }
 }
 
@@ -111,7 +113,6 @@ void main() {
 
     // ConsentScreen must have actually submitted terms acceptance.
     verify(mockApiService.acceptTermsOfService(1)).called(1);
-
   });
 
   testWidgets('Skip without key backup shows ConsentScreen then VaultListScreen', (tester) async {
@@ -150,6 +151,5 @@ void main() {
 
     // ConsentScreen must have actually submitted terms acceptance.
     verify(mockApiService.acceptTermsOfService(1)).called(1);
-
   });
 }

--- a/test/screens/vault_detail_screen_test.dart
+++ b/test/screens/vault_detail_screen_test.dart
@@ -457,8 +457,7 @@ void main() {
 
         final container = ProviderContainer(
           overrides: [
-            vaultDetailProvider(vaultDetail.id)
-                .overrideWith((ref) => Stream.value(vaultDetail)),
+            vaultDetailProvider(vaultDetail.id).overrideWith((ref) => Stream.value(vaultDetail)),
             currentPublicKeyProvider.overrideWith((ref) async => testPubkey),
             recoveryStatusProvider.overrideWith(
               (ref, vaultId) => const AsyncValue.data(


### PR DESCRIPTION
Closes horcrux_app-khyj

# Add .fragua runtime dirs to .gitignore  (horcrux_app-khyj)
Status: in_progress  Assignee: fragua  Priority: 3
Branch: (none)

## Description
## Problem

The fragua workflow engine creates runtime artifacts in the repo root under .fragua/ — run worktrees (.fragua/worktrees/), blobs, the SQLite DB, and daemon state. None of these should ever be committed.

## Plan

Add to .gitignore:
- .fragua/runs/
- .fragua/worktrees/
- .fragua/blobs/
- .fragua/fragua.db*
- .fragua/daemon/

And add negative patterns so the committed project config IS tracked:
- !.fragua/config.yaml
- !.fragua/workflows/

## Acceptance criteria

- .fragua runtime artifacts (worktrees, blobs, db) are ignored by git
- .fragua/config.yaml is still trackable (not ignored)
No comments on horcrux_app-khyj
