### PR TITLE
Add fragua project config

### DIFF
--- a/.fragua/config.yaml
+++ b/.fragua/config.yaml
@@ -1,0 +1,10 @@
+# fragua project config — project-specific knobs only.
+# Generic preferences live in ~/.fragua/config.yaml.
+
+# Stable project identity. Committed so every clone shares it and runs
+# stay attributable across machines — do not change it.
+id: 019ffbf3-6c64-7620-bb97-1c00528b85d7
+name: horcrux
+
+# Uncomment if the project needs a per-worktree bootstrap command:
+# bootstrap: "bun install --frozen-lockfile"


### PR DESCRIPTION
## Summary

Adds `.fragua/config.yaml` — the fragua workflow engine's per-project config for the horcrux repo.

## What it does

- Stable project identity (UUID) so fragua runs stay attributable across machines
- Project name: horcrux
- Optional bootstrap hook (commented out — no build step needed for this repo)

The fragua runtime artifacts (.fragua/runs, worktrees, blobs, db) are already gitignored; this commits the tracked config that should be shared.