### PR TITLE
Fix stale ack overwriting newer acknowledgment in steward status

### DIFF
--- a/lib/services/share_distribution_service.dart
+++ b/lib/services/share_distribution_service.dart
@@ -415,6 +415,23 @@ class ShareDistributionService {
       return;
     }
 
+    // Drop stale acks: if the steward has already acknowledged a higher version,
+    // ignore the incoming lower-version ack to avoid downgrading.
+    if (tagDistributionVersion != null && config != null) {
+      for (final s in config.stewards) {
+        if (s.pubkey == keyHolderPubkey &&
+            s.acknowledgedDistributionVersion != null &&
+            tagDistributionVersion < s.acknowledgedDistributionVersion!) {
+          Log.info(
+            'Ignoring stale share confirmation for vault $vaultId, share $shareIndex '
+            'from steward $keyHolderPubkey: incoming v$tagDistributionVersion '
+            'is older than already-acked v${s.acknowledgedDistributionVersion}',
+          );
+          return;
+        }
+      }
+    }
+
     final acknowledgedDistributionVersion = tagDistributionVersion ?? currentDistributionVersion;
     await _repository.updateStewardStatus(
       vaultId: vaultId,

--- a/lib/services/share_distribution_service.dart
+++ b/lib/services/share_distribution_service.dart
@@ -39,6 +39,13 @@ class ShareDistributionService {
   final NdkService _ndkService;
   final HorcruxNotificationService _notificationService;
 
+  /// Tracks the maximum distribution version acknowledged per steward (vault:pubkey)
+  /// within this service instance. Used as an in-memory monotonic guard to
+  /// prevent concurrent ack races where two events arrive before the repository
+  /// is updated — the pre-read stale guard cannot catch this case because both
+  /// events read the same initial vault state.
+  final Map<String, int> _maxAckedVersionPerSteward = {};
+
   ShareDistributionService(
     this._repository,
     this._loginService,
@@ -418,18 +425,35 @@ class ShareDistributionService {
     // Drop stale acks: if the steward has already acknowledged a higher version,
     // ignore the incoming lower-version ack to avoid downgrading.
     if (tagDistributionVersion != null && config != null) {
-      for (final s in config.stewards) {
-        if (s.pubkey == keyHolderPubkey &&
-            s.acknowledgedDistributionVersion != null &&
-            tagDistributionVersion < s.acknowledgedDistributionVersion!) {
+      for (final steward in config.stewards) {
+        if (steward.pubkey == keyHolderPubkey &&
+            steward.acknowledgedDistributionVersion != null &&
+            tagDistributionVersion < steward.acknowledgedDistributionVersion!) {
           Log.info(
             'Ignoring stale share confirmation for vault $vaultId, share $shareIndex '
             'from steward $keyHolderPubkey: incoming v$tagDistributionVersion '
-            'is older than already-acked v${s.acknowledgedDistributionVersion}',
+            'is older than already-acked v${steward.acknowledgedDistributionVersion}',
           );
           return;
         }
       }
+    }
+
+    // In-memory monotonic guard: tracks max acked version per steward to
+    // prevent the concurrent-ack race where the pre-read guard above misses
+    // because both events read the same initial vault state.
+    if (tagDistributionVersion != null) {
+      final trackerKey = '$vaultId:$keyHolderPubkey';
+      final maxAcked = _maxAckedVersionPerSteward[trackerKey];
+      if (maxAcked != null && tagDistributionVersion < maxAcked) {
+        Log.info(
+          'Ignoring stale share confirmation for vault $vaultId, share $shareIndex '
+          'from steward $keyHolderPubkey: incoming v$tagDistributionVersion '
+          'is older than in-memory max v$maxAcked',
+        );
+        return;
+      }
+      _maxAckedVersionPerSteward[trackerKey] = tagDistributionVersion;
     }
 
     final acknowledgedDistributionVersion = tagDistributionVersion ?? currentDistributionVersion;

--- a/test/services/share_distribution_service_test.dart
+++ b/test/services/share_distribution_service_test.dart
@@ -1053,6 +1053,71 @@ void main() {
           throwsA(isA<ArgumentError>()),
         );
       });
+
+      test('drops stale ack when steward already acknowledged a higher version', () async {
+        // Steward Bob already acked at v7 (holding the current key).
+        // A stale v6 ack arrives — must be ignored.
+        const vaultId = 'vault-stale-ack';
+        final bobSteward = createSteward(pubkey: bobPubHex, name: 'Bob').copyWith(
+          acknowledgedDistributionVersion: 7,
+          status: StewardStatus.holdingKey,
+        );
+        final cfg = createBackupConfig(
+          vaultId: vaultId,
+          threshold: 2,
+          totalKeys: 2,
+          stewards: [
+            createOwnerSteward(pubkey: alicePubHex, name: 'Alice'),
+            bobSteward,
+          ],
+          relays: TestBackupConfigs.simple2of2Relays,
+        ).copyWith(distributionVersion: 7);
+
+        when(mockRepository.getVault(vaultId)).thenAnswer((_) async {
+          return Vault(
+            id: vaultId,
+            name: 'Test',
+            createdAt: DateTime.utc(2024),
+            ownerPubkey: alicePubHex,
+            backupConfig: cfg,
+          );
+        });
+        when(
+          mockRepository.updateStewardStatus(
+            vaultId: anyNamed('vaultId'),
+            pubkey: anyNamed('pubkey'),
+            status: anyNamed('status'),
+            acknowledgedAt: anyNamed('acknowledgedAt'),
+            acknowledgmentEventId: anyNamed('acknowledgmentEventId'),
+            acknowledgedDistributionVersion: anyNamed('acknowledgedDistributionVersion'),
+            giftWrapEventId: anyNamed('giftWrapEventId'),
+          ),
+        ).thenAnswer((_) async {});
+
+        final event = confirmationEvent(
+          stewardPubkey: bobPubHex,
+          tags: [
+            ['vault_id', vaultId],
+            ['share_index', '1'],
+            ['distribution_version', '6'],
+          ],
+        );
+
+        await service.processShareConfirmationEvent(event: event);
+
+        // Steward already acked at v7 — stale v6 must NOT overwrite.
+        verifyNever(
+          mockRepository.updateStewardStatus(
+            vaultId: anyNamed('vaultId'),
+            pubkey: anyNamed('pubkey'),
+            status: anyNamed('status'),
+            acknowledgedAt: anyNamed('acknowledgedAt'),
+            acknowledgmentEventId: anyNamed('acknowledgmentEventId'),
+            acknowledgedDistributionVersion: anyNamed('acknowledgedDistributionVersion'),
+            giftWrapEventId: anyNamed('giftWrapEventId'),
+          ),
+        );
+      });
     });
 
     group('processShareErrorEvent', () {

--- a/test/services/share_distribution_service_test.dart
+++ b/test/services/share_distribution_service_test.dart
@@ -1118,6 +1118,95 @@ void main() {
           ),
         );
       });
+
+      test(
+        'REGRESSION: stale ack overwrites newer ack when both arrive before '
+        'repository is updated (race condition)',
+        () async {
+          // Steward Bob has NO acknowledgedDistributionVersion yet.
+          // Two events arrive in quick succession: v7 first, then v6.
+          // getVault returns the initial state for both reads (the mock
+          // isn't updated between calls), so the stale guard sees null for
+          // both — neither is caught, and the v6 write overwrites the v7
+          // write.
+          const vaultId = 'vault-race-stale';
+          final bobSteward = createSteward(pubkey: bobPubHex, name: 'Bob')
+              .copyWith(acknowledgedDistributionVersion: null);
+          final cfg = createBackupConfig(
+            vaultId: vaultId,
+            threshold: 2,
+            totalKeys: 2,
+            stewards: [
+              createOwnerSteward(pubkey: alicePubHex, name: 'Alice'),
+              bobSteward,
+            ],
+            relays: TestBackupConfigs.simple2of2Relays,
+          ).copyWith(distributionVersion: 7);
+
+          when(mockRepository.getVault(vaultId)).thenAnswer((_) async {
+            return Vault(
+              id: vaultId,
+              name: 'Test',
+              createdAt: DateTime.utc(2024),
+              ownerPubkey: alicePubHex,
+              backupConfig: cfg,
+            );
+          });
+          when(
+            mockRepository.updateStewardStatus(
+              vaultId: anyNamed('vaultId'),
+              pubkey: anyNamed('pubkey'),
+              status: anyNamed('status'),
+              acknowledgedAt: anyNamed('acknowledgedAt'),
+              acknowledgmentEventId: anyNamed('acknowledgmentEventId'),
+              acknowledgedDistributionVersion: anyNamed('acknowledgedDistributionVersion'),
+              giftWrapEventId: anyNamed('giftWrapEventId'),
+            ),
+          ).thenAnswer((_) async {});
+
+          // Process v7 first.
+          await service.processShareConfirmationEvent(
+            event: confirmationEvent(
+              stewardPubkey: bobPubHex,
+              tags: [
+                ['vault_id', vaultId],
+                ['share_index', '1'],
+                ['distribution_version', '7'],
+              ],
+            ),
+          );
+
+          // Process v6 next — getVault still returns the same initial vault
+          // (Bob with null acknowledgedDistributionVersion), so the stale
+          // guard DOES NOT catch 6 < 7.
+          await service.processShareConfirmationEvent(
+            event: confirmationEvent(
+              stewardPubkey: bobPubHex,
+              tags: [
+                ['vault_id', vaultId],
+                ['share_index', '1'],
+                ['distribution_version', '6'],
+              ],
+            ),
+          );
+
+          // The stale v6 should have been dropped — it MUST NOT overwrite
+          // the v7 write.  Because the mock returns the same initial state
+          // for both getVault calls, the guard lets v6 through and this
+          // assertion FAILS, proving the race condition.
+          verifyNever(
+            mockRepository.updateStewardStatus(
+              vaultId: vaultId,
+              pubkey: bobPubHex,
+              acknowledgedDistributionVersion: 6,
+              status: anyNamed('status'),
+              acknowledgedAt: anyNamed('acknowledgedAt'),
+              acknowledgmentEventId: anyNamed('acknowledgmentEventId'),
+              giftWrapEventId: anyNamed('giftWrapEventId'),
+            ),
+          );
+        },
+      );
     });
 
     group('processShareErrorEvent', () {


### PR DESCRIPTION
horcrux_app-5yzy

Fixes a race condition where a stale lower-version share confirmation (kind-718) can overwrite a newer acknowledgment, causing the steward to incorrectly show as "Awaiting New Key" in the vault UI even though they already acked the current distribution.

**The bug:** `processShareConfirmationEvent` unconditionally writes `acknowledgedDistributionVersion` from whichever ack the owner processes last. The existing guard only drops acks with a *future* distribution version — it does nothing when a stale v6 ack arrives after the owner already stored the newer v7 ack. The v6 ack simply overwrites v7, and `stewardStatusFromDistributionAck(v6, current=v7)` returns `awaitingNewKey`, downgrading the steward.

**The fix:** After the existing "drop future versions" guard, add a monotonic max-version guard: look up the steward's current `acknowledgedDistributionVersion` and skip the write if the incoming version is lower. The steward's status and readiness then derive from the latest acked version.

**Out of scope:** Multi-version storage (preserving old ack provenance per steward for parallel distribution versions) is deferred to [horcrux_app-tma2](https://github.com/mplorentz/horcrux/issues/tma2).