### PR TITLE
Add .fragua runtime dirs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,14 @@ test-reports/
 # Broken directories from docker permission issues
 .dart_tool_broken/
 build_broken/
+
+# Fragua runtime artifacts (worktrees, blobs, database — never commit)
+.fragua/runs/
+.fragua/worktrees/
+.fragua/blobs/
+.fragua/fragua.db*
+.fragua/daemon/
+
+# But keep committed project config trackable
+!.fragua/config.yaml
+!.fragua/workflows/


### PR DESCRIPTION
horcrux_app-khyj

The fragua workflow engine creates transient runtime artifacts (run worktrees, blobs, a SQLite database, and daemon state) in `.fragua/` under the repo root. These should never be committed, but the project's own config files in `.fragua/` must remain trackable.

**Changes:**

- Added gitignore patterns for `.fragua/runs/`, `.fragua/worktrees/`, `.fragua/blobs/`, `.fragua/fragua.db*`, and `.fragua/daemon/` — these directories and files are now ignored by git.
- Added negation patterns (`!.fragua/config.yaml`, `!.fragua/workflows/`) so the committed workflow definitions and engine config stay tracked despite the broader ignore rules.